### PR TITLE
chore(ci): disable npm version updates — ui/ is source-only

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,11 +26,28 @@ updates:
     commit-message:
       prefix: "deps"
 
-  # UI dependencies (Next.js app)
+  # UI dependencies (Next.js app) — version updates disabled on purpose.
+  #
+  # ui/ is SOURCE ONLY. The UI that actually ships is the prebuilt bundle
+  # committed at isitsecure/server/static/, which `isitsecure launch` serves via
+  # FastAPI StaticFiles. Regenerating it is a deliberate manual step (npm run
+  # build -> copy ui/out/. -> commit both source and output; see ui/README.md).
+  # Nothing in CI or in the wheel build (packages = ["isitsecure"]) does it
+  # automatically, and no CI job builds ui/ at all.
+  #
+  # So merging a ui/package.json bump changes a version string in a directory
+  # that is not built, not packaged, and not served — while widening the drift
+  # against the shipped bundle. `open-pull-requests-limit: 0` stops that PR
+  # class; UI dependencies are updated by rebuilding the bundle intentionally.
+  #
+  # NOTE: this disables VERSION updates only. Dependabot SECURITY updates are
+  # repo-wide and unaffected by this limit — they will still open PRs here (and
+  # for test-app/, which isn't even a configured ecosystem). Those are dismissed
+  # as `not_used`; see .github/codeql/codeql-config.yml for the rationale.
   - package-ecosystem: "npm"
     directory: "/ui"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 0
     commit-message:
       prefix: "deps"


### PR DESCRIPTION
Stops Dependabot from opening `ui/` version-update PRs, which cannot affect what ships.

### Why

`ui/` is **source only**. The UI that actually runs is the prebuilt bundle committed at `isitsecure/server/static/` (56 files), served by `isitsecure launch` via FastAPI `StaticFiles`. Regenerating it is a deliberate manual step — `npm run build` → copy `ui/out/.` → commit both source and output (`ui/README.md`). Nothing in CI or in the wheel build (`packages = ["isitsecure"]`) does this automatically, and no CI job builds `ui/` at all.

So a `ui/package.json` bump changes a version string in a directory that is not built, not packaged, and not served — while widening drift against the shipped bundle, last rebuilt in 1964055 (2026-07-13).

### What changed

`open-pull-requests-limit: 5` → `0` on the npm ecosystem. The entry is kept rather than deleted so the rationale stays recorded in the config.

### Limitation

This disables **version** updates only. Dependabot **security** updates are repo-wide and unaffected by the limit — they will still open PRs for `ui/` and for `test-app/` (which is not a configured ecosystem; that is where #82 came from). Those get dismissed as `not_used`.

### Related

Closes the PR class behind #84, #83, #30. Complements #81/#79 and the `ui/` alert dismissals, which rest on the same static-export reasoning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)