### PR TITLE
feat(sast): Python taint/injection rule pack for the Semgrep layer (#93)

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -8,6 +8,10 @@ name: "isitsecure CodeQL config"
 #              not runtime sanitization.
 #   test-app/  An INTENTIONALLY vulnerable sample app (old next/jsonwebtoken/etc.)
 #              used as input to exercise the scanner. It is supposed to be insecure.
+#   benchmarks/fixtures/
+#              INTENTIONALLY vulnerable SAST-injection fixtures (the taint
+#              benchmark's ground truth — planted SQLi/cmdi/SSRF/etc.). They are
+#              supposed to be insecure; flagging them is noise, not a finding.
 #   ui/        A Next.js STATIC EXPORT (`output: "export"`, images.unoptimized),
 #              served as plain files by the localhost-bound FastAPI launch server
 #              (`isitsecure launch` binds 127.0.0.1; CORS restricted to localhost).
@@ -25,4 +29,5 @@ name: "isitsecure CodeQL config"
 paths-ignore:
   - tests
   - test-app
+  - benchmarks/fixtures
   - ui

--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ The scan narrates each phase and every scanner as it runs (with elapsed time), s
 
 | Scanner | What It Finds |
 |---|---|
-| Semgrep Taint Analyzer | Deterministic source→sink injection for JS/TS — SQLi, reflected/DOM XSS, SSRF, path traversal, command injection (a reproducible floor beneath the LLM reviewer; needs the `[taint]` extra, no-ops without the `semgrep` binary) |
+| Semgrep Taint Analyzer | Deterministic source→sink injection for JS/TS and Python — SQLi, XSS, SSRF, path traversal, command injection, SSTI (a reproducible floor beneath the LLM reviewer; needs the `[taint]` extra, no-ops without the `semgrep` binary) |
 | Git Secret Scanner | API keys, tokens, and credentials in git history (not just HEAD) |
 | Route Auth Analyzer | Next.js/Express/Django/FastAPI/Spring routes missing authentication |
 | RLS Policy Analyzer | Supabase tables without Row Level Security enabled |
@@ -390,7 +390,7 @@ isitsecure works well alongside other tools. Run `isitsecure scan` for the combi
 
 ## What It Does NOT Cover
 
-- **Inter-procedural taint analysis** — The opt-in Semgrep taint layer (`[taint]`) does intra-file source→sink dataflow for JS/TS injection; cross-function/cross-file tracking (Semgrep Pro territory) still falls back to LLM reasoning
+- **Inter-procedural taint analysis** — The opt-in Semgrep taint layer (`[taint]`) does intra-file source→sink dataflow for JS/TS and Python injection; cross-function/cross-file tracking (Semgrep Pro territory) still falls back to LLM reasoning
 - **WAF evasion** — DAST payloads don't include advanced bypass techniques
 - **Compliance mapping** — No OWASP Top 10, CWE, or PCI-DSS tagging (yet)
 - **Network-level scanning** — No port scanning, TLS analysis, or infrastructure enumeration
@@ -624,7 +624,7 @@ python benchmarks/run_benchmarks.py sast-injection  # taint recall/FP (code-only
 python benchmarks/run_benchmarks.py --all       # + NodeGoat + crAPI + Juice Shop (heavy)
 ```
 
-Most targets spin the app up in Docker, run a DAST scan, score against a known ground truth, and tear it down (require Docker). The `sast-injection` target is **code-only** (no Docker) — it scores the deterministic Semgrep taint layer on a JS/TS injection fixture (**12/12 recall, 0 FP**) and needs the `semgrep` binary instead; it's included in the default run. Measured results are tracked in [benchmarks/RESULTS.md](benchmarks/RESULTS.md); see [benchmarks/README.md](benchmarks/README.md) for targets and how scoring works.
+Most targets spin the app up in Docker, run a DAST scan, score against a known ground truth, and tear it down (require Docker). The `sast-injection` target is **code-only** (no Docker) — it scores the deterministic Semgrep taint layer on a JS/TS + Python injection fixture (**27/27 recall, 0 FP**) and needs the `semgrep` binary instead; it's included in the default run. Measured results are tracked in [benchmarks/RESULTS.md](benchmarks/RESULTS.md); see [benchmarks/README.md](benchmarks/README.md) for targets and how scoring works.
 
 ## Privacy
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -83,20 +83,24 @@ python benchmarks/sast_injection.py findings.json    # score an existing code-on
 
 The fixtures **are** the ground truth (no separate file to drift):
 
-- `fixtures/sast-injection/vulnerable/*` — each line tagged `// EXPECT <class>`
-  (`sqli | reflected-xss | dom-xss | ssrf | path-traversal | command-injection`)
-  is a bug the taint layer must flag (recall).
-- `fixtures/sast-injection/safe/*` — benign near-misses (parameterized queries,
-  constant-path writes, non-DB `.query()`, escaped output, fixed-URL fetch). Any
-  injection finding here — or on an unmarked line in a vulnerable file — is a
-  **false positive**.
+- `fixtures/sast-injection/vulnerable/*` — each sink line tagged with a trailing
+  `EXPECT <class>` marker (`//` for JS/TS, `#` for Python; classes: `sqli |
+  reflected-xss | dom-xss | ssrf | path-traversal | command-injection | ssti`)
+  is a bug the taint layer must flag (recall). Covers **JS/TS (#4)** and
+  **Python (#93)**.
+- `fixtures/sast-injection/safe/*` — benign near-misses. JS: parameterized
+  queries, constant-path writes, non-DB `.query()`, escaped output, fixed-URL
+  fetch. Python: bound/parameterized queries (including request-derived values in
+  the params tuple), a bare `text()` i18n alias, `subprocess` without
+  `shell=True`, constant-path `open()`, fixed-URL requests. Any injection finding
+  here — or on an unmarked line in a vulnerable file — is a **false positive**.
 
 The scorer (`sast_injection.py`) matches findings to expected bugs by file and
 line (±1, since Semgrep can report the statement head), reports per-class recall,
 and **exits non-zero unless recall is 100% and FP is 0**. It needs the `semgrep`
 binary; scoring an existing `findings.json` needs neither Docker nor semgrep.
-This is an *independent* fixture (not `test-app`, which the rules were tuned on),
-so it's a genuine second data point.
+This is an *independent* fixture (not `test-app`, which the JS rules were tuned
+on), so it's a genuine second data point.
 
 ## Authenticated cross-user IDOR (BOLA)
 

--- a/benchmarks/RESULTS.md
+++ b/benchmarks/RESULTS.md
@@ -18,24 +18,30 @@ _Runs: 2026-07 · `--llm none` (pure DAST detection, no LLM) · Juice Shop pinne
 | `vampi-vulnerable` | url-only | **3/3** (SQLi, IDOR, headers) | — | 14–16 |
 | `vampi-secure` | url-only | — | **2** (IDOR) | 13–15 |
 | `nodegoat-auth` | authenticated | **2/3** (headers, XSS; injection missed) | unmeasured | 28 |
-| `sast-injection` | code-only | **12/12 (100%)** — taint, per-class, deterministic | **0** | 12 |
+| `sast-injection` | code-only | **27/27 (100%)** — taint, per-class, deterministic | **0** | 27 |
 
-### SAST injection (`sast-injection`, code-only, taint layer #4)
+### SAST injection (`sast-injection`, code-only, taint layer #4 + #93)
 
-The deterministic Semgrep taint layer scored on an independent JS/TS injection
-fixture (not `test-app`, which the rules were tuned on). Recall **12/12** with
-**0 false positives** across all six classes, deterministic across runs:
+The deterministic Semgrep taint layer scored on an independent injection fixture
+(not `test-app`, which the JS rules were tuned on) covering **JS/TS (#4)** and
+**Python (#93)**. Recall **27/27** with **0 false positives** across all classes,
+deterministic across runs:
 
-| Class | Found / expected | Class | Found / expected |
-|---|--:|---|--:|
-| sqli | **5/5** | ssrf | **1/1** |
-| reflected-xss | **2/2** | path-traversal | **1/1** |
-| dom-xss | **2/2** | command-injection | **1/1** |
+| Class | JS/TS | Python | Class | JS/TS | Python |
+|---|--:|--:|---|--:|--:|
+| sqli | 5/5 | 7/7 | path-traversal | 1/1 | 2/2 |
+| reflected-xss | 2/2 | — | command-injection | 1/1 | 3/3 |
+| dom-xss | 2/2 | — | ssti | — | 1/1 |
+| ssrf | 1/1 | 2/2 | | | |
 
-The FP side is exercised by benign near-misses (parameterized queries,
-constant-path writes, non-DB `.query()`, escaped output, fixed-URL fetch) — none
-flagged. This is the baseline the taint layer and future rule packs (#93/#94)
-must hold.
+The FP side is exercised by benign near-misses in both languages — parameterized
+queries, constant-path writes, non-DB `.query()`, escaped output, fixed-URL
+fetch (JS); parameterized/bound queries (including request-derived values in the
+params tuple), a bare `text()` i18n alias, `subprocess` without `shell=True`,
+constant-path `open()`, fixed-URL requests (Python) — none flagged. Cross-checked
+against isitsecure's own 164 Python files (which contain real `subprocess`,
+`requests`/`httpx`, and `open()` call sites): **0 false positives**. This is the
+baseline the taint layer and future rule packs (#94) must hold.
 
 > Juice Shop recall is scored **per challenge** — a finding must match the class
 > signature AND land on the right endpoint — over the 45 DAST-detectable

--- a/benchmarks/fixtures/sast-injection/safe/python_benign.py
+++ b/benchmarks/fixtures/sast-injection/safe/python_benign.py
@@ -1,0 +1,55 @@
+# Injection benchmark fixture — Python SAFE / benign near-misses.
+# NOTHING here may be flagged — this is the false-positive side for Python.
+
+import os
+import subprocess
+
+import requests
+from flask import request
+from sqlalchemy import text
+
+
+# SAFE: parameterized queries (placeholders + params, not string-built)
+def get_user(db, uid):
+    db.execute("SELECT * FROM users WHERE id = ?", (uid,))
+    db.execute("SELECT * FROM users WHERE id = %s", (uid,))
+
+
+# SAFE: parameterized even though the value comes from the request — the taint
+# rule focuses on the query string, so a value in the params tuple is fine.
+def param_from_request(db):
+    uid = request.args.get("id")
+    db.execute("SELECT * FROM users WHERE id = ?", (uid,))
+
+
+# SAFE: a bare text() call (e.g. an i18n gettext alias) is not a SQL sink —
+# only text(...) passed into execute() is flagged.
+def label(name):
+    return text(f"Hello {name}")
+
+
+# SAFE: SQLAlchemy with bound parameters
+def sa_query(conn, uid):
+    return conn.execute(text("SELECT * FROM users WHERE id = :id"), {"id": uid})
+
+
+# SAFE: subprocess WITHOUT shell=True (argv list — no shell parsing)
+def run_cmd():
+    name = request.args.get("name")
+    subprocess.run(["ls", "-la", name])
+
+
+# SAFE: constant-path file open (not user-derived)
+def read_config():
+    with open("/etc/app/config.yaml") as f:
+        return f.read()
+
+
+# SAFE: request to a fixed, non-user-controlled URL
+def health():
+    return requests.get("https://api.internal.example.com/health")
+
+
+# SAFE: user input used as a query PARAMETER via join, not shelled/executed
+def build_path(base):
+    return os.path.join(base, "static", "logo.png")

--- a/benchmarks/fixtures/sast-injection/vulnerable/python_injection.py
+++ b/benchmarks/fixtures/sast-injection/vulnerable/python_injection.py
@@ -1,0 +1,54 @@
+# Injection benchmark fixture — Python command injection, SSRF, path traversal,
+# and SSTI (VULNERABLE). Sources: Flask/Django request objects.
+
+import os
+import subprocess
+import urllib.request
+
+import requests
+from flask import render_template_string, request
+
+
+# --- Command injection ---
+def ping():
+    host = request.args.get("host")
+    os.system(f"ping -c 1 {host}")  # EXPECT command-injection
+
+
+def run_cmd():
+    cmd = request.args.get("cmd")
+    subprocess.run(cmd, shell=True)  # EXPECT command-injection
+
+
+def list_dir():
+    path = request.args.get("path")
+    os.popen("ls " + path)  # EXPECT command-injection
+
+
+# --- SSRF ---
+def proxy():
+    url = request.args.get("url")
+    return requests.get(url)  # EXPECT ssrf
+
+
+def fetch():
+    url = request.args.get("url")
+    return urllib.request.urlopen(url)  # EXPECT ssrf
+
+
+# --- Path traversal ---
+def read_file():
+    name = request.args.get("file")
+    with open(name) as f:  # EXPECT path-traversal
+        return f.read()
+
+
+def read_joined():
+    name = request.args.get("file")
+    return open(os.path.join("/data", name)).read()  # EXPECT path-traversal
+
+
+# --- Server-side template injection ---
+def render():
+    tmpl = request.args.get("template")
+    return render_template_string(tmpl)  # EXPECT ssti

--- a/benchmarks/fixtures/sast-injection/vulnerable/python_sqli.py
+++ b/benchmarks/fixtures/sast-injection/vulnerable/python_sqli.py
@@ -1,0 +1,41 @@
+# Injection benchmark fixture — Python SQL injection (VULNERABLE).
+# Each trailing marker on a sink line is a bug the taint layer must flag.
+# Stack shapes: raw DB-API cursor.execute, SQLAlchemy text(), Django raw/extra.
+
+from flask import request
+from sqlalchemy import text
+
+from .models import User
+
+
+def get_user(db, uid):
+    cur = db.cursor()
+    cur.execute(f"SELECT * FROM users WHERE id = {uid}")  # EXPECT sqli
+
+
+def search(db):
+    term = request.args.get("q")
+    db.execute("SELECT * FROM items WHERE name = '%s'" % term)  # EXPECT sqli
+
+
+def by_name(db, name):
+    db.execute("SELECT * FROM users WHERE name = " + name)  # EXPECT sqli
+
+
+def sqlalchemy_raw(conn, uid):
+    return conn.execute(text(f"SELECT * FROM users WHERE id = {uid}"))  # EXPECT sqli
+
+
+def django_raw():
+    uid = request.GET.get("id")
+    return User.objects.raw(f"SELECT * FROM users WHERE id = {uid}")  # EXPECT sqli
+
+
+def assign_then_execute(db):
+    uid = request.args.get("id")
+    query = f"SELECT * FROM users WHERE id = {uid}"  # built on one line...
+    db.execute(query)  # EXPECT sqli  ...executed on the next (taint, not inline)
+
+
+def format_query(db, name):
+    db.execute("SELECT * FROM users WHERE name = '{}'".format(name))  # EXPECT sqli

--- a/benchmarks/sast_injection.py
+++ b/benchmarks/sast_injection.py
@@ -33,8 +33,9 @@ import tempfile
 from collections import defaultdict
 
 FIXTURES = pathlib.Path(__file__).parent / "fixtures" / "sast-injection"
-EXPECT_RE = re.compile(r"//\s*EXPECT\s+([a-z-]+)")
-CLASSES = ("sqli", "reflected-xss", "dom-xss", "ssrf", "path-traversal", "command-injection")
+EXPECT_RE = re.compile(r"(?://|#)\s*EXPECT\s+([a-z-]+)")  # // (JS/TS) or # (Python)
+CLASSES = ("sqli", "reflected-xss", "dom-xss", "ssrf", "path-traversal",
+           "command-injection", "ssti")
 
 # Injection finding → vuln class, inferred from the title (findings are all
 # category injection_risk). Cues are DISTINCTIVE phrases, not bare substrings, so
@@ -42,20 +43,28 @@ CLASSES = ("sqli", "reflected-xss", "dom-xss", "ssrf", "path-traversal", "comman
 _TITLE_CUES = [
     ("dom-xss", ("into the dom", "innerhtml", "document.write", "dom xss")),
     ("reflected-xss", ("reflected", "html response")),
+    ("ssti", ("template injection", "ssti", "server-side template")),
     ("ssrf", ("outbound request", "ssrf")),
-    ("path-traversal", ("filesystem write", "path traversal", "request-derived filename")),
+    ("path-traversal", ("filesystem write", "path traversal", "request-derived")),
     ("command-injection", ("shell command", "command injection")),
     ("sqli", ("sql",)),
 ]
 
 
 def expected_bugs() -> list[dict]:
-    """Parse ``// EXPECT <class>`` markers out of the vulnerable fixtures."""
+    """Parse trailing ``EXPECT <class>`` markers out of the vulnerable fixtures.
+
+    Only *trailing* markers (code, then a comment) count as ground truth. A marker
+    inside a standalone/descriptive comment line (one that starts with ``//`` or
+    ``#``) is ignored, so prose mentioning "EXPECT" can't inflate the count.
+    """
     bugs = []
     for f in sorted((FIXTURES / "vulnerable").rglob("*")):
         if not f.is_file():
             continue
         for i, line in enumerate(f.read_text().splitlines(), start=1):
+            if line.lstrip().startswith(("//", "#")):
+                continue  # descriptive comment line, not a code+marker line
             m = EXPECT_RE.search(line)
             if m:
                 bugs.append({"file": f.name, "line": i, "class": m.group(1)})

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -99,7 +99,7 @@ The repository is cloned (shallow, to temp dir) and indexed:
    - `GraphQLRouteMapper`: schema definitions → query/mutation types
 4. **File indexing** — reads all source files into memory (filtered by extension, size limit, skip `node_modules`)
 
-18 SAST scanners then run in parallel against the indexed codebase (plus the LLM-powered Semantic Rule Verifier when an API key is available). One of them, the **Semgrep Taint Analyzer** (`semgrep_taint`), is a deterministic source→sink injection floor for JS/TS that sits beneath the LLM code reviewer: it catches the mechanical SQLi/XSS/SSRF/path-traversal/command-injection cases reproducibly and for free, leaving the LLM to cover business logic and uncatalogued libraries. It is opt-in (`[taint]` extra) and no-ops if the `semgrep` binary is absent.
+18 SAST scanners then run in parallel against the indexed codebase (plus the LLM-powered Semantic Rule Verifier when an API key is available). One of them, the **Semgrep Taint Analyzer** (`semgrep_taint`), is a deterministic source→sink injection floor for JS/TS and Python that sits beneath the LLM code reviewer: it catches the mechanical SQLi/XSS/SSRF/path-traversal/command-injection/SSTI cases reproducibly and for free, leaving the LLM to cover business logic and uncatalogued libraries. It is opt-in (`[taint]` extra) and no-ops if the `semgrep` binary is absent.
 
 ### Phase 7.5: LSP Validation
 

--- a/docs/scanners/semgrep-taint.md
+++ b/docs/scanners/semgrep-taint.md
@@ -6,7 +6,9 @@
 
 Runs [Semgrep](https://semgrep.dev) with isitsecure's own taint/sink rule packs over your cloned repo and maps the results to findings. It is a **deterministic injection floor beneath the LLM code reviewer**: the same input always produces the same findings, instantly and at no token cost.
 
-The current rule pack (`semgrep_rules/injection-js.yaml`) targets **JavaScript/TypeScript** and covers five injection classes:
+Two rule packs ship today — **JavaScript/TypeScript** (`semgrep_rules/injection-js.yaml`, #4) and **Python** (`semgrep_rules/injection-python.yaml`, #93). Semgrep applies each rule only to its declared language, so a repo of either (or both) is covered.
+
+**JavaScript/TypeScript** — six classes:
 
 1. **SQL injection** — raw-query sinks (`sql.unsafe`, Prisma `$queryRawUnsafe`/`$executeRawUnsafe`, `knex.raw`, Drizzle `sql.raw`) and user-input → raw-query taint flows.
 2. **Reflected XSS** — request data flowing into an HTML response (`new Response(html)`, `res.send`, `res.write`) without escaping.
@@ -15,7 +17,15 @@ The current rule pack (`semgrep_rules/injection-js.yaml`) targets **JavaScript/T
 5. **Path traversal / unrestricted upload** — request-derived filenames flowing into `fs.writeFile`/`createWriteStream` via `path.join` (constant paths are excluded).
 6. **Command injection** — user input flowing into `exec`/`spawn`.
 
-Rules target **framework/library APIs** (Next.js `searchParams`, Express `req.*`, the `postgres`/Prisma/Drizzle/Knex sinks, Node `fs`), so they apply to **any app on those stacks — not per-app**. Apps on an uncatalogued library fall through to the LLM backstop.
+**Python** (Flask/Django request sources) — five classes:
+
+1. **SQL injection** — string-built queries in `cursor.execute`/`executemany` (f-string/`%`/`.format`/concat), SQLAlchemy `execute(text(f"…"))`, Django `.objects.raw(…)`, plus a taint rule for the build-then-execute shape. Parameterized queries are never flagged — the taint sink focuses on the query-string argument, so a request value in the `params` tuple is safe.
+2. **Command injection** — request input → `os.system`/`os.popen`/`subprocess(..., shell=True)`.
+3. **SSRF** — request input → `requests`/`httpx`/`urllib.request.urlopen`.
+4. **Path traversal** — request-derived path → `open(...)`.
+5. **SSTI** — request input → `render_template_string(...)`.
+
+Rules target **framework/library APIs** (Next.js `searchParams`, Express `req.*`, the `postgres`/Prisma/Drizzle/Knex sinks, Node `fs`; Flask/Django `request.*`, DB-API/SQLAlchemy/Django ORM, `os`/`subprocess`, `requests`/`urllib`, Jinja), so they apply to **any app on those stacks — not per-app**. Apps on an uncatalogued library fall through to the LLM backstop.
 
 Findings are emitted with `scanner_name = "semgrep_taint"`, `confidence = 0.85`, and category `injection_risk`, then flow through the same triage → dedup → plain-English → grading pipeline as every other scanner.
 
@@ -31,14 +41,14 @@ It is **best-effort and self-contained**:
 
 - If the `semgrep` binary isn't installed, the analyzer **no-ops and returns nothing** — the LLM layer still runs, exactly as before.
 - A crash or timeout in Semgrep **never fails the scan**; it logs and returns no findings. The subprocess is always killed and reaped (never orphaned), even if the overall scan is cancelled.
-- It only runs when the repo contains JS/TS files.
+- It only runs when the repo contains JS/TS or Python files.
 - No network: the rule packs ship with isitsecure; Semgrep runs with `--metrics off`.
 
 ## Why It Matters
 
 Before this analyzer, injection detection (SQLi/XSS/SSRF/path-traversal/command-injection) rested **entirely on the LLM**, which is non-deterministic (finding counts wobble run-to-run), costs tokens, and is slow. The Semgrep layer gives a reproducible, instant, free floor for the mechanical source→sink cases, while the LLM keeps covering business-logic flaws and the long tail of libraries without rules.
 
-See [docs/taint-analysis.md](../taint-analysis.md) for the full design rationale, the spike results, and the per-stack rule model. The layer has its own recall/FP scorecard — **12/12 recall, 0 false positives** on an independent JS/TS injection fixture — via `python benchmarks/run_benchmarks.py sast-injection` (see [benchmarks/RESULTS.md](../../benchmarks/RESULTS.md)).
+See [docs/taint-analysis.md](../taint-analysis.md) for the full design rationale, the spike results, and the per-stack rule model. The layer has its own recall/FP scorecard — **27/27 recall, 0 false positives** on an independent JS/TS + Python injection fixture — via `python benchmarks/run_benchmarks.py sast-injection` (see [benchmarks/RESULTS.md](../../benchmarks/RESULTS.md)).
 
 ## What Vulnerable Code Looks Like
 
@@ -60,7 +70,8 @@ const rows = await sql`SELECT * FROM users WHERE id = ${id}`;
 ## Limitations
 
 - **Intra-file only.** OSS Semgrep taint tracks dataflow within a single file. A route that hands user input to a helper in another file which then reaches a sink (inter-procedural) is not tracked — that path falls back to the LLM reviewer. (Inter-file taint is Semgrep Pro territory.)
-- **JS/TS today.** Python and other stacks are future rule-pack work; those apps rely on the LLM layer meanwhile.
+- **JS/TS and Python today.** Other stacks (Go, Ruby, Java, …) are future rule-pack work; those apps rely on the LLM layer meanwhile. Python reflected/stored XSS (template-autoescaping nuance) is also not yet covered.
+- **Python taint sources are Flask/Django** (`request.*`). FastAPI endpoint parameters aren't yet tracked as sources, so FastAPI command-injection/SSRF/path/SSTI fall to the LLM layer — though string-built SQL (the pattern rule) is still caught on any stack.
 - **Per-stack rules.** Sinks for libraries we haven't catalogued won't fire deterministically (again, the LLM backstops them).
 
 ## Configuration

--- a/docs/taint-analysis.md
+++ b/docs/taint-analysis.md
@@ -163,7 +163,7 @@ Note: the original benchmark was DAST-oriented, so this work added a **SAST
 injection benchmark** — a fixture set with known source→sink bugs giving the taint
 layer its own recall/FP scorecard. **Delivered** (#92): `benchmarks/sast_injection.py`
 + `benchmarks/fixtures/sast-injection/`, run via `python benchmarks/run_benchmarks.py
-sast-injection`. Baseline **12/12 recall, 0 FP** ([benchmarks/RESULTS.md](../benchmarks/RESULTS.md)).
+sast-injection`. Baseline **27/27 recall, 0 FP** across JS/TS + Python ([benchmarks/RESULTS.md](../benchmarks/RESULTS.md)).
 
 ## Risks & open questions
 
@@ -174,15 +174,18 @@ sast-injection`. Baseline **12/12 recall, 0 FP** ([benchmarks/RESULTS.md](../ben
 - **Binary dependency** — bundling/pinning Semgrep; graceful fallback when absent.
 - **Semgrep licensing** — OSS engine + our own rules are fine; confirm no
   reliance on registry rules with restrictive terms (we ship our own packs).
-- **Language coverage** — start JS/TS (largest vibe-coder surface), then Python.
+- **Language coverage** — JS/TS (#4) and Python/Flask/Django (#93) ship today;
+  other stacks (Go, Ruby, Java) are future packs.
 
 ## Phasing
 
 1. ✅ **SAST injection benchmark fixtures** + a recall/FP harness (#92) — the
-   `sast-injection` target, baseline 12/12 recall / 0 FP.
+   `sast-injection` target, baseline 27/27 recall / 0 FP (JS/TS + Python).
 2. ✅ **`SemgrepAnalyzer`** (subprocess → parse → `CodeFinding`) with a first rule
    pack for the top stack (Next.js/Express + postgres/Prisma/Drizzle + DOM) — #4.
 3. ✅ **Benchmark**: proved it adds recall without FP vs. LLM-only. Shipped in #4.
-4. **Broaden rule packs** (FastAPI/Flask/Django, more libraries) iteratively, each
-   gated by the benchmark — tracked in #93.
+4. 🚧 **Broaden rule packs** iteratively, each gated by the benchmark — #93 adds
+   the **Python** pack (Flask/Django sources; DB-API/SQLAlchemy/Django ORM, os/
+   subprocess, requests/urllib, Jinja sinks; SQLi/cmdi/SSRF/path/SSTI). Further
+   stacks/libraries continue here.
 5. **Keep the LLM layer** as the long-tail + business-logic backstop throughout.

--- a/isitsecure/engine/code_analysis/semgrep_analyzer.py
+++ b/isitsecure/engine/code_analysis/semgrep_analyzer.py
@@ -30,7 +30,9 @@ from isitsecure.engine.enums import FindingCategory, SeverityLevel
 logger = logging.getLogger(__name__)
 
 _RULES_DIR = Path(__file__).parent / "semgrep_rules"
-_JS_TS_EXT = (".js", ".jsx", ".ts", ".tsx", ".mjs", ".cjs")
+# Extensions the shipped rule packs cover (JS/TS #4, Python #93). Semgrep applies
+# each rule only to its declared language, so running the whole rules dir is safe.
+_SUPPORTED_EXT = (".js", ".jsx", ".ts", ".tsx", ".mjs", ".cjs", ".py")
 _SCAN_TIMEOUT_S = 120.0
 
 _SEVERITY_MAP = {
@@ -83,8 +85,8 @@ class SemgrepAnalyzer:
         return shutil.which("semgrep")
 
     def _has_supported_files(self, repo: RepoSnapshot) -> bool:
-        """Only run when there are JS/TS files (the current rule packs' scope)."""
-        return any(p.endswith(_JS_TS_EXT) for p in repo.file_index)
+        """Only run when there are files a rule pack covers (JS/TS or Python)."""
+        return any(p.endswith(_SUPPORTED_EXT) for p in repo.file_index)
 
     async def _run_semgrep(self, semgrep: str, clone_path: str) -> dict | None:
         cmd = [

--- a/isitsecure/engine/code_analysis/semgrep_rules/injection-python.yaml
+++ b/isitsecure/engine/code_analysis/semgrep_rules/injection-python.yaml
@@ -1,0 +1,110 @@
+# isitsecure taint/sink rules for Python injection (#93).
+# Rules target FRAMEWORK/LIBRARY APIs (Flask/Django request objects as sources;
+# DB-API/SQLAlchemy/Django ORM, os/subprocess, requests/urllib, Jinja as sinks) —
+# they apply to any app on these stacks, not to a specific app.
+rules:
+  # ---- SQL injection: dangerous query construction (pattern) ----
+  # Pattern-based (not taint) so parameterized queries — execute(sql, params) —
+  # are never flagged; only string-built queries match. `text(...)` is scoped to
+  # inside execute() so it can't false-positive on a bare `text()` (e.g. an i18n
+  # gettext alias).
+  - id: isitsecure-py-sqli
+    languages: [python]
+    severity: ERROR
+    metadata: {category: injection_risk, isitsecure-severity: critical}
+    message: "Raw SQL built from an f-string/%/concatenation — SQL injection. Use a parameterized query."
+    patterns:
+      - pattern-either:
+          - pattern: $X.execute(f"...{...}...")
+          - pattern: $X.execute("..." % ...)
+          - pattern: $X.execute("..." + ...)
+          - pattern: $X.execute("...".format(...))
+          - pattern: $X.executemany(f"...{...}...")
+          - pattern: $X.execute(text(f"...{...}..."))
+          - pattern: $M.objects.raw(f"...{...}...")
+          - pattern: $M.objects.raw("..." % ...)
+          - pattern: $M.objects.raw("..." + ...)
+
+  # ---- SQL injection: user input → query STRING (intra-file taint) ----
+  # Catches the assign-then-execute shape the inline pattern above misses. The
+  # sink focuses on the query-string argument, so a parameterized call —
+  # execute(sql, params) with taint in `params` — is NOT flagged.
+  - id: isitsecure-py-sqli-taint
+    mode: taint
+    languages: [python]
+    severity: ERROR
+    metadata: {category: injection_risk, isitsecure-severity: critical}
+    message: "User input flows into a raw SQL query — SQL injection."
+    pattern-sources: &py_sources
+      - pattern: request.args
+      - pattern: request.form
+      - pattern: request.values
+      - pattern: request.data
+      - pattern: request.json
+      - pattern: request.args.get(...)
+      - pattern: request.form.get(...)
+      - pattern: request.values.get(...)
+      - pattern: request.GET
+      - pattern: request.POST
+      - pattern: request.GET.get(...)
+      - pattern: request.POST.get(...)
+    pattern-sinks:
+      - patterns:
+          - pattern-either:
+              - pattern: $CUR.execute($Q, ...)
+              - pattern: $CUR.executemany($Q, ...)
+              - pattern: $M.objects.raw($Q, ...)
+          - focus-metavariable: $Q
+
+  # ---- Command injection: user input → shell (intra-file taint) ----
+  - id: isitsecure-py-command-injection
+    mode: taint
+    languages: [python]
+    severity: ERROR
+    metadata: {category: injection_risk, isitsecure-severity: critical}
+    message: "User input flows into a shell command — command injection."
+    pattern-sources: *py_sources
+    pattern-sinks:
+      - pattern: os.system(...)
+      - pattern: os.popen(...)
+      - pattern: subprocess.run(..., shell=True, ...)
+      - pattern: subprocess.call(..., shell=True, ...)
+      - pattern: subprocess.Popen(..., shell=True, ...)
+      - pattern: subprocess.check_output(..., shell=True, ...)
+
+  # ---- SSRF: user-controlled URL → outbound request ----
+  - id: isitsecure-py-ssrf
+    mode: taint
+    languages: [python]
+    severity: ERROR
+    metadata: {category: injection_risk, isitsecure-severity: high}
+    message: "User-controlled URL flows into an outbound request (requests/urllib) — SSRF."
+    pattern-sources: *py_sources
+    pattern-sinks:
+      - pattern: requests.get(...)
+      - pattern: requests.post(...)
+      - pattern: requests.request(...)
+      - pattern: httpx.get(...)
+      - pattern: urllib.request.urlopen(...)
+
+  # ---- Path traversal: request-derived path → file open ----
+  - id: isitsecure-py-path-traversal
+    mode: taint
+    languages: [python]
+    severity: WARNING
+    metadata: {category: injection_risk, isitsecure-severity: high}
+    message: "File opened with a request-derived path — path traversal."
+    pattern-sources: *py_sources
+    pattern-sinks:
+      - pattern: open(...)
+
+  # ---- SSTI: user input → server-side template render ----
+  - id: isitsecure-py-ssti
+    mode: taint
+    languages: [python]
+    severity: ERROR
+    metadata: {category: injection_risk, isitsecure-severity: critical}
+    message: "User input flows into a server-side template render — template injection (SSTI)."
+    pattern-sources: *py_sources
+    pattern-sinks:
+      - pattern: render_template_string(...)

--- a/tests/benchmarks/test_sast_injection_scorer.py
+++ b/tests/benchmarks/test_sast_injection_scorer.py
@@ -20,6 +20,7 @@ _CLASS_TITLE = {
     "ssrf": "User-controlled URL flows into an outbound request",
     "path-traversal": "Filesystem write using a request-derived filename",
     "command-injection": "User input flows into a shell command",
+    "ssti": "User input flows into a server-side template render — template injection (SSTI)",
 }
 
 
@@ -43,8 +44,29 @@ def _findings_for(bugs: list[dict], *, correct_class: bool = True) -> list[dict]
 class TestGroundTruth:
     def test_fixtures_have_expected_markers(self):
         bugs = si.expected_bugs()
-        assert len(bugs) >= 12  # 6 classes represented
+        assert len(bugs) >= 25  # JS/TS + Python across 7 classes
         assert {b["class"] for b in bugs} == set(si.CLASSES)
+
+    def test_python_and_js_fixtures_both_present(self):
+        files = {b["file"] for b in si.expected_bugs()}
+        assert any(f.endswith(".py") for f in files)   # Python (#93)
+        assert any(f.endswith(".ts") for f in files)   # JS/TS (#4)
+
+    def test_marker_regex_accepts_both_comment_styles(self):
+        assert si.EXPECT_RE.search("foo()  // EXPECT sqli").group(1) == "sqli"
+        assert si.EXPECT_RE.search("foo()  # EXPECT ssti").group(1) == "ssti"
+
+    def test_descriptive_comment_lines_are_not_ground_truth(self, tmp_path, monkeypatch):
+        """A standalone comment mentioning EXPECT must not inflate the count."""
+        vuln = tmp_path / "vulnerable"
+        vuln.mkdir()
+        (vuln / "x.py").write_text(
+            "# this line says EXPECT sqli but is prose\n"
+            "cur.execute(bad)  # EXPECT sqli\n"
+        )
+        monkeypatch.setattr(si, "FIXTURES", tmp_path)
+        bugs = si.expected_bugs()
+        assert len(bugs) == 1 and bugs[0]["line"] == 2
 
 
 class TestScoring:
@@ -144,6 +166,8 @@ class TestHelpers:
         ("User-controlled URL flows into an outbound request", "ssrf"),
         ("Filesystem write using a request-derived filename", "path-traversal"),
         ("User input flows into a shell command", "command-injection"),
+        ("User input flows into a server-side template render (SSTI)", "ssti"),
+        ("File opened with a request-derived path — path traversal", "path-traversal"),
         ("something else entirely", "?"),
         # regression: bare "dom" substring must NOT swallow these
         ("User-controlled URL flows to an external domain (SSRF)", "ssrf"),

--- a/tests/engine/test_semgrep_analyzer.py
+++ b/tests/engine/test_semgrep_analyzer.py
@@ -67,16 +67,30 @@ class TestGracefulNoOp:
 
     @pytest.mark.asyncio
     async def test_no_supported_files_skips_run(self, monkeypatch):
-        """A repo with no JS/TS files never even invokes semgrep."""
+        """A repo with no rule-pack-covered files (no JS/TS/Python) skips semgrep."""
         monkeypatch.setattr(SemgrepAnalyzer, "_find_semgrep", staticmethod(lambda: "/bin/semgrep"))
 
         async def _boom(*a, **k):  # pragma: no cover - must not be called
-            raise AssertionError("_run_semgrep should not run without JS/TS files")
+            raise AssertionError("_run_semgrep should not run without supported files")
 
         monkeypatch.setattr(SemgrepAnalyzer, "_run_semgrep", _boom)
         analyzer = SemgrepAnalyzer()
-        findings = await analyzer.scan(_snapshot({"main.py": "", "README.md": ""}))
+        findings = await analyzer.scan(_snapshot({"main.go": "", "README.md": ""}))
         assert findings == []
+
+    @pytest.mark.asyncio
+    async def test_python_files_trigger_run(self, monkeypatch):
+        """A Python-only repo runs semgrep (the #93 Python rule pack)."""
+        monkeypatch.setattr(SemgrepAnalyzer, "_find_semgrep", staticmethod(lambda: "/bin/semgrep"))
+        ran = {}
+
+        async def _fake(self, semgrep, clone_path):
+            ran["called"] = True
+            return {"results": []}
+
+        monkeypatch.setattr(SemgrepAnalyzer, "_run_semgrep", _fake)
+        await SemgrepAnalyzer().scan(_snapshot({"app/views.py": ""}))
+        assert ran.get("called") is True
 
     @pytest.mark.asyncio
     async def test_semgrep_crash_returns_empty(self, monkeypatch):


### PR DESCRIPTION
Closes #93. Broadens the deterministic Semgrep taint floor (#4) beyond JS/TS to **Python**, gated by the SAST injection benchmark (#92).

## What's in it
- **`injection-python.yaml`** (Flask/Django sources) — SQLi, command injection, SSRF, path traversal, SSTI.
  - **SQLi** is pattern-based for string-built queries (f-string/`%`/`.format`/concat, `execute(text(f"…"))`, Django `.objects.raw`) **plus** a taint rule whose sink **focuses on the query-string argument** — so it catches the *build-then-execute* shape while **never flagging parameterized queries** (a request-derived value in the `params` tuple is safe).
- **`SemgrepAnalyzer`** now scans `.py` (`_SUPPORTED_EXT`). Semgrep applies each rule only to its declared language, so the whole rules dir runs safely on mixed repos. No new scanner — still `semgrep_taint`, still opt-in `[taint]`.
- **Benchmark (#92) extended** with independent Python fixtures (vulnerable + benign near-misses); the scorer now parses `#` markers and the `ssti` class, and ignores standalone comment lines so prose can't inflate counts.

## Benchmark
**27/27 recall, 0 FP** across JS/TS + Python (Python: sqli 7, cmdi 3, ssrf 2, path 2, ssti 1). Cross-checked on isitsecure's own **164 `.py` files** (real `subprocess`/`requests`/`open` call sites): **0 false positives**.

## Adversarial review → fixed
Code review found (and semgrep-verified) a **critical FP**: a bare `text(f"…")` SQLi rule matched *any* function named `text` — e.g. `from django.utils.translation import gettext as text` firing a critical SQLi on ordinary i18n code. Fixed by scoping `text()` to inside `execute(...)`, re-verified. The review also exposed an inline-only SQLi **recall gap** the fixtures hid → added `.format()` + the focus-metavariable taint rule (catches build-then-execute, still no parameterized-query FP). Docs scoped honestly to **Flask/Django** (FastAPI param-sources noted as a known gap). Doc review's required `architecture.md` fix applied.

## Known limitations (documented, not blockers)
- Python taint sources are Flask/Django; FastAPI endpoint params aren't tracked yet (SQLi pattern rule still works on any stack).
- Intra-file taint only (OSS Semgrep); inter-file falls to the LLM layer.

## Verification
74 tests pass (analyzer + factory + benchmark scorer); ruff clean; both rule packs ship in the wheel; `python benchmarks/run_benchmarks.py sast-injection` → 27/27, 0 FP, exit 0.

Follow-up: #94 (auto-select packs per detected stack).

🤖 Generated with [Claude Code](https://claude.com/claude-code)