### PR TITLE
feat(sast): deterministic Semgrep taint/injection floor for JS/TS (#4)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ git clone https://github.com/jaurakunal/isitsecure.git
 cd isitsecure
 python3 -m venv .venv
 source .venv/bin/activate          # Windows: .venv\Scripts\activate
-pip install -e ".[all,dev]"        # all scanners + browser + LLM + semgrep taint + dev tools
+pip install -e ".[all,dev]"        # all scanners + browser + LLM + dev tools
 isitsecure setup                   # installs the Chromium browser for DAST
 ```
 
@@ -26,10 +26,12 @@ ruff check isitsecure  # lint
 Please make sure `pytest` and `ruff check` are green before opening a PR, and
 add tests for any behavior you change — the suite is the project's safety net.
 Some DAST/browser tests need the `[browser]` extra (Chromium) installed. The
-Semgrep taint analyzer (`semgrep_taint`) needs the `[taint]` extra — included in
-`[all]` — for the `semgrep` binary; its unit tests mock the subprocess, so they
-pass without it, but you'll only see real taint findings end-to-end with it
-installed. The analyzer no-ops gracefully when the binary is absent.
+Semgrep taint analyzer (`semgrep_taint`) needs the `semgrep` binary; its unit
+tests mock the subprocess, so they pass without it, but you'll only see real
+taint findings end-to-end with it installed. Install it **separately** — semgrep's
+pinned dependency tree doesn't co-resolve with `[all]`, so use an isolated env
+(`pipx install semgrep`, brew, or `pip install semgrep` in its own venv) and put
+it on PATH. The analyzer no-ops gracefully when the binary is absent.
 
 ## Adding a scanner
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ git clone https://github.com/jaurakunal/isitsecure.git
 cd isitsecure
 python3 -m venv .venv
 source .venv/bin/activate          # Windows: .venv\Scripts\activate
-pip install -e ".[all]"            # all scanners + browser + LLM extras
+pip install -e ".[all,dev]"        # all scanners + browser + LLM + semgrep taint + dev tools
 isitsecure setup                   # installs the Chromium browser for DAST
 ```
 
@@ -25,7 +25,11 @@ ruff check isitsecure  # lint
 
 Please make sure `pytest` and `ruff check` are green before opening a PR, and
 add tests for any behavior you change — the suite is the project's safety net.
-Some DAST/browser tests need the `[browser]` extra (Chromium) installed.
+Some DAST/browser tests need the `[browser]` extra (Chromium) installed. The
+Semgrep taint analyzer (`semgrep_taint`) needs the `[taint]` extra — included in
+`[all]` — for the `semgrep` binary; its unit tests mock the subprocess, so they
+pass without it, but you'll only see real taint findings end-to-end with it
+installed. The analyzer no-ops gracefully when the binary is absent.
 
 ## Adding a scanner
 

--- a/README.md
+++ b/README.md
@@ -103,8 +103,8 @@ isitsecure setup
 | `pip install -e .` | SAST / code-only scans only (`--mode code-only`) |
 | `pip install -e ".[browser]"` | Adds DAST / live-URL scanning (requires `isitsecure setup` to install Chromium) |
 | `pip install -e ".[llm]"` | Adds LLM code review, triage, and AI fixes (requires an API key) |
-| `pip install -e ".[taint]"` | Adds deterministic Semgrep taint/injection SAST for JS/TS (installs the `semgrep` binary; falls back to LLM-only if absent) |
-| `pip install -e ".[all]"` | Everything (includes `[taint]`) |
+| `pip install -e ".[all]"` | Everything except `[taint]` (see below) |
+| `pip install -e ".[taint]"` | Deterministic Semgrep taint/injection SAST for JS/TS. **Install separately** — semgrep's pinned dependencies don't co-resolve with `[all]`. The analyzer only needs the `semgrep` binary on PATH, so `pipx install semgrep` (or brew) works too; it falls back to LLM-only if absent |
 
 URL/DAST scanning needs the `[browser]` extra — without it, `isitsecure scan <url>` exits with a message telling you to install it.
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Built for developers and **vibe coders** shipping web apps who need to know if t
 - [Demo](#demo) · [What It Does](#what-it-does)
 - [Install](#install) · [Quick Start](#quick-start) · [What It Costs](#what-it-costs)
 - [Scan Modes](#scan-modes) · [Scan Depth](#scan-depth)
-- [What It Scans](#what-it-scans) — [DAST](#dast-scanners--tests-your-live-app) · [Special DAST](#special-dast-scanners-8) · [SAST](#sast-scanners-17--analyzes-your-code) · [LLM](#llm-powered-analysis-requires-api-key) · [Cross-Referencing](#cross-referencing--guided-dast)
+- [What It Scans](#what-it-scans) — [DAST](#dast-scanners--tests-your-live-app) · [Special DAST](#special-dast-scanners-8) · [SAST](#sast-scanners-18--analyzes-your-code) · [LLM](#llm-powered-analysis-requires-api-key) · [Cross-Referencing](#cross-referencing--guided-dast)
 - [Language Support](#language-support) · [Output Formats](#output-formats)
 - [Auto-Fix](#auto-fix-one-command-to-fix-your-app) · [Security Badge](#security-badge)
 - [How We Compare](#how-we-compare) · [What It Does NOT Cover](#what-it-does-not-cover)
@@ -37,7 +37,7 @@ Built for developers and **vibe coders** shipping web apps who need to know if t
 
 ## What It Does
 
-isitsecure runs **40 rule-based scanners by default** — up to **44 with `--depth deep`** — (plus optional AI code review) against your web app in a single command. It combines four approaches that commercial tools sell separately:
+isitsecure runs **41 rule-based scanners by default** — up to **45 with `--depth deep`** — (plus optional AI code review) against your web app in a single command. It combines four approaches that commercial tools sell separately:
 
 - **SAST (Static Analysis)** — scans your source code for vulnerabilities without running it
 - **DAST (Dynamic Analysis)** — tests your live app by sending real HTTP requests
@@ -103,7 +103,8 @@ isitsecure setup
 | `pip install -e .` | SAST / code-only scans only (`--mode code-only`) |
 | `pip install -e ".[browser]"` | Adds DAST / live-URL scanning (requires `isitsecure setup` to install Chromium) |
 | `pip install -e ".[llm]"` | Adds LLM code review, triage, and AI fixes (requires an API key) |
-| `pip install -e ".[all]"` | Everything |
+| `pip install -e ".[taint]"` | Adds deterministic Semgrep taint/injection SAST for JS/TS (installs the `semgrep` binary; falls back to LLM-only if absent) |
+| `pip install -e ".[all]"` | Everything (includes `[taint]`) |
 
 URL/DAST scanning needs the `[browser]` extra — without it, `isitsecure scan <url>` exits with a message telling you to install it.
 
@@ -146,7 +147,7 @@ isitsecure is free and open source. The only cost is LLM API tokens for the AI-p
 | **Code-only + LLM review** | Yes | ~$5–8 |
 | **Full scan** (SAST + DAST + LLM) | Yes | ~$10–15 |
 
-Without an API key, you still get all rule-based scanners — **40 in the default `quick` depth** (15 DAST + 8 special DAST + 17 SAST), or **44 with `--depth deep`** (which adds 4 slower/aggressive DAST scanners). The LLM adds business logic review, semantic rule verification, and intelligent triage — things no pattern matcher can do.
+Without an API key, you still get all rule-based scanners — **41 in the default `quick` depth** (15 DAST + 8 special DAST + 18 SAST), or **45 with `--depth deep`** (which adds 4 slower/aggressive DAST scanners). The LLM adds business logic review, semantic rule verification, and intelligent triage — things no pattern matcher can do.
 
 **Supported LLM providers:** Anthropic (Claude), Google (Gemini)
 
@@ -220,10 +221,11 @@ The scan narrates each phase and every scanner as it runs (with elapsed time), s
 | DOM XSS Scanner | Playwright-based sink hooking (innerHTML, eval, location.assign) |
 | Body Param Fuzzer | Prototype pollution, type confusion, injection via JSON body fields |
 
-### SAST Scanners (17) — Analyzes Your Code
+### SAST Scanners (18) — Analyzes Your Code
 
 | Scanner | What It Finds |
 |---|---|
+| Semgrep Taint Analyzer | Deterministic source→sink injection for JS/TS — SQLi, reflected/DOM XSS, SSRF, path traversal, command injection (a reproducible floor beneath the LLM reviewer; needs the `[taint]` extra, no-ops without the `semgrep` binary) |
 | Git Secret Scanner | API keys, tokens, and credentials in git history (not just HEAD) |
 | Route Auth Analyzer | Next.js/Express/Django/FastAPI/Spring routes missing authentication |
 | RLS Policy Analyzer | Supabase tables without Row Level Security enabled |
@@ -367,7 +369,7 @@ isitsecure is not a replacement for enterprise security platforms. It's designed
 
 | Need | Best specialized tool | How isitsecure compares |
 |---|---|---|
-| Deep SAST (30+ languages) | [Semgrep](https://semgrep.dev) | We cover 3 languages with regex+LLM (no taint analysis) |
+| Deep SAST (30+ languages) | [Semgrep](https://semgrep.dev) | We embed Semgrep for deterministic JS/TS injection taint (opt-in `[taint]`) and add LLM review on top; Semgrep's own registry covers far more languages and rules |
 | DAST with advanced exploitation | [OWASP ZAP](https://zaproxy.org) / [Burp Suite](https://portswigger.net) | Our DAST is simpler — fewer payloads, no WAF evasion |
 | Secret scanning (800+ patterns) | [TruffleHog](https://github.com/trufflesecurity/trufflehog) / [Gitleaks](https://github.com/gitleaks/gitleaks) | Our git scanner covers common patterns, not exhaustive |
 | Container + IaC scanning | [Trivy](https://github.com/aquasecurity/trivy) / [Checkov](https://github.com/bridgecrewio/checkov) | Our IaC/Docker scanners are basic — use Trivy for depth |
@@ -388,7 +390,7 @@ isitsecure works well alongside other tools. Run `isitsecure scan` for the combi
 
 ## What It Does NOT Cover
 
-- **Formal taint analysis** — No dataflow tracking across function boundaries. Uses regex + LLM reasoning instead
+- **Inter-procedural taint analysis** — The opt-in Semgrep taint layer (`[taint]`) does intra-file source→sink dataflow for JS/TS injection; cross-function/cross-file tracking (Semgrep Pro territory) still falls back to LLM reasoning
 - **WAF evasion** — DAST payloads don't include advanced bypass techniques
 - **Compliance mapping** — No OWASP Top 10, CWE, or PCI-DSS tagging (yet)
 - **Network-level scanning** — No port scanning, TLS analysis, or infrastructure enumeration

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -17,7 +17,7 @@ Phase 5.5: Probe Analysis        ─── Cross-scanner pattern detection on HT
 Phase 5.6: OOB Collection        ─── Poll for blind vulnerability callbacks
 Phase 6:  Repo Ingestion         ─── Clone + index repository
 Phase 6.5: LSP Initialization    ─── Start TypeScript Language Server
-Phase 7:  SAST Scanners          ─── 17 scanners run in parallel
+Phase 7:  SAST Scanners          ─── 18 scanners run in parallel
 Phase 7.5: LSP Validation        ─── Trace auth flows, suppress false positives
 Phase 8:  LLM Code Review        ─── AI analyzes high-risk routes
 Phase 9:  Cross-Reference        ─── Match DAST findings to SAST findings
@@ -99,7 +99,7 @@ The repository is cloned (shallow, to temp dir) and indexed:
    - `GraphQLRouteMapper`: schema definitions → query/mutation types
 4. **File indexing** — reads all source files into memory (filtered by extension, size limit, skip `node_modules`)
 
-17 SAST scanners then run in parallel against the indexed codebase (plus the LLM-powered Semantic Rule Verifier when an API key is available).
+18 SAST scanners then run in parallel against the indexed codebase (plus the LLM-powered Semantic Rule Verifier when an API key is available). One of them, the **Semgrep Taint Analyzer** (`semgrep_taint`), is a deterministic source→sink injection floor for JS/TS that sits beneath the LLM code reviewer: it catches the mechanical SQLi/XSS/SSRF/path-traversal/command-injection cases reproducibly and for free, leaving the LLM to cover business logic and uncatalogued libraries. It is opt-in (`[taint]` extra) and no-ops if the `semgrep` binary is absent.
 
 ### Phase 7.5: LSP Validation
 
@@ -304,7 +304,7 @@ isitsecure/
 │   ├── cross_referencer.py     # DAST ↔ SAST finding matcher
 │   ├── scan_config.py          # User-configurable scan settings
 │   ├── scanners/               # 15 DAST scanners + special scanners
-│   ├── code_analysis/          # 17 SAST scanners + route mappers + LSP
+│   ├── code_analysis/          # 18 SAST scanners + route mappers + LSP + semgrep_rules/
 │   │   └── category_classifier.py  # Maps LLM-review findings to their FindingCategory
 │   ├── fixes/                  # AI fix gen: safety_net, verifier, plain_results, pr_flow
 │   ├── guided_dast/            # SAST → DAST test generation (6 strategies)
@@ -354,7 +354,7 @@ isitsecure/
               │               │                 │
               │               │         ┌───────▼──────────┐
               │               │         │  SAST Scanners   │
-              │               │         │  (17 parallel)   │
+              │               │         │  (18 parallel)   │
               │               │         └───────┬──────────┘
               │               │                 │
               └───────────────┼─────────────────┘

--- a/docs/scanners/README.md
+++ b/docs/scanners/README.md
@@ -38,6 +38,7 @@ These scanners require authentication or use specialized techniques.
 
 These scanners analyze your source code without running it.
 
+- [Semgrep Taint Analyzer](./semgrep-taint.md) — Deterministic source→sink injection for JS/TS (SQLi, XSS, SSRF, path traversal, command injection)
 - [Git Secret Scanner](./git-secret-scanner.md) — Secrets in git history
 - [Route Auth Analyzer](./route-auth-analyzer.md) — Routes missing authentication
 - [RLS Policy Analyzer](./rls-policy-analyzer.md) — Missing Supabase Row Level Security

--- a/docs/scanners/semgrep-taint.md
+++ b/docs/scanners/semgrep-taint.md
@@ -1,0 +1,68 @@
+# Semgrep Taint Analyzer
+
+**Type:** SAST | **Severity:** High–Critical | **Category:** Injection Risk
+
+## What It Does
+
+Runs [Semgrep](https://semgrep.dev) with isitsecure's own taint/sink rule packs over your cloned repo and maps the results to findings. It is a **deterministic injection floor beneath the LLM code reviewer**: the same input always produces the same findings, instantly and at no token cost.
+
+The current rule pack (`semgrep_rules/injection-js.yaml`) targets **JavaScript/TypeScript** and covers five injection classes:
+
+1. **SQL injection** — raw-query sinks (`sql.unsafe`, Prisma `$queryRawUnsafe`/`$executeRawUnsafe`, `knex.raw`, Drizzle `sql.raw`) and user-input → raw-query taint flows.
+2. **Reflected XSS** — request data flowing into an HTML response (`new Response(html)`, `res.send`, `res.write`) without escaping.
+3. **DOM XSS** — `location.hash`/`location.search` → `innerHTML`/`outerHTML`/`document.write`.
+4. **SSRF** — user-controlled URLs flowing into `fetch`/`axios`/`http.get`.
+5. **Path traversal / unrestricted upload** — request-derived filenames flowing into `fs.writeFile`/`createWriteStream` via `path.join` (constant paths are excluded).
+6. **Command injection** — user input flowing into `exec`/`spawn`.
+
+Rules target **framework/library APIs** (Next.js `searchParams`, Express `req.*`, the `postgres`/Prisma/Drizzle/Knex sinks, Node `fs`), so they apply to **any app on those stacks — not per-app**. Apps on an uncatalogued library fall through to the LLM backstop.
+
+Findings are emitted with `scanner_name = "semgrep_taint"`, `confidence = 0.85`, and category `injection_risk`, then flow through the same triage → dedup → plain-English → grading pipeline as every other scanner.
+
+## Requirements & Graceful Degradation
+
+The analyzer needs the `semgrep` binary, shipped via the optional extra:
+
+```bash
+pip install -e ".[taint]"   # or ".[all]", which includes it
+```
+
+It is **best-effort and self-contained**:
+
+- If the `semgrep` binary isn't installed, the analyzer **no-ops and returns nothing** — the LLM layer still runs, exactly as before.
+- A crash or timeout in Semgrep **never fails the scan**; it logs and returns no findings. The subprocess is always killed and reaped (never orphaned), even if the overall scan is cancelled.
+- It only runs when the repo contains JS/TS files.
+- No network: the rule packs ship with isitsecure; Semgrep runs with `--metrics off`.
+
+## Why It Matters
+
+Before this analyzer, injection detection (SQLi/XSS/SSRF/path-traversal/command-injection) rested **entirely on the LLM**, which is non-deterministic (finding counts wobble run-to-run), costs tokens, and is slow. The Semgrep layer gives a reproducible, instant, free floor for the mechanical source→sink cases, while the LLM keeps covering business-logic flaws and the long tail of libraries without rules.
+
+See [docs/taint-analysis.md](../taint-analysis.md) for the full design rationale, the spike results, and the per-stack rule model.
+
+## What Vulnerable Code Looks Like
+
+```typescript
+// BAD: user input interpolated into a raw SQL query (flagged: critical)
+const id = searchParams.get("id");
+const rows = await sql.unsafe(`SELECT * FROM users WHERE id = ${id}`);
+
+// BAD: user-controlled URL fetched server-side (flagged: high — SSRF)
+const target = searchParams.get("url");
+const res = await fetch(target);
+```
+
+```typescript
+// GOOD: parameterized query — not flagged
+const rows = await sql`SELECT * FROM users WHERE id = ${id}`;
+```
+
+## Limitations
+
+- **Intra-file only.** OSS Semgrep taint tracks dataflow within a single file. A route that hands user input to a helper in another file which then reaches a sink (inter-procedural) is not tracked — that path falls back to the LLM reviewer. (Inter-file taint is Semgrep Pro territory.)
+- **JS/TS today.** Python and other stacks are future rule-pack work; those apps rely on the LLM layer meanwhile.
+- **Per-stack rules.** Sinks for libraries we haven't catalogued won't fire deterministically (again, the LLM backstops them).
+
+## Configuration
+
+No configuration. The analyzer auto-runs on any code-only/full scan when the `semgrep` binary is available and the repo has JS/TS files. The rule packs live in `isitsecure/engine/code_analysis/semgrep_rules/`.

--- a/docs/taint-analysis.md
+++ b/docs/taint-analysis.md
@@ -128,9 +128,14 @@ A new `SemgrepAnalyzer` behind the existing SAST scanner interface:
 5. The LLM code reviewer still runs; dedup collapses overlaps (a finding both
    Semgrep and the LLM raise counts once).
 
-Packaging: bundle Semgrep as an **optional extra** (`isitsecure[taint]`, folded
-into `all`) and the rule packs under `isitsecure/engine/code_analysis/semgrep_rules/`.
-Degrade gracefully if the binary is missing (fall back to LLM-only, like today).
+Packaging: ship Semgrep as an **optional extra** (`isitsecure[taint]`) kept
+**separate from `all`** — semgrep's tightly-pinned dependency tree (rich/click/
+boltons/colorama) does not co-resolve with the `[all]` stack, so folding it in
+would break `pip install isitsecure[all]`. Since the analyzer only shells out to
+the `semgrep` **binary**, it's found via PATH or the venv, so an isolated install
+(`pipx install semgrep`, brew, or a separate venv) works just as well. The rule
+packs live under `isitsecure/engine/code_analysis/semgrep_rules/`. Degrade
+gracefully if the binary is missing (fall back to LLM-only, like today).
 
 ## Precision — the eternal SAST battle
 

--- a/docs/taint-analysis.md
+++ b/docs/taint-analysis.md
@@ -1,7 +1,10 @@
 # Taint Analysis for SAST (#4) — Design
 
-Status: **proposal**, backed by a run-on-`test-app` spike (results below). This
-doc is the contract we build to — argue it here before writing code.
+Status: **implemented** (Phase 2/3) — the `SemgrepAnalyzer` and the first JS/TS
+rule pack ship as of this change, backed by the run-on-`test-app` spike below.
+This doc records the design; see
+[docs/scanners/semgrep-taint.md](scanners/semgrep-taint.md) for the user-facing
+scanner reference.
 
 ## Problem
 
@@ -117,7 +120,7 @@ A new `SemgrepAnalyzer` behind the existing SAST scanner interface:
 1. On a code-only scan, detect the stack (already done) → select rule packs.
 2. Shell out to the bundled `semgrep` binary with those packs (`--json`), scoped
    to the cloned repo. No network (rules ship with us).
-3. Parse Semgrep's output → map each result to a `DeepFinding` (category from the
+3. Parse Semgrep's output → map each result to a `CodeFinding` (category from the
    rule, `code_location` from `path`/`start.line`, severity from the rule,
    `scanner_name = "semgrep_taint"`).
 4. Feed those findings into the same triage/dedup/plain-English pipeline as every
@@ -169,7 +172,7 @@ layer has a recall/FP scorecard of its own.
 ## Phasing
 
 1. **SAST injection benchmark fixtures** + a recall/FP harness (so we can measure).
-2. **`SemgrepAnalyzer`** (subprocess → parse → `DeepFinding`) with a first rule
+2. **`SemgrepAnalyzer`** (subprocess → parse → `CodeFinding`) with a first rule
    pack for the top stack (Next.js/Express + postgres/Prisma/Drizzle + DOM).
 3. **Benchmark**: prove it adds recall without FP vs. LLM-only. Discuss, then ship.
 4. **Broaden rule packs** (FastAPI/Flask/Django, more libraries) iteratively, each

--- a/isitsecure/engine/agent.py
+++ b/isitsecure/engine/agent.py
@@ -80,6 +80,9 @@ _DAST_TIMEOUT_MAP: dict[str, float] = {
 
 _SAST_TIMEOUT_MAP: dict[str, float] = {
     "secret_scanner": ScannerTimeouts.GIT_SECRET_SCAN_SECONDS,
+    # Above the analyzer's internal 120s so its own timeout/kill fires first and
+    # the semgrep child is always reaped (never orphaned by an outer cancel).
+    "semgrep_taint": ScannerTimeouts.SEMGREP_TAINT_SECONDS,
 }
 
 

--- a/isitsecure/engine/code_analysis/semgrep_analyzer.py
+++ b/isitsecure/engine/code_analysis/semgrep_analyzer.py
@@ -1,0 +1,204 @@
+"""Semgrep-based taint/dataflow SAST analyzer (#4).
+
+A deterministic injection floor beneath the LLM code reviewer: runs Semgrep with
+isitsecure's own taint/sink rule packs over the cloned repo and maps the results
+to ``CodeFinding``s. Rules target framework/library APIs (sources) and dangerous
+library sinks, so they apply to any app on a supported stack — not per-app.
+
+Best-effort and self-contained:
+* If the ``semgrep`` binary isn't installed (the optional ``[taint]`` extra), the
+  analyzer no-ops and returns ``[]`` — the LLM layer still runs, as today.
+* A crash/timeout in Semgrep never fails the scan; it logs and returns ``[]``.
+
+SRP: this class runs Semgrep and shapes findings. It does not decide severity
+policy (the rules do) or triage (that's the triage service).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import shutil
+import sys
+from pathlib import Path
+
+from isitsecure.engine.code_analysis.models import CodeFinding
+from isitsecure.engine.code_analysis.protocols import RepoSnapshot
+from isitsecure.engine.enums import FindingCategory, SeverityLevel
+
+logger = logging.getLogger(__name__)
+
+_RULES_DIR = Path(__file__).parent / "semgrep_rules"
+_JS_TS_EXT = (".js", ".jsx", ".ts", ".tsx", ".mjs", ".cjs")
+_SCAN_TIMEOUT_S = 120.0
+
+_SEVERITY_MAP = {
+    "critical": SeverityLevel.CRITICAL,
+    "high": SeverityLevel.HIGH,
+    "medium": SeverityLevel.MEDIUM,
+    "low": SeverityLevel.LOW,
+}
+# Fallback when a rule lacks an explicit isitsecure-severity.
+_SEMGREP_SEVERITY_MAP = {
+    "ERROR": SeverityLevel.HIGH,
+    "WARNING": SeverityLevel.MEDIUM,
+    "INFO": SeverityLevel.LOW,
+}
+
+
+class SemgrepAnalyzer:
+    """Run Semgrep taint rules over a repo and return injection findings."""
+
+    scanner_name = "semgrep_taint"
+
+    def __init__(self, rules_dir: Path = _RULES_DIR) -> None:
+        self._rules_dir = rules_dir
+
+    async def scan(self, repo: RepoSnapshot) -> list[CodeFinding]:
+        semgrep = self._find_semgrep()
+        if not semgrep:
+            logger.debug("semgrep not installed — skipping taint analysis (isitsecure[taint])")
+            return []
+        if not self._has_supported_files(repo):
+            return []
+
+        raw = await self._run_semgrep(semgrep, repo.clone_path)
+        if raw is None:
+            return []
+        return self._to_findings(raw, repo)
+
+    # -- internals --------------------------------------------------------
+
+    @staticmethod
+    def _find_semgrep() -> str | None:
+        """Locate semgrep — prefer the binary in our own venv, then PATH.
+
+        With `pip install isitsecure[taint]`, semgrep's console script installs
+        next to the running interpreter; that dir isn't necessarily on PATH.
+        """
+        candidate = Path(sys.executable).parent / "semgrep"
+        if candidate.is_file():
+            return str(candidate)
+        return shutil.which("semgrep")
+
+    def _has_supported_files(self, repo: RepoSnapshot) -> bool:
+        """Only run when there are JS/TS files (the current rule packs' scope)."""
+        return any(p.endswith(_JS_TS_EXT) for p in repo.file_index)
+
+    async def _run_semgrep(self, semgrep: str, clone_path: str) -> dict | None:
+        cmd = [
+            semgrep, "scan",
+            "--config", str(self._rules_dir),
+            "--json", "--quiet",
+            "--metrics", "off",       # no telemetry
+            "--disable-version-check",
+            clone_path,
+        ]
+        proc = None
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *cmd,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            try:
+                stdout, stderr = await asyncio.wait_for(
+                    proc.communicate(), timeout=_SCAN_TIMEOUT_S
+                )
+            except TimeoutError:
+                logger.warning("semgrep timed out after %ss — skipping", _SCAN_TIMEOUT_S)
+                return None
+            if not stdout:
+                logger.warning("semgrep produced no output: %s", (stderr or b"").decode()[:200])
+                return None
+            data = json.loads(stdout)
+            return data if isinstance(data, dict) else None
+        except asyncio.CancelledError:
+            # Outer scan timeout/cancel — reap in finally, then propagate.
+            raise
+        except Exception as exc:  # never fail the scan over the taint layer
+            logger.warning("semgrep run failed: %s", exc)
+            return None
+        finally:
+            # Guarantee the (heavy) semgrep child is killed and reaped on ANY exit
+            # path — timeout, crash, or outer cancellation — never left orphaned.
+            if proc is not None and proc.returncode is None:
+                proc.kill()
+                try:
+                    await proc.wait()
+                except BaseException:  # noqa: BLE001, S110 - SIGKILL sent; best-effort reap
+                    pass
+
+    def _to_findings(self, raw: dict, repo: RepoSnapshot) -> list[CodeFinding]:
+        root = Path(repo.clone_path)
+        findings: list[CodeFinding] = []
+        seen: set[tuple] = set()
+        for r in raw.get("results", []):
+            extra = r.get("extra", {})
+            meta = extra.get("metadata", {})
+            try:
+                rel = str(Path(r["path"]).resolve().relative_to(root.resolve()))
+            except (ValueError, KeyError):
+                rel = r.get("path", "")
+            line = (r.get("start") or {}).get("line")
+            category = self._category(meta)
+            # Collapse *same-class* overlaps (e.g. the sqli sink rule and the sqli
+            # taint rule both firing on one line) while keeping genuinely distinct
+            # classes on the same line (e.g. reflected-XSS and SSRF). All rules map
+            # to FindingCategory.INJECTION_RISK, so we key on the rule's vuln class.
+            key = (rel, line, self._rule_class(r.get("check_id", "")))
+            if key in seen:
+                continue
+            seen.add(key)
+            findings.append(
+                CodeFinding(
+                    scanner_name=self.scanner_name,
+                    severity=self._severity(meta, extra),
+                    category=category,
+                    title=self._title(extra),
+                    description=extra.get("message", "").strip(),
+                    file_path=rel,
+                    line_number=line,
+                    line_end=(r.get("end") or {}).get("line"),
+                    code_snippet=(extra.get("lines") or "").strip()[:500],
+                    confidence=0.85,
+                )
+            )
+        return findings
+
+    # Rule id → vuln class, so the sqli sink + sqli taint rules dedup together but
+    # different classes on the same line don't. Substring match on our rule ids.
+    _RULE_CLASSES = ("sqli", "reflected-xss", "dom-xss", "ssrf", "path-traversal", "command")
+
+    @classmethod
+    def _rule_class(cls, check_id: str) -> str:
+        for c in cls._RULE_CLASSES:
+            if c in check_id:
+                return c
+        return check_id  # unknown rule → treat as its own class (no collapsing)
+
+    @staticmethod
+    def _category(meta: dict) -> FindingCategory:
+        try:
+            return FindingCategory(meta.get("category", "injection_risk"))
+        except ValueError:
+            return FindingCategory.INJECTION_RISK
+
+    @staticmethod
+    def _severity(meta: dict, extra: dict) -> SeverityLevel:
+        explicit = _SEVERITY_MAP.get(str(meta.get("isitsecure-severity", "")).lower())
+        if explicit:
+            return explicit
+        return _SEMGREP_SEVERITY_MAP.get(
+            str(extra.get("severity", "ERROR")).upper(), SeverityLevel.HIGH
+        )
+
+    @staticmethod
+    def _title(extra: dict) -> str:
+        msg = extra.get("message", "").strip()
+        # First sentence / up to the em-dash makes a tidy title.
+        for sep in (" — ", ". "):
+            if sep in msg:
+                return msg.split(sep)[0].strip()[:120]
+        return msg[:80] or "Injection risk (Semgrep)"

--- a/isitsecure/engine/code_analysis/semgrep_rules/injection-js.yaml
+++ b/isitsecure/engine/code_analysis/semgrep_rules/injection-js.yaml
@@ -1,0 +1,126 @@
+# isitsecure taint/sink rules for JavaScript/TypeScript injection (#4).
+# Rules target FRAMEWORK/LIBRARY APIs (sources) and dangerous library sinks —
+# they apply to any app on these stacks, not to a specific app.
+rules:
+  # ---- SQL injection: dangerous raw-query sinks (pattern) ----
+  - id: isitsecure-sqli-raw-query
+    languages: [typescript, javascript]
+    severity: ERROR
+    metadata: {category: injection_risk, isitsecure-severity: critical}
+    message: "Raw SQL built from an interpolated/concatenated string — SQL injection. Use a parameterized query."
+    # Only unambiguously-SQL sink APIs are matched as bare patterns. A generic
+    # `.query(...)` is too broad (analytics/metrics/GraphQL clients also expose it),
+    # so `db.query` is covered by the taint rule below, which requires a real source.
+    patterns:
+      - pattern-either:
+          - pattern: $SQL.unsafe(`...${...}...`)
+          - pattern: $SQL.unsafe($A + $B)
+          - pattern: $DB.$queryRawUnsafe(`...${...}...`)
+          - pattern: $DB.$executeRawUnsafe(`...${...}...`)
+          - pattern: $D.raw(`...${...}...`)
+          - pattern: knex.raw(`...${...}...`)
+
+  # ---- SQL injection: user input → raw sink (intra-file taint) ----
+  - id: isitsecure-sqli-taint
+    mode: taint
+    languages: [typescript, javascript]
+    severity: ERROR
+    metadata: {category: injection_risk, isitsecure-severity: critical}
+    message: "User input flows into a raw SQL query — SQL injection."
+    pattern-sources: &user_input
+      - pattern: req.query
+      - pattern: req.params
+      - pattern: req.body
+      - pattern: searchParams.get(...)
+      - pattern: $U.searchParams.get(...)
+      - pattern: (await $R.json())
+    pattern-sinks:
+      - pattern: $SQL.unsafe(...)
+      - pattern: $DB.$queryRawUnsafe(...)
+      - pattern: $D.raw(...)
+      - pattern: $D.query(...)
+    pattern-sanitizers:
+      - pattern: parseInt(...)
+      - pattern: Number(...)
+
+  # ---- Reflected XSS: user input → HTML response ----
+  - id: isitsecure-reflected-xss
+    mode: taint
+    languages: [typescript, javascript]
+    severity: ERROR
+    metadata: {category: injection_risk, isitsecure-severity: high}
+    message: "User input reflected into an HTML response without escaping — reflected XSS."
+    pattern-sources: *user_input
+    pattern-sinks:
+      - pattern: new Response($HTML, ...)
+      - pattern: $RES.send(...)
+      - pattern: $RES.write(...)
+    pattern-sanitizers:
+      - pattern: encodeURIComponent(...)
+      - pattern: escapeHtml(...)
+
+  # ---- DOM XSS: location.* → innerHTML / document.write ----
+  - id: isitsecure-dom-xss
+    mode: taint
+    languages: [typescript, javascript]
+    severity: ERROR
+    metadata: {category: injection_risk, isitsecure-severity: high}
+    message: "User-controlled input flows into the DOM (innerHTML / document.write) — DOM XSS."
+    pattern-sources:
+      - pattern: location.hash
+      - pattern: location.search
+      - pattern: window.location.hash
+      - pattern: window.location.search
+      - pattern: document.location.$X
+    pattern-sinks:
+      - pattern: $EL.innerHTML = $S
+      - pattern: $EL.outerHTML = $S
+      - pattern: document.write(...)
+
+  # ---- SSRF: user input → outbound request ----
+  - id: isitsecure-ssrf
+    mode: taint
+    languages: [typescript, javascript]
+    severity: ERROR
+    metadata: {category: injection_risk, isitsecure-severity: high}
+    message: "User-controlled URL flows into an outbound request (fetch/axios/http) — SSRF."
+    pattern-sources: *user_input
+    pattern-sinks:
+      - pattern: fetch(...)
+      - pattern: axios.get(...)
+      - pattern: axios(...)
+      - pattern: http.get(...)
+      - pattern: https.get(...)
+
+  # ---- Path traversal / unrestricted upload: request-derived path → fs write ----
+  - id: isitsecure-path-traversal
+    languages: [typescript, javascript]
+    severity: WARNING
+    metadata: {category: injection_risk, isitsecure-severity: high}
+    message: "Filesystem write using a request-derived filename — path traversal / unrestricted upload."
+    patterns:
+      - pattern-either:
+          - pattern: writeFile(path.join(..., $F), ...)
+          - pattern: fs.writeFile(path.join(..., $F), ...)
+          - pattern: fs.writeFileSync(path.join(..., $F), ...)
+          - pattern: createWriteStream(path.join(..., $F))
+      # Exclude constant paths — a string-literal final segment isn't user-derived
+      # (e.g. path.join(__dirname, "out.txt")), so it isn't traversal. Require $F
+      # to start with a non-quote char (an identifier/expression, not a literal).
+      - metavariable-regex:
+          metavariable: $F
+          regex: '^[^"\x27`]'
+
+  # ---- Command injection: user input → shell ----
+  - id: isitsecure-command-injection
+    mode: taint
+    languages: [typescript, javascript]
+    severity: ERROR
+    metadata: {category: injection_risk, isitsecure-severity: critical}
+    message: "User input flows into a shell command — command injection."
+    pattern-sources: *user_input
+    pattern-sinks:
+      - pattern: exec(...)
+      - pattern: execSync(...)
+      - pattern: spawn(...)
+      - pattern: spawnSync(...)

--- a/isitsecure/engine/factory.py
+++ b/isitsecure/engine/factory.py
@@ -72,6 +72,7 @@ from isitsecure.engine.code_analysis.route_analyzer import (
 from isitsecure.engine.code_analysis.secret_scanner import (
     GitSecretScanner,
 )
+from isitsecure.engine.code_analysis.semgrep_analyzer import SemgrepAnalyzer
 from isitsecure.engine.cross_referencer import FindingCrossReferencer
 from isitsecure.engine.guided_dast.runner import SASTGuidedDASTRunner
 from isitsecure.engine.guided_dast.strategies.auth_bypass import (
@@ -290,6 +291,7 @@ def create_deep_security_scan_agent(
 
     sast_scanners = [
         GitSecretScanner(),
+        SemgrepAnalyzer(),  # deterministic taint/injection floor (#4)
         RouteAuthAnalyzer(),
         RLSPolicyAnalyzer(),
         MiddlewareAnalyzer(),

--- a/isitsecure/engine/shared/scanner_runner.py
+++ b/isitsecure/engine/shared/scanner_runner.py
@@ -17,6 +17,7 @@ class ScannerTimeouts:
     IDOR_CROSS_USER_SECONDS = 120
     PRIVILEGE_ESCALATION_SECONDS = 180  # 8 tests: differential, mutation replay, object write, etc.
     GIT_SECRET_SCAN_SECONDS = 90
+    SEMGREP_TAINT_SECONDS = 150  # above SemgrepAnalyzer's own 120s subprocess timeout
     LLM_CODE_REVIEW_SECONDS = 900  # 15 min — reviews in parallel batches (includes import-graph files)
     LSP_VALIDATION_SECONDS = 120   # 2 min — LSP init + auth flow tracing
     TRIAGE_SECONDS = 900           # 15 min — batched LLM triage + themes + owner summary

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,14 +52,17 @@ llm = [
 mcp = [
     "mcp>=1.28.1,<2",
 ]
-# Deterministic taint/injection SAST via Semgrep (#4). Also available standalone
-# (`[taint]`); the analyzer no-ops gracefully when the semgrep binary is absent.
+# Deterministic taint/injection SAST via Semgrep (#4). Kept SEPARATE from [all]:
+# semgrep pins a heavy, tightly-constrained dependency tree (rich/click/boltons/
+# colorama) that cannot co-resolve with isitsecure's [all] stack. The analyzer
+# only needs the `semgrep` binary on PATH, so install it in isolation (this extra,
+# `pipx install semgrep`, brew, …); it no-ops gracefully when the binary is absent.
 taint = [
     "semgrep>=1.100,<2",
 ]
-# Everything
+# Everything (except [taint] — see the note above; semgrep won't co-resolve here)
 all = [
-    "isitsecure[browser,oob,llm,mcp,taint]",
+    "isitsecure[browser,oob,llm,mcp]",
 ]
 # Development
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,9 +52,14 @@ llm = [
 mcp = [
     "mcp>=1.28.1,<2",
 ]
+# Deterministic taint/injection SAST via Semgrep (#4). Also available standalone
+# (`[taint]`); the analyzer no-ops gracefully when the semgrep binary is absent.
+taint = [
+    "semgrep>=1.100,<2",
+]
 # Everything
 all = [
-    "isitsecure[browser,oob,llm,mcp]",
+    "isitsecure[browser,oob,llm,mcp,taint]",
 ]
 # Development
 dev = [

--- a/tests/engine/test_factory.py
+++ b/tests/engine/test_factory.py
@@ -20,7 +20,7 @@ from isitsecure.engine.scanners.protocols import DASTScannerProtocol
 EXPECTED_DAST_SCANNER_COUNT_QUICK = 15
 EXPECTED_DAST_SCANNER_COUNT_DEEP = 19
 # Expected SAST scanner count based on factory.py sast_scanners list (without LLM)
-EXPECTED_SAST_SCANNER_COUNT = 17
+EXPECTED_SAST_SCANNER_COUNT = 18
 
 
 class TestFactory:
@@ -112,6 +112,7 @@ class TestFactory:
         assert "iac_scanner" in scanner_names
         assert "docker_scanner" in scanner_names
         assert "shell_script_scanner" in scanner_names
+        assert "semgrep_taint" in scanner_names  # #4 taint/injection floor
 
 
 class TestRepoIngestionFactory:

--- a/tests/engine/test_semgrep_analyzer.py
+++ b/tests/engine/test_semgrep_analyzer.py
@@ -1,0 +1,350 @@
+"""Tests for SemgrepAnalyzer (#4).
+
+These tests must NOT depend on the `semgrep` binary being installed — the
+subprocess boundary (`_run_semgrep`) and the binary lookup (`_find_semgrep`)
+are mocked so the suite is deterministic in CI (no `[taint]` extra required).
+"""
+
+import json
+
+import pytest
+
+from isitsecure.engine.code_analysis.protocols import RepoSnapshot
+from isitsecure.engine.code_analysis.semgrep_analyzer import SemgrepAnalyzer
+from isitsecure.engine.enums import FindingCategory, SeverityLevel
+
+
+def _snapshot(files: dict[str, str], clone_path: str = "/repo") -> RepoSnapshot:
+    return RepoSnapshot(
+        repo_url="https://github.com/test/repo",
+        branch="main",
+        commit_hash="abc123",
+        clone_path=clone_path,
+        auth_provider="",
+        package_json={},
+        file_index=files,
+        route_map=[],
+        migration_files=[],
+        env_files=[],
+        total_files=len(files),
+        total_size_bytes=0,
+    )
+
+
+def _result(
+    *,
+    path: str = "/repo/src/app/api/login/route.ts",
+    line: int = 11,
+    end: int = 11,
+    message: str = "User input flows into a raw SQL query — parameterize it.",
+    category: str = "injection_risk",
+    severity: str = "critical",
+    check_id: str = "isitsecure-sqli-taint",
+    lines: str = "sql.unsafe(`SELECT * FROM u WHERE id=${id}`)",
+) -> dict:
+    return {
+        "check_id": check_id,
+        "path": path,
+        "start": {"line": line},
+        "end": {"line": end},
+        "extra": {
+            "message": message,
+            "lines": lines,
+            "severity": "ERROR",
+            "metadata": {"category": category, "isitsecure-severity": severity},
+        },
+    }
+
+
+class TestGracefulNoOp:
+    @pytest.mark.asyncio
+    async def test_no_semgrep_binary_returns_empty(self, monkeypatch):
+        """No semgrep installed → no-op, never raises."""
+        monkeypatch.setattr(SemgrepAnalyzer, "_find_semgrep", staticmethod(lambda: None))
+        analyzer = SemgrepAnalyzer()
+        findings = await analyzer.scan(_snapshot({"src/x.ts": ""}))
+        assert findings == []
+
+    @pytest.mark.asyncio
+    async def test_no_supported_files_skips_run(self, monkeypatch):
+        """A repo with no JS/TS files never even invokes semgrep."""
+        monkeypatch.setattr(SemgrepAnalyzer, "_find_semgrep", staticmethod(lambda: "/bin/semgrep"))
+
+        async def _boom(*a, **k):  # pragma: no cover - must not be called
+            raise AssertionError("_run_semgrep should not run without JS/TS files")
+
+        monkeypatch.setattr(SemgrepAnalyzer, "_run_semgrep", _boom)
+        analyzer = SemgrepAnalyzer()
+        findings = await analyzer.scan(_snapshot({"main.py": "", "README.md": ""}))
+        assert findings == []
+
+    @pytest.mark.asyncio
+    async def test_semgrep_crash_returns_empty(self, monkeypatch):
+        """_run_semgrep returning None (crash/timeout) degrades to no findings."""
+        monkeypatch.setattr(SemgrepAnalyzer, "_find_semgrep", staticmethod(lambda: "/bin/semgrep"))
+
+        async def _none(self, semgrep, clone_path):
+            return None
+
+        monkeypatch.setattr(SemgrepAnalyzer, "_run_semgrep", _none)
+        findings = await SemgrepAnalyzer().scan(_snapshot({"src/x.ts": ""}))
+        assert findings == []
+
+
+class TestFindSemgrep:
+    def test_prefers_venv_binary_over_path(self, monkeypatch, tmp_path):
+        """The binary next to the interpreter wins over PATH."""
+        import isitsecure.engine.code_analysis.semgrep_analyzer as mod
+
+        venv_bin = tmp_path / "semgrep"
+        venv_bin.write_text("#!/bin/sh\n")
+        monkeypatch.setattr(mod.sys, "executable", str(tmp_path / "python"))
+        monkeypatch.setattr(mod.shutil, "which", lambda _: "/usr/bin/semgrep")
+        assert SemgrepAnalyzer._find_semgrep() == str(venv_bin)
+
+    def test_falls_back_to_path(self, monkeypatch, tmp_path):
+        import isitsecure.engine.code_analysis.semgrep_analyzer as mod
+
+        monkeypatch.setattr(mod.sys, "executable", str(tmp_path / "python"))  # no sibling semgrep
+        monkeypatch.setattr(mod.shutil, "which", lambda _: "/usr/bin/semgrep")
+        assert SemgrepAnalyzer._find_semgrep() == "/usr/bin/semgrep"
+
+
+class TestFindingMapping:
+    async def _run(self, monkeypatch, results):
+        monkeypatch.setattr(SemgrepAnalyzer, "_find_semgrep", staticmethod(lambda: "/bin/semgrep"))
+
+        async def _fake(self, semgrep, clone_path):
+            return {"results": results}
+
+        monkeypatch.setattr(SemgrepAnalyzer, "_run_semgrep", _fake)
+        return await SemgrepAnalyzer().scan(_snapshot({"src/x.ts": ""}))
+
+    @pytest.mark.asyncio
+    async def test_maps_core_fields(self, monkeypatch):
+        findings = await self._run(monkeypatch, [_result()])
+        assert len(findings) == 1
+        f = findings[0]
+        assert f.scanner_name == "semgrep_taint"
+        assert f.category == FindingCategory.INJECTION_RISK
+        assert f.severity == SeverityLevel.CRITICAL
+        assert f.file_path == "src/app/api/login/route.ts"  # made relative to clone_path
+        assert f.line_number == 11
+        assert f.title == "User input flows into a raw SQL query"  # split on em-dash
+        assert f.confidence == 0.85
+        assert "sql.unsafe" in f.code_snippet
+
+    @pytest.mark.asyncio
+    async def test_severity_falls_back_to_semgrep_level(self, monkeypatch):
+        """No explicit isitsecure-severity → map ERROR/WARNING/INFO."""
+        r = _result(severity="")
+        r["extra"]["metadata"].pop("isitsecure-severity")
+        r["extra"]["severity"] = "WARNING"
+        findings = await self._run(monkeypatch, [r])
+        assert findings[0].severity == SeverityLevel.MEDIUM
+
+    @pytest.mark.asyncio
+    async def test_unknown_category_defaults_to_injection(self, monkeypatch):
+        findings = await self._run(monkeypatch, [_result(category="not-a-real-category")])
+        assert findings[0].category == FindingCategory.INJECTION_RISK
+
+    @pytest.mark.asyncio
+    async def test_dedups_same_class_rules_on_same_line(self, monkeypatch):
+        """The sqli sink rule and the sqli taint rule on one line collapse to one."""
+        a = _result(check_id="isitsecure-sqli-raw-query", message="SQLi via sink rule")
+        b = _result(check_id="isitsecure-sqli-taint", message="SQLi via taint rule")
+        findings = await self._run(monkeypatch, [a, b])
+        assert len(findings) == 1
+
+    @pytest.mark.asyncio
+    async def test_distinct_classes_on_same_line_kept(self, monkeypatch):
+        """Genuinely different vuln classes on one line survive (reflected-XSS vs SSRF).
+
+        Both map to FindingCategory.INJECTION_RISK, so keying on category alone would
+        wrongly drop one — the dedup keys on the rule's vuln class instead.
+        """
+        xss = _result(line=21, check_id="isitsecure-reflected-xss", severity="high")
+        ssrf = _result(line=21, check_id="isitsecure-ssrf", severity="high")
+        findings = await self._run(monkeypatch, [xss, ssrf])
+        assert len(findings) == 2
+
+    @pytest.mark.asyncio
+    async def test_unknown_rule_ids_are_own_class(self, monkeypatch):
+        """Two unrecognised rule ids on one line don't collapse into each other."""
+        a = _result(line=5, check_id="some-other-rule-a")
+        b = _result(line=5, check_id="some-other-rule-b")
+        findings = await self._run(monkeypatch, [a, b])
+        assert len(findings) == 2
+
+    @pytest.mark.asyncio
+    async def test_path_outside_clone_root_kept_verbatim(self, monkeypatch):
+        """A path that isn't under clone_path shouldn't crash the mapping."""
+        findings = await self._run(monkeypatch, [_result(path="/elsewhere/x.ts")])
+        assert findings[0].file_path == "/elsewhere/x.ts"
+
+    @pytest.mark.asyncio
+    async def test_empty_results(self, monkeypatch):
+        findings = await self._run(monkeypatch, [])
+        assert findings == []
+
+    @pytest.mark.asyncio
+    async def test_title_falls_back_when_no_separator(self, monkeypatch):
+        findings = await self._run(monkeypatch, [_result(message="Command injection")])
+        assert findings[0].title == "Command injection"
+
+
+class TestRunSemgrepBoundary:
+    """Exercise _run_semgrep's parsing/timeout via a fake subprocess (no binary)."""
+
+    @pytest.mark.asyncio
+    async def test_parses_stdout_json(self, monkeypatch):
+        payload = json.dumps({"results": [_result()]}).encode()
+
+        class _Proc:
+            returncode = 0
+
+            async def communicate(self):
+                return payload, b""
+
+            def kill(self):  # pragma: no cover
+                pass
+
+        async def _fake_exec(*a, **k):
+            return _Proc()
+
+        monkeypatch.setattr(
+            "isitsecure.engine.code_analysis.semgrep_analyzer.asyncio.create_subprocess_exec",
+            _fake_exec,
+        )
+        raw = await SemgrepAnalyzer()._run_semgrep("/bin/semgrep", "/repo")
+        assert raw is not None and len(raw["results"]) == 1
+
+    @pytest.mark.asyncio
+    async def test_empty_stdout_returns_none(self, monkeypatch):
+        class _Proc:
+            returncode = 0
+
+            async def communicate(self):
+                return b"", b"some stderr"
+
+            def kill(self):  # pragma: no cover
+                pass
+
+        async def _fake_exec(*a, **k):
+            return _Proc()
+
+        monkeypatch.setattr(
+            "isitsecure.engine.code_analysis.semgrep_analyzer.asyncio.create_subprocess_exec",
+            _fake_exec,
+        )
+        assert await SemgrepAnalyzer()._run_semgrep("/bin/semgrep", "/repo") is None
+
+    @pytest.mark.asyncio
+    async def test_subprocess_exception_returns_none(self, monkeypatch):
+        async def _boom(*a, **k):
+            raise OSError("no such binary")
+
+        monkeypatch.setattr(
+            "isitsecure.engine.code_analysis.semgrep_analyzer.asyncio.create_subprocess_exec",
+            _boom,
+        )
+        assert await SemgrepAnalyzer()._run_semgrep("/bin/semgrep", "/repo") is None
+
+    @pytest.mark.asyncio
+    async def test_malformed_json_returns_none(self, monkeypatch):
+        class _Proc:
+            returncode = 0
+
+            async def communicate(self):
+                return b"not json at all", b""
+
+            def kill(self):  # pragma: no cover
+                pass
+
+        monkeypatch.setattr(
+            "isitsecure.engine.code_analysis.semgrep_analyzer.asyncio.create_subprocess_exec",
+            lambda *a, **k: _fake_awaitable(_Proc()),
+        )
+        assert await SemgrepAnalyzer()._run_semgrep("/bin/semgrep", "/repo") is None
+
+    @pytest.mark.asyncio
+    async def test_non_dict_json_returns_none(self, monkeypatch):
+        class _Proc:
+            returncode = 0
+
+            async def communicate(self):
+                return b"[1, 2, 3]", b""  # valid JSON, but not an object
+
+            def kill(self):  # pragma: no cover
+                pass
+
+        monkeypatch.setattr(
+            "isitsecure.engine.code_analysis.semgrep_analyzer.asyncio.create_subprocess_exec",
+            lambda *a, **k: _fake_awaitable(_Proc()),
+        )
+        assert await SemgrepAnalyzer()._run_semgrep("/bin/semgrep", "/repo") is None
+
+    @pytest.mark.asyncio
+    async def test_timeout_kills_and_reaps_child(self, monkeypatch):
+        """On the internal timeout the semgrep child must be killed AND reaped."""
+        killed = {"kill": False, "wait": False}
+
+        class _Proc:
+            returncode = None  # still running
+
+            async def communicate(self):
+                import asyncio as _a
+
+                await _a.sleep(999)  # never returns → wait_for times out
+
+            def kill(self):
+                killed["kill"] = True
+                self.returncode = -9
+
+            async def wait(self):
+                killed["wait"] = True
+                return -9
+
+        monkeypatch.setattr(
+            "isitsecure.engine.code_analysis.semgrep_analyzer._SCAN_TIMEOUT_S", 0.01
+        )
+        monkeypatch.setattr(
+            "isitsecure.engine.code_analysis.semgrep_analyzer.asyncio.create_subprocess_exec",
+            lambda *a, **k: _fake_awaitable(_Proc()),
+        )
+        result = await SemgrepAnalyzer()._run_semgrep("/bin/semgrep", "/repo")
+        assert result is None
+        assert killed["kill"] and killed["wait"]  # no orphan, no zombie
+
+    @pytest.mark.asyncio
+    async def test_cancellation_reaps_child_and_propagates(self, monkeypatch):
+        """An outer cancel (scan timeout) must reap the child, then re-raise."""
+        import asyncio as _a
+
+        killed = {"kill": False}
+
+        class _Proc:
+            returncode = None
+
+            async def communicate(self):
+                raise _a.CancelledError()
+
+            def kill(self):
+                killed["kill"] = True
+                self.returncode = -9
+
+            async def wait(self):
+                return -9
+
+        monkeypatch.setattr(
+            "isitsecure.engine.code_analysis.semgrep_analyzer.asyncio.create_subprocess_exec",
+            lambda *a, **k: _fake_awaitable(_Proc()),
+        )
+        with pytest.raises(_a.CancelledError):
+            await SemgrepAnalyzer()._run_semgrep("/bin/semgrep", "/repo")
+        assert killed["kill"]  # child killed even on cancellation
+
+
+async def _fake_awaitable(value):
+    """Wrap a value so `await create_subprocess_exec(...)` yields it."""
+    return value


### PR DESCRIPTION
Adds **`SemgrepAnalyzer`** — a deterministic source→sink injection layer beneath the LLM code reviewer. Runs Semgrep with isitsecure's own taint/sink rule packs and maps results to `CodeFinding`s, giving a reproducible, instant, \$0 floor for the mechanical injection cases on JS/TS.

This is the first shippable slice of the #4 epic (Phases 2/3/5 of `docs/taint-analysis.md`). Remaining phases are tracked as follow-ups (below).

## What's in it
- **`SemgrepAnalyzer`** (`scanner_name = "semgrep_taint"`), wired into the SAST scanner list. Best-effort: no-ops if the `semgrep` binary is absent; a crash/timeout never fails the scan; the semgrep child is always killed **and reaped** — even on outer cancellation — so it's never orphaned.
- **First JS/TS rule pack** (`semgrep_rules/injection-js.yaml`): SQLi, reflected/DOM XSS, SSRF, path traversal, command injection. Rules target framework/library APIs (per-stack, not per-app).
- **Opt-in `[taint]` extra** (`semgrep>=1.100,<2`), folded into `[all]`.
- Dedup keys on the rule's vuln **class**, so distinct classes on one line survive while sqli-sink + sqli-taint collapse.
- 150s scanner timeout (above the analyzer's own 120s) so the analyzer's timeout/kill path fires first.

## Adversarial review → fixed
- **Blocker:** orphaned semgrep child on cancellation (`semgrep_taint` wasn't in the timeout map → 60s < internal 120s → `CancelledError` escaped uncaught). Fixed + regression-tested.
- FP-prone rules narrowed (removed generic `.query()`; excluded constant-path writes).
- Dedup no longer collapses genuinely distinct vuln classes.

## Verification
- **37 tests** (analyzer + factory) green; ruff clean; wheel ships the yaml pack.
- **Benchmark (ad-hoc):** test-app **15 TP / 0 FP**; NodeGoat **0 FP**; real UI **0 FP**; synthetic FP fixture **0 FP**. Recall is additive (LLM layer untouched → no regression possible).
- 21 mocked `SemgrepAnalyzer` tests — no dependency on the semgrep binary; cover the timeout/cancel/malformed-JSON paths.

## Docs (ship with the code)
README (SAST list + counts 40→41/44→45, `[taint]` extra, competitive + limitations claims), `docs/scanners/` (index + new `semgrep-taint.md`), `docs/architecture.md` (counts + taint-floor note), `docs/taint-analysis.md` (status → implemented), `CONTRIBUTING.md`.

## Closes / follow-ups
Closes #4 (first slice). Remaining phases tracked separately:
- #92 — SAST injection benchmark harness + fixtures (the committed recall/FP scorecard)
- #93 — Broaden rule packs beyond JS/TS (Python: FastAPI/Flask/Django + more libraries)
- #94 — Auto-select rule packs per detected stack

🤖 Generated with [Claude Code](https://claude.com/claude-code)