### PR TITLE
test(benchmarks): SAST injection recall/FP benchmark for the taint layer (#92)

### DIFF
--- a/README.md
+++ b/README.md
@@ -619,11 +619,12 @@ isitsecure ships a repeatable benchmark harness that scores **recall** (of the v
 
 ```bash
 python benchmarks/run_benchmarks.py juiceshop   # OWASP Juice Shop — the headline recall number
-python benchmarks/run_benchmarks.py             # VAmPI (vulnerable + secure builds)
+python benchmarks/run_benchmarks.py             # VAmPI (vulnerable + secure builds) + sast-injection
+python benchmarks/run_benchmarks.py sast-injection  # taint recall/FP (code-only, no Docker)
 python benchmarks/run_benchmarks.py --all       # + NodeGoat + crAPI + Juice Shop (heavy)
 ```
 
-Each run spins the target up in Docker, runs a DAST scan, scores against a known ground truth, and tears it down (requires Docker). Measured results are tracked in [benchmarks/RESULTS.md](benchmarks/RESULTS.md); see [benchmarks/README.md](benchmarks/README.md) for targets and how scoring works.
+Most targets spin the app up in Docker, run a DAST scan, score against a known ground truth, and tear it down (require Docker). The `sast-injection` target is **code-only** (no Docker) — it scores the deterministic Semgrep taint layer on a JS/TS injection fixture (**12/12 recall, 0 FP**) and needs the `semgrep` binary instead; it's included in the default run. Measured results are tracked in [benchmarks/RESULTS.md](benchmarks/RESULTS.md); see [benchmarks/README.md](benchmarks/README.md) for targets and how scoring works.
 
 ## Privacy
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,19 +1,23 @@
 # isitsecure benchmark harness
 
 Repeatable **recall + false-positive** scoring against deliberately-vulnerable
-apps. Each run spins the app up in Docker, runs an isitsecure DAST scan, scores
-the findings against a known ground truth, and tears the app down.
+apps. Most targets spin the app up in Docker, run an isitsecure DAST scan, score
+the findings against a known ground truth, and tear the app down. One target —
+`sast-injection` — is **code-only** (no Docker): it scores the deterministic
+Semgrep taint layer against a local injection fixture (see below).
 
 ```bash
 pip install -e ".[all]"          # isitsecure on PATH + browser deps
-python benchmarks/run_benchmarks.py            # default: VAmPI (both builds)
+python benchmarks/run_benchmarks.py            # default: VAmPI (both builds) + sast-injection
 python benchmarks/run_benchmarks.py juiceshop  # OWASP Juice Shop — the headline recall number
 python benchmarks/run_benchmarks.py --all      # + NodeGoat + crAPI + Juice Shop (heavy)
 python benchmarks/run_benchmarks.py crapi      # a single target
+python benchmarks/run_benchmarks.py sast-injection            # taint recall/FP, no Docker
 python benchmarks/run_benchmarks.py --keep vampi-vulnerable   # leave it running
 ```
 
-Requires Docker running.
+Docker is required for every target **except** `sast-injection`, which instead
+needs the `semgrep` binary (`pipx install semgrep` or `pip install semgrep`).
 
 ## What it measures
 
@@ -42,6 +46,7 @@ For each target the scorecard reports two things — both matter:
 | `crapi` | microservices | upstream compose (auto-cloned) | OWASP API Top 10; IDOR/BAC/auth depth |
 | `juiceshop` | Angular/Express SPA | single image | **headline recall** — scored per-challenge vs the app's own `/api/Challenges` |
 | `juiceshop-auth` | same, authenticated | single image | adds the login-gated challenges (the `~40%` number) |
+| `sast-injection` | JS/TS fixtures | **none** (code-only) | **taint layer recall/FP** — deterministic SAST injection floor (#4) |
 
 VAmPI is a single container and runs in the default set. NodeGoat and crAPI are
 heavier (compose, mongo, several GB for crAPI) — run them individually. They are
@@ -62,6 +67,36 @@ seeded from `/api/Challenges`): recall over the **45 DAST-detectable** challenge
 (of 113), broken down per class, with each finding required to land on the right
 endpoint. `run_benchmarks.py juiceshop` runs this end to end; you can also score a
 saved scan by hand with `python benchmarks/score.py juiceshop findings.json`.
+
+## SAST injection benchmark (`sast-injection`)
+
+The deterministic Semgrep taint layer (#4) has its own **code-only** scorecard,
+separate from the DAST targets. It scans a local fixture tree and scores taint
+recall + false positives — the gate for the taint layer and every future
+rule-pack change (#93/#94).
+
+```bash
+python benchmarks/run_benchmarks.py sast-injection   # via the harness (fails non-zero on any miss/FP)
+python benchmarks/sast_injection.py                  # standalone, same scorecard
+python benchmarks/sast_injection.py findings.json    # score an existing code-only scan JSON
+```
+
+The fixtures **are** the ground truth (no separate file to drift):
+
+- `fixtures/sast-injection/vulnerable/*` — each line tagged `// EXPECT <class>`
+  (`sqli | reflected-xss | dom-xss | ssrf | path-traversal | command-injection`)
+  is a bug the taint layer must flag (recall).
+- `fixtures/sast-injection/safe/*` — benign near-misses (parameterized queries,
+  constant-path writes, non-DB `.query()`, escaped output, fixed-URL fetch). Any
+  injection finding here — or on an unmarked line in a vulnerable file — is a
+  **false positive**.
+
+The scorer (`sast_injection.py`) matches findings to expected bugs by file and
+line (±1, since Semgrep can report the statement head), reports per-class recall,
+and **exits non-zero unless recall is 100% and FP is 0**. It needs the `semgrep`
+binary; scoring an existing `findings.json` needs neither Docker nor semgrep.
+This is an *independent* fixture (not `test-app`, which the rules were tuned on),
+so it's a genuine second data point.
 
 ## Authenticated cross-user IDOR (BOLA)
 

--- a/benchmarks/RESULTS.md
+++ b/benchmarks/RESULTS.md
@@ -18,6 +18,24 @@ _Runs: 2026-07 · `--llm none` (pure DAST detection, no LLM) · Juice Shop pinne
 | `vampi-vulnerable` | url-only | **3/3** (SQLi, IDOR, headers) | — | 14–16 |
 | `vampi-secure` | url-only | — | **2** (IDOR) | 13–15 |
 | `nodegoat-auth` | authenticated | **2/3** (headers, XSS; injection missed) | unmeasured | 28 |
+| `sast-injection` | code-only | **12/12 (100%)** — taint, per-class, deterministic | **0** | 12 |
+
+### SAST injection (`sast-injection`, code-only, taint layer #4)
+
+The deterministic Semgrep taint layer scored on an independent JS/TS injection
+fixture (not `test-app`, which the rules were tuned on). Recall **12/12** with
+**0 false positives** across all six classes, deterministic across runs:
+
+| Class | Found / expected | Class | Found / expected |
+|---|--:|---|--:|
+| sqli | **5/5** | ssrf | **1/1** |
+| reflected-xss | **2/2** | path-traversal | **1/1** |
+| dom-xss | **2/2** | command-injection | **1/1** |
+
+The FP side is exercised by benign near-misses (parameterized queries,
+constant-path writes, non-DB `.query()`, escaped output, fixed-URL fetch) — none
+flagged. This is the baseline the taint layer and future rule packs (#93/#94)
+must hold.
 
 > Juice Shop recall is scored **per challenge** — a finding must match the class
 > signature AND land on the right endpoint — over the 45 DAST-detectable

--- a/benchmarks/fixtures/sast-injection/safe/benign.ts
+++ b/benchmarks/fixtures/sast-injection/safe/benign.ts
@@ -1,0 +1,46 @@
+// Injection benchmark fixture — SAFE / benign near-misses.
+// NOTHING in this file may be flagged. Each case is deliberately close to a
+// vulnerable shape but is not actually injectable — this is the false-positive
+// side of the scorecard.
+
+import { sql } from "../vulnerable/db";
+import fs from "fs";
+import path from "path";
+
+// SAFE: parameterized query (tagged template, not `.unsafe`) — the correct fix
+export async function getUser(id: string) {
+  return sql`SELECT * FROM users WHERE id = ${id}`;
+}
+
+// SAFE: non-DB `.query()` with interpolation (analytics client, not SQL)
+declare const analytics: { query: (s: string) => void };
+export function track(name: string) {
+  analytics.query(`event ${name} fired`);
+}
+
+// SAFE: GraphQL client `.query` with interpolation — not a SQL sink
+declare const gqlClient: { query: (s: string) => Promise<unknown> };
+export function fetchUser(id: string) {
+  return gqlClient.query(`query { user(id: ${id}) { name } }`);
+}
+
+// SAFE: constant-path file write (no user-derived filename)
+export function writeLog(data: string) {
+  fs.writeFile(path.join(__dirname, "app.log"), data, () => {});
+  fs.writeFileSync(path.join(process.cwd(), "out.txt"), data);
+}
+
+// SAFE: value passes through a recognized sanitizer before the response, which
+// breaks the taint flow (tests sanitizer recognition, not a specific escaper).
+export function reflect(req: Request) {
+  const url = new URL(req.url);
+  const q = encodeURIComponent(url.searchParams.get("q") ?? "");
+  return new Response(`<h1>Results for ${q}</h1>`, {
+    headers: { "content-type": "text/html" },
+  });
+}
+
+// SAFE: fetch to a fixed, non-user-controlled URL
+export async function health() {
+  return fetch("https://api.internal.example.com/health");
+}

--- a/benchmarks/fixtures/sast-injection/vulnerable/sqli.ts
+++ b/benchmarks/fixtures/sast-injection/vulnerable/sqli.ts
@@ -1,0 +1,35 @@
+// Injection benchmark fixture — SQL injection (VULNERABLE).
+// Each `EXPECT` comment marks a line the taint layer must flag (injection_risk).
+// Stack shapes: postgres `.unsafe`, Prisma raw, Drizzle `.raw`, knex.raw, and a
+// request-source → raw-query taint flow.
+
+import { sql } from "./db";
+import { prisma } from "./prisma";
+import knex from "./knex";
+
+// case: postgres template-literal interpolation into an unsafe query
+export async function getUser(id: string) {
+  return sql.unsafe(`SELECT * FROM users WHERE id = ${id}`); // EXPECT sqli
+}
+
+// case: string concatenation into an unsafe query
+export async function search(term: string) {
+  return sql.unsafe("SELECT * FROM items WHERE name LIKE '%" + term + "%'"); // EXPECT sqli
+}
+
+// case: Prisma raw-unsafe with interpolation
+export async function prismaLookup(email: string) {
+  return prisma.$queryRawUnsafe(`SELECT * FROM users WHERE email = '${email}'`); // EXPECT sqli
+}
+
+// case: knex.raw with interpolation
+export async function knexLookup(role: string) {
+  return knex.raw(`SELECT * FROM users WHERE role = '${role}'`); // EXPECT sqli
+}
+
+// case: request source (searchParams) flows into a raw query (taint)
+export async function handler(req: Request) {
+  const url = new URL(req.url);
+  const name = url.searchParams.get("name");
+  return sql.unsafe(`SELECT * FROM accounts WHERE name = '${name}'`); // EXPECT sqli
+}

--- a/benchmarks/fixtures/sast-injection/vulnerable/ssrf-and-more.ts
+++ b/benchmarks/fixtures/sast-injection/vulnerable/ssrf-and-more.ts
@@ -1,0 +1,24 @@
+// Injection benchmark fixture — SSRF, path traversal, command injection (VULNERABLE).
+
+import { exec } from "child_process";
+import fs from "fs";
+import path from "path";
+
+// --- SSRF: user-controlled URL → outbound fetch ---
+export async function proxy(req: Request) {
+  const url = new URL(req.url);
+  const target = url.searchParams.get("url");
+  return fetch(target as string); // EXPECT ssrf
+}
+
+// --- Path traversal: request-derived filename → fs write ---
+export async function upload(req: any, uploadDir: string) {
+  const filename = req.body.filename;
+  fs.writeFile(path.join(uploadDir, filename), req.body.data, () => {}); // EXPECT path-traversal
+}
+
+// --- Command injection: user input → shell ---
+export function ping(req: any) {
+  const host = req.query.host;
+  exec(`ping -c 1 ${host}`); // EXPECT command-injection
+}

--- a/benchmarks/fixtures/sast-injection/vulnerable/xss.ts
+++ b/benchmarks/fixtures/sast-injection/vulnerable/xss.ts
@@ -1,0 +1,26 @@
+// Injection benchmark fixture — reflected & DOM XSS (VULNERABLE).
+
+// --- Reflected XSS: request data → HTML response without escaping ---
+export async function reflected(req: Request) {
+  const url = new URL(req.url);
+  const q = url.searchParams.get("q");
+  const html = `<h1>Results for ${q}</h1>`;
+  return new Response(html, { headers: { "content-type": "text/html" } }); // EXPECT reflected-xss
+}
+
+// --- Reflected XSS via res.send (Express shape) ---
+export function expressReflect(req: any, res: any) {
+  const name = req.query.name;
+  res.send(`<p>Hello ${name}</p>`); // EXPECT reflected-xss
+}
+
+// --- DOM XSS: location.hash → innerHTML ---
+export function renderFromHash(el: HTMLElement) {
+  const data = window.location.hash;
+  el.innerHTML = data; // EXPECT dom-xss
+}
+
+// --- DOM XSS: location.search → document.write ---
+export function writeFromSearch() {
+  document.write(window.location.search); // EXPECT dom-xss
+}

--- a/benchmarks/run_benchmarks.py
+++ b/benchmarks/run_benchmarks.py
@@ -386,24 +386,67 @@ def print_scorecard(results: list[dict]) -> None:
                 print(f"    {n:>2}  {label}")
 
 
+# The SAST injection benchmark is not a Docker/DAST target — it scores a
+# code-only scan of a local fixture tree (see sast_injection.py). It's exposed
+# here as a pseudo-target so it runs from the same entrypoint (and by default).
+SAST_INJECTION = "sast-injection"
+
+
+def resolve_selection(targets: list[str], all_flag: bool) -> tuple[list[str], bool, list[str]]:
+    """Plan a run from the CLI args (pure — no Docker, no side effects).
+
+    Returns (docker target names to run, whether to run sast-injection, unknown names).
+    The SAST pseudo-target runs when named, with --all, or in the default (no-arg) set.
+    """
+    valid = {t.name for t in TARGETS}
+    want_sast = SAST_INJECTION in targets or all_flag or not targets
+    docker_names = [n for n in targets if n != SAST_INJECTION]
+    if docker_names:
+        unknown = [n for n in docker_names if n not in valid]
+        return [n for n in docker_names if n in valid], want_sast, unknown
+    if all_flag:
+        return [t.name for t in TARGETS], want_sast, []
+    if targets:  # only sast-injection was requested
+        return [], want_sast, []
+    return ["vampi-vulnerable", "vampi-secure"], want_sast, []
+
+
+def run_sast_injection() -> int:
+    """Run the SAST injection benchmark; return 0 on full recall + 0 FP, else 1.
+
+    Skips (returns 0) if the semgrep binary is absent — like the Docker targets
+    can't run without Docker, this one can't run without semgrep.
+    """
+    import sast_injection as si
+
+    print(f"\n=== {SAST_INJECTION} ===\n    code-only taint recall / FP on the "
+          f"injection fixtures (no Docker; needs the semgrep binary)")
+    if not si.semgrep_available():
+        print("    SKIPPED — semgrep binary not found (pipx install semgrep).")
+        return 0
+    try:
+        findings = si.run_scan()
+    except Exception as e:  # noqa: BLE001 - surface, don't crash the whole suite
+        print(f"    SAST injection scan failed: {e}")
+        return 1
+    r = si.score(findings)
+    si.print_report(r)
+    return 0 if si.passed(r) else 1
+
+
 def main() -> int:
     ap = argparse.ArgumentParser()
-    ap.add_argument("targets", nargs="*", help="target names (default: vampi both)")
+    ap.add_argument("targets", nargs="*", help="target names (default: vampi + sast-injection)")
     ap.add_argument("--keep", action="store_true", help="don't tear down containers")
     ap.add_argument("--all", action="store_true", help="include heavy compose targets")
     args = ap.parse_args()
 
     by_name = {t.name: t for t in TARGETS}
-    if args.targets:
-        selected = [by_name[n] for n in args.targets if n in by_name]
-        missing = [n for n in args.targets if n not in by_name]
-        if missing:
-            print(f"Unknown targets: {missing}. Available: {list(by_name)}")
-            return 2
-    elif args.all:
-        selected = TARGETS
-    else:
-        selected = [by_name["vampi-vulnerable"], by_name["vampi-secure"]]
+    docker_names, want_sast, unknown = resolve_selection(args.targets, args.all)
+    if unknown:
+        print(f"Unknown targets: {unknown}. Available: {list(by_name) + [SAST_INJECTION]}")
+        return 2
+    selected = [by_name[n] for n in docker_names]
 
     results = [run_target(t, args.keep) for t in selected]
     print_scorecard(results)
@@ -413,9 +456,13 @@ def main() -> int:
         len(r.get("scorecard", {}).get("regression_failures", []))
         for r in results
     )
+    sast_rc = run_sast_injection() if want_sast else 0
     if regressions:
         print(f"\n✗ {regressions} regression failure(s) — a finding the scanner "
               f"reliably catches was dropped by the full scan. See ⚠ REGRESSION above.")
+        return 1
+    if sast_rc:
+        print("\n✗ SAST injection benchmark failed (recall < 100% or FP > 0).")
         return 1
     return 0
 

--- a/benchmarks/sast_injection.py
+++ b/benchmarks/sast_injection.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+"""SAST injection benchmark — recall + false-positive scorecard for the taint layer.
+
+Unlike the Docker/DAST harness in ``run_benchmarks.py``, this scores a *code-only*
+scan of a local fixture tree with known source→sink bugs. It is the deterministic
+gate for the Semgrep taint layer (#4) and every future rule-pack change (#93/#94).
+
+Ground truth is the fixtures themselves — no separate file to drift out of sync:
+
+  * ``fixtures/sast-injection/vulnerable/*`` — each line marked ``// EXPECT <class>``
+    is a bug the taint layer MUST flag (recall). ``<class>`` is one of
+    sqli | reflected-xss | dom-xss | ssrf | path-traversal | command-injection.
+  * ``fixtures/sast-injection/safe/*`` — benign near-misses. ANY injection finding
+    here (or on an unmarked line in a vulnerable file) is a false positive.
+
+Usage:
+  python benchmarks/sast_injection.py                 # scan the fixtures + score
+  python benchmarks/sast_injection.py findings.json   # score an existing scan JSON
+
+Requires (for the scan path): ``isitsecure`` on PATH and the ``semgrep`` binary
+(``pip install semgrep`` / ``pipx install semgrep``). Scoring an existing JSON
+needs neither.
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import re
+import subprocess
+import sys
+import tempfile
+from collections import defaultdict
+
+FIXTURES = pathlib.Path(__file__).parent / "fixtures" / "sast-injection"
+EXPECT_RE = re.compile(r"//\s*EXPECT\s+([a-z-]+)")
+CLASSES = ("sqli", "reflected-xss", "dom-xss", "ssrf", "path-traversal", "command-injection")
+
+# Injection finding → vuln class, inferred from the title (findings are all
+# category injection_risk). Cues are DISTINCTIVE phrases, not bare substrings, so
+# they don't collide (e.g. "dom" would match "domain"/"random"). First hit wins.
+_TITLE_CUES = [
+    ("dom-xss", ("into the dom", "innerhtml", "document.write", "dom xss")),
+    ("reflected-xss", ("reflected", "html response")),
+    ("ssrf", ("outbound request", "ssrf")),
+    ("path-traversal", ("filesystem write", "path traversal", "request-derived filename")),
+    ("command-injection", ("shell command", "command injection")),
+    ("sqli", ("sql",)),
+]
+
+
+def expected_bugs() -> list[dict]:
+    """Parse ``// EXPECT <class>`` markers out of the vulnerable fixtures."""
+    bugs = []
+    for f in sorted((FIXTURES / "vulnerable").rglob("*")):
+        if not f.is_file():
+            continue
+        for i, line in enumerate(f.read_text().splitlines(), start=1):
+            m = EXPECT_RE.search(line)
+            if m:
+                bugs.append({"file": f.name, "line": i, "class": m.group(1)})
+    return bugs
+
+
+def is_injection(f: dict) -> bool:
+    return f.get("category") == "injection_risk" or f.get("scanner_name") == "semgrep_taint"
+
+
+def finding_loc(f: dict) -> tuple[str, int | None]:
+    loc = f.get("code_location") or {}
+    fp = loc.get("file_path") or f.get("file_path") or ""
+    return pathlib.Path(fp).name, loc.get("line_number") or f.get("line_number")
+
+
+def finding_class(f: dict) -> str:
+    title = (f.get("title") or "").lower()
+    for cls, cues in _TITLE_CUES:
+        if any(c in title for c in cues):
+            return cls
+    return "?"
+
+
+def _near(fn: str, ln: int | None, bug: dict) -> bool:
+    # ±1 line — Semgrep can report the statement head rather than the exact line.
+    return fn == bug["file"] and ln is not None and abs(ln - bug["line"]) <= 1
+
+
+def score(findings: list[dict]) -> dict:
+    injection = [f for f in findings if is_injection(f)]
+    expected = expected_bugs()
+
+    # Recall: 1:1 greedy match — each expected bug consumes at most one finding,
+    # and each finding credits at most one bug (so two bugs can't both be credited
+    # to a single finding, and a bug can't be credited twice).
+    used: set[int] = set()
+    items = []
+    for bug in expected:
+        hit = None
+        for idx, f in enumerate(injection):
+            if idx in used:
+                continue
+            fn, ln = finding_loc(f)
+            if _near(fn, ln, bug):
+                hit = idx
+                used.add(idx)
+                break
+        class_match = hit is not None and finding_class(injection[hit]) == bug["class"]
+        items.append({**bug, "detected": hit is not None, "class_match": class_match})
+
+    # False positives: an injection finding that isn't near ANY expected bug —
+    # everything under safe/, plus unmarked lines in vulnerable files. A finding
+    # near a real bug is NOT an FP even if the 1:1 match already consumed another
+    # finding for it (real Semgrep output double-reports a sink: taint + pattern).
+    false_positives = [
+        {"file": fn, "line": ln, "title": f.get("title"), "class": finding_class(f)}
+        for f in injection
+        for fn, ln in [finding_loc(f)]
+        if not any(_near(fn, ln, b) for b in expected)
+    ]
+
+    by_class: dict[str, list[int]] = defaultdict(lambda: [0, 0])
+    for it in items:
+        by_class[it["class"]][1] += 1
+        if it["detected"]:
+            by_class[it["class"]][0] += 1
+
+    found = sum(1 for it in items if it["detected"])
+    return {
+        "recall": {"found": found, "total": len(expected)},
+        "false_positives": {"count": len(false_positives), "items": false_positives},
+        "by_class": {k: {"found": v[0], "total": v[1]} for k, v in sorted(by_class.items())},
+        "gaps": [it for it in items if not it["detected"]],
+        "class_mismatches": [it for it in items if it["detected"] and not it["class_match"]],
+        "total_injection_findings": len(injection),
+    }
+
+
+def passed(result: dict) -> bool:
+    """The gate: full recall AND zero false positives."""
+    return (result["recall"]["found"] == result["recall"]["total"]
+            and result["false_positives"]["count"] == 0)
+
+
+def semgrep_available() -> bool:
+    """True if the taint layer can actually run (the semgrep binary is present)."""
+    try:
+        from isitsecure.engine.code_analysis.semgrep_analyzer import SemgrepAnalyzer
+        return SemgrepAnalyzer._find_semgrep() is not None
+    except Exception:  # noqa: BLE001 - fall back to a PATH probe
+        import shutil
+        return shutil.which("semgrep") is not None
+
+
+def run_scan() -> list[dict]:
+    out = tempfile.NamedTemporaryFile("r", suffix=".json", delete=False).name
+    cmd = ["isitsecure", "scan", "-r", f"file://{FIXTURES.resolve()}",
+           "--mode", "code-only", "--llm", "none", "--output", "json", "-f", out]
+    print(f"$ {' '.join(cmd)}")
+    try:
+        subprocess.run(cmd, check=True, timeout=300)  # noqa: S603 - fixed command, benchmark tool
+        data = json.loads(pathlib.Path(out).read_text())
+        return data.get("findings", []) if isinstance(data, dict) else data
+    finally:
+        pathlib.Path(out).unlink(missing_ok=True)
+
+
+def print_report(r: dict) -> None:
+    rec = r["recall"]
+    pct = (100 * rec["found"] / rec["total"]) if rec["total"] else 0
+    print("=" * 60)
+    print("SAST INJECTION BENCHMARK — taint recall / FP scorecard")
+    print("=" * 60)
+    print(f"\nRecall:          {rec['found']}/{rec['total']}  ({pct:.0f}%)")
+    print(f"False positives: {r['false_positives']['count']}  (must be 0)")
+    print(f"Total injection findings: {r['total_injection_findings']}")
+    print("\nBy class (found / expected):")
+    for cls, v in r["by_class"].items():
+        mark = "x" if v["found"] == v["total"] else (" " if v["found"] == 0 else "~")
+        print(f"  [{mark}] {cls:18} {v['found']}/{v['total']}")
+    if r["gaps"]:
+        print(f"\nGaps — {len(r['gaps'])} expected bug(s) MISSED:")
+        for g in r["gaps"]:
+            print(f"  - [{g['class']}] {g['file']}:{g['line']}")
+    if r["false_positives"]["count"]:
+        print(f"\n⚠ FALSE POSITIVES — {r['false_positives']['count']}:")
+        for fp in r["false_positives"]["items"]:
+            print(f"  - [{fp['class']}] {fp['file']}:{fp['line']}  {fp['title']}")
+    if r["class_mismatches"]:
+        print(f"\nNote — {len(r['class_mismatches'])} finding(s) detected but "
+              f"labeled a different class than expected (recall still counts):")
+        for m in r["class_mismatches"]:
+            print(f"  - expected {m['class']} at {m['file']}:{m['line']}")
+
+
+def main() -> int:
+    if len(sys.argv) == 2:
+        data = json.loads(pathlib.Path(sys.argv[1]).read_text())
+        findings = data.get("findings", data) if isinstance(data, dict) else data
+    elif not semgrep_available():
+        print("SKIPPED — semgrep binary not found; install it "
+              "(pipx install semgrep) to run the SAST injection benchmark.")
+        return 0
+    else:
+        findings = run_scan()
+    result = score(findings)
+    print_report(result)
+    ok = passed(result)
+    print(f"\n{'PASS' if ok else 'FAIL'} — recall {result['recall']['found']}/"
+          f"{result['recall']['total']}, {result['false_positives']['count']} FP")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/scanners/semgrep-taint.md
+++ b/docs/scanners/semgrep-taint.md
@@ -38,7 +38,7 @@ It is **best-effort and self-contained**:
 
 Before this analyzer, injection detection (SQLi/XSS/SSRF/path-traversal/command-injection) rested **entirely on the LLM**, which is non-deterministic (finding counts wobble run-to-run), costs tokens, and is slow. The Semgrep layer gives a reproducible, instant, free floor for the mechanical source→sink cases, while the LLM keeps covering business-logic flaws and the long tail of libraries without rules.
 
-See [docs/taint-analysis.md](../taint-analysis.md) for the full design rationale, the spike results, and the per-stack rule model.
+See [docs/taint-analysis.md](../taint-analysis.md) for the full design rationale, the spike results, and the per-stack rule model. The layer has its own recall/FP scorecard — **12/12 recall, 0 false positives** on an independent JS/TS injection fixture — via `python benchmarks/run_benchmarks.py sast-injection` (see [benchmarks/RESULTS.md](../../benchmarks/RESULTS.md)).
 
 ## What Vulnerable Code Looks Like
 

--- a/docs/taint-analysis.md
+++ b/docs/taint-analysis.md
@@ -159,9 +159,11 @@ anything ships:
   catches) without introducing FP noise.
 - Discuss results and get explicit go-ahead before commit/push.
 
-Note: today's benchmark is DAST-oriented; part of this work is a **SAST
-injection benchmark** (a fixture set with known source→sink bugs) so the taint
-layer has a recall/FP scorecard of its own.
+Note: the original benchmark was DAST-oriented, so this work added a **SAST
+injection benchmark** — a fixture set with known source→sink bugs giving the taint
+layer its own recall/FP scorecard. **Delivered** (#92): `benchmarks/sast_injection.py`
++ `benchmarks/fixtures/sast-injection/`, run via `python benchmarks/run_benchmarks.py
+sast-injection`. Baseline **12/12 recall, 0 FP** ([benchmarks/RESULTS.md](../benchmarks/RESULTS.md)).
 
 ## Risks & open questions
 
@@ -176,10 +178,11 @@ layer has a recall/FP scorecard of its own.
 
 ## Phasing
 
-1. **SAST injection benchmark fixtures** + a recall/FP harness (so we can measure).
-2. **`SemgrepAnalyzer`** (subprocess → parse → `CodeFinding`) with a first rule
-   pack for the top stack (Next.js/Express + postgres/Prisma/Drizzle + DOM).
-3. **Benchmark**: prove it adds recall without FP vs. LLM-only. Discuss, then ship.
+1. ✅ **SAST injection benchmark fixtures** + a recall/FP harness (#92) — the
+   `sast-injection` target, baseline 12/12 recall / 0 FP.
+2. ✅ **`SemgrepAnalyzer`** (subprocess → parse → `CodeFinding`) with a first rule
+   pack for the top stack (Next.js/Express + postgres/Prisma/Drizzle + DOM) — #4.
+3. ✅ **Benchmark**: proved it adds recall without FP vs. LLM-only. Shipped in #4.
 4. **Broaden rule packs** (FastAPI/Flask/Django, more libraries) iteratively, each
-   gated by the benchmark.
+   gated by the benchmark — tracked in #93.
 5. **Keep the LLM layer** as the long-tail + business-logic backstop throughout.

--- a/tests/benchmarks/__init__.py
+++ b/tests/benchmarks/__init__.py
@@ -1,0 +1,1 @@
+"""Benchmark harness tests."""

--- a/tests/benchmarks/test_sast_injection_scorer.py
+++ b/tests/benchmarks/test_sast_injection_scorer.py
@@ -1,0 +1,207 @@
+"""Tests for the SAST injection benchmark scorer (benchmarks/sast_injection.py).
+
+Pure scoring logic — no scan, no semgrep binary. Ground truth is parsed from the
+committed fixtures, so these also assert the fixtures stay well-formed.
+"""
+
+import pathlib
+import sys
+
+import pytest
+
+sys.path.insert(0, str(pathlib.Path(__file__).parents[2] / "benchmarks"))
+
+import sast_injection as si  # noqa: E402
+
+_CLASS_TITLE = {
+    "sqli": "User input flows into a raw SQL query",
+    "reflected-xss": "User input reflected into an HTML response without escaping",
+    "dom-xss": "User-controlled input flows into the DOM (innerHTML)",
+    "ssrf": "User-controlled URL flows into an outbound request",
+    "path-traversal": "Filesystem write using a request-derived filename",
+    "command-injection": "User input flows into a shell command",
+}
+
+
+def _finding(file: str, line: int, title: str, *, category: str = "injection_risk") -> dict:
+    return {
+        "category": category,
+        "scanner_name": "semgrep_taint",
+        "title": title,
+        "code_location": {"file_path": f"vulnerable/{file}", "line_number": line},
+    }
+
+
+def _findings_for(bugs: list[dict], *, correct_class: bool = True) -> list[dict]:
+    out = []
+    for b in bugs:
+        title = _CLASS_TITLE[b["class"]] if correct_class else "something unrelated"
+        out.append(_finding(b["file"], b["line"], title))
+    return out
+
+
+class TestGroundTruth:
+    def test_fixtures_have_expected_markers(self):
+        bugs = si.expected_bugs()
+        assert len(bugs) >= 12  # 6 classes represented
+        assert {b["class"] for b in bugs} == set(si.CLASSES)
+
+
+class TestScoring:
+    def test_full_recall_zero_fp(self):
+        bugs = si.expected_bugs()
+        r = si.score(_findings_for(bugs))
+        assert r["recall"]["found"] == r["recall"]["total"] == len(bugs)
+        assert r["false_positives"]["count"] == 0
+        assert r["gaps"] == []
+        assert r["class_mismatches"] == []
+
+    @pytest.mark.parametrize("delta,should_match", [(1, True), (-1, True), (2, False), (-2, False)])
+    def test_line_tolerance_boundaries(self, delta, should_match):
+        """±1 line counts (statement head); ±2 does not."""
+        bugs = si.expected_bugs()
+        shifted = _findings_for(bugs)
+        for f in shifted:
+            f["code_location"]["line_number"] += delta
+        r = si.score(shifted)
+        assert (r["recall"]["found"] == len(bugs)) is should_match
+
+    def test_duplicate_finding_on_real_bug_is_not_fp(self):
+        """Real Semgrep double-reports a sink (taint + pattern) — must NOT be an FP."""
+        bugs = si.expected_bugs()
+        findings = _findings_for(bugs)
+        dup = dict(findings[0])  # a second finding on the same real bug line
+        r = si.score(findings + [dup])
+        assert r["recall"]["found"] == len(bugs)
+        assert r["false_positives"]["count"] == 0  # the duplicate is not a false alarm
+
+    def test_one_finding_credits_at_most_one_bug(self):
+        """Two distinct bugs can't both be credited to a single finding (1:1)."""
+        two = [{"file": "x.ts", "line": 10, "class": "sqli"},
+               {"file": "x.ts", "line": 11, "class": "sqli"}]
+        # monkeypatch expected_bugs to return two closely-spaced bugs
+        one_finding = [_finding("x.ts", 10, _CLASS_TITLE["sqli"])]
+        orig = si.expected_bugs
+        si.expected_bugs = lambda: two
+        try:
+            r = si.score(one_finding)
+        finally:
+            si.expected_bugs = orig
+        assert r["recall"]["found"] == 1  # not 2
+        assert r["false_positives"]["count"] == 0
+
+    def test_missing_finding_is_a_gap(self):
+        bugs = si.expected_bugs()
+        r = si.score(_findings_for(bugs[1:]))  # drop one
+        assert r["recall"]["found"] == len(bugs) - 1
+        assert len(r["gaps"]) == 1
+        assert r["gaps"][0]["file"] == bugs[0]["file"]
+
+    def test_finding_on_safe_file_is_false_positive(self):
+        bugs = si.expected_bugs()
+        findings = _findings_for(bugs)
+        findings.append({
+            "category": "injection_risk",
+            "scanner_name": "semgrep_taint",
+            "title": "User input flows into a raw SQL query",
+            "code_location": {"file_path": "safe/benign.ts", "line_number": 12},
+        })
+        r = si.score(findings)
+        assert r["false_positives"]["count"] == 1
+        assert r["false_positives"]["items"][0]["file"] == "benign.ts"
+
+    def test_unmarked_line_in_vulnerable_file_is_fp(self):
+        bugs = si.expected_bugs()
+        findings = _findings_for(bugs)
+        findings.append(_finding("sqli.ts", 999, "User input flows into a raw SQL query"))
+        r = si.score(findings)
+        assert r["false_positives"]["count"] == 1
+
+    def test_non_injection_findings_ignored(self):
+        bugs = si.expected_bugs()
+        findings = _findings_for(bugs)
+        findings.append({
+            "category": "missing_headers",
+            "scanner_name": "security_headers",
+            "title": "Missing CSP",
+            "code_location": {"file_path": "safe/benign.ts", "line_number": 1},
+        })
+        r = si.score(findings)
+        assert r["false_positives"]["count"] == 0  # not an injection finding
+
+    def test_detected_but_wrong_class_still_recalled(self):
+        bugs = si.expected_bugs()
+        r = si.score(_findings_for(bugs, correct_class=False))
+        assert r["recall"]["found"] == len(bugs)  # recall by location
+        assert len(r["class_mismatches"]) == len(bugs)  # but class label is off
+
+
+class TestHelpers:
+    @pytest.mark.parametrize("title,expected", [
+        ("User input flows into a raw SQL query", "sqli"),
+        ("User input reflected into an HTML response", "reflected-xss"),
+        ("User-controlled input flows into the DOM (innerHTML)", "dom-xss"),
+        ("User-controlled URL flows into an outbound request", "ssrf"),
+        ("Filesystem write using a request-derived filename", "path-traversal"),
+        ("User input flows into a shell command", "command-injection"),
+        ("something else entirely", "?"),
+        # regression: bare "dom" substring must NOT swallow these
+        ("User-controlled URL flows to an external domain (SSRF)", "ssrf"),
+        ("Tainted random value used in a raw SQL query", "sqli"),
+    ])
+    def test_finding_class_inference(self, title, expected):
+        assert si.finding_class({"title": title}) == expected
+
+    def test_finding_loc_nested_and_flat(self):
+        nested = {"code_location": {"file_path": "a/b/x.ts", "line_number": 5}}
+        assert si.finding_loc(nested) == ("x.ts", 5)
+        assert si.finding_loc({"file_path": "y.ts", "line_number": 9}) == ("y.ts", 9)
+
+    def test_is_injection(self):
+        assert si.is_injection({"category": "injection_risk"})
+        assert si.is_injection({"scanner_name": "semgrep_taint"})
+        assert not si.is_injection({"category": "missing_headers", "scanner_name": "x"})
+
+    def test_passed_gate(self):
+        assert si.passed({"recall": {"found": 12, "total": 12},
+                          "false_positives": {"count": 0}})
+        assert not si.passed({"recall": {"found": 11, "total": 12},
+                              "false_positives": {"count": 0}})
+        assert not si.passed({"recall": {"found": 12, "total": 12},
+                              "false_positives": {"count": 1}})
+
+
+class TestRunBenchmarksWiring:
+    """The sast-injection pseudo-target dispatch in run_benchmarks.resolve_selection."""
+
+    @pytest.fixture(autouse=True)
+    def _import(self):
+        import run_benchmarks as rb  # noqa: E402
+        self.rb = rb
+
+    def test_default_runs_vampi_plus_sast(self):
+        docker, want_sast, unknown = self.rb.resolve_selection([], all_flag=False)
+        assert want_sast is True
+        assert set(docker) == {"vampi-vulnerable", "vampi-secure"}
+        assert unknown == []
+
+    def test_sast_only(self):
+        docker, want_sast, unknown = self.rb.resolve_selection(["sast-injection"], all_flag=False)
+        assert docker == [] and want_sast is True and unknown == []
+
+    def test_docker_target_only_skips_sast(self):
+        docker, want_sast, unknown = self.rb.resolve_selection(["juiceshop"], all_flag=False)
+        assert docker == ["juiceshop"] and want_sast is False
+
+    def test_mixed_docker_and_sast(self):
+        docker, want_sast, unknown = self.rb.resolve_selection(
+            ["juiceshop", "sast-injection"], all_flag=False)
+        assert docker == ["juiceshop"] and want_sast is True
+
+    def test_all_flag_includes_sast(self):
+        docker, want_sast, unknown = self.rb.resolve_selection([], all_flag=True)
+        assert want_sast is True and len(docker) == len(self.rb.TARGETS)
+
+    def test_unknown_target_reported(self):
+        docker, want_sast, unknown = self.rb.resolve_selection(["nope"], all_flag=False)
+        assert unknown == ["nope"] and docker == []


### PR DESCRIPTION
Closes #92. Adds the committed, code-only recall/FP scorecard for the Semgrep taint layer (#4) — the deterministic gate the ad-hoc measurement in #4 lacked, and the gate for future rule packs (#93/#94).

## What's in it
- **`benchmarks/fixtures/sast-injection/`** — an *independent* JS/TS injection fixture (not `test-app`, which the rules were tuned on). Vulnerable cases across all six classes carry `// EXPECT <class>` markers (self-documenting ground truth); `safe/` holds benign near-misses (parameterized queries, constant-path writes, non-DB `.query()`, escaped output, fixed-URL fetch) for the FP side.
- **`benchmarks/sast_injection.py`** — runs a code-only scan and scores recall + FP. 1:1 finding↔bug matching (±1 line); a finding near a real bug is never an FP (real Semgrep double-reports a sink via taint + pattern rules); skips gracefully when the `semgrep` binary is absent.
- **`benchmarks/run_benchmarks.py`** — `sast-injection` wired as a non-Docker pseudo-target (in the default set; exits non-zero on any miss/FP).
- **`tests/benchmarks/`** — 31 pure-logic tests (no scan/semgrep dependency).

## Baseline
**12/12 recall, 0 false positives** across all six classes, deterministic:

| Class | Found/Exp | Class | Found/Exp |
|---|--:|---|--:|
| sqli | 5/5 | ssrf | 1/1 |
| reflected-xss | 2/2 | path-traversal | 1/1 |
| dom-xss | 2/2 | command-injection | 1/1 |

## Adversarial review → fixed
Code review found a **real MAJOR bug**: duplicate findings on a genuine bug line were counted as FPs → the gate would FAIL on legitimate Semgrep double-reporting (sink + taint on one line). Fixed with proper 1:1 matching + "FP = not near *any* expected bug". Also fixed non-1:1 double-credit, the `dom` substring collision in class inference, added graceful semgrep-absent skip, temp-file cleanup, and a shared pass gate. Doc review's required updates (top-level README "requires Docker" claim, taint-analysis phasing) applied.

## Verification
31/31 benchmark tests pass; ruff clean; `python benchmarks/run_benchmarks.py sast-injection` → 12/12, 0 FP, exit 0.

Committed as `test:` so it doesn't force a version bump (pure benchmark/test tooling).

🤖 Generated with [Claude Code](https://claude.com/claude-code)