### PR TITLE
feat(sast): auto-select taint rule packs by repo language (#94)

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ isitsecure setup
 | `pip install -e ".[browser]"` | Adds DAST / live-URL scanning (requires `isitsecure setup` to install Chromium) |
 | `pip install -e ".[llm]"` | Adds LLM code review, triage, and AI fixes (requires an API key) |
 | `pip install -e ".[all]"` | Everything except `[taint]` (see below) |
-| `pip install -e ".[taint]"` | Deterministic Semgrep taint/injection SAST for JS/TS. **Install separately** — semgrep's pinned dependencies don't co-resolve with `[all]`. The analyzer only needs the `semgrep` binary on PATH, so `pipx install semgrep` (or brew) works too; it falls back to LLM-only if absent |
+| `pip install -e ".[taint]"` | Deterministic Semgrep taint/injection SAST for JS/TS and Python. **Install separately** — semgrep's pinned dependencies don't co-resolve with `[all]`. The analyzer only needs the `semgrep` binary on PATH, so `pipx install semgrep` (or brew) works too; it falls back to LLM-only if absent |
 
 URL/DAST scanning needs the `[browser]` extra — without it, `isitsecure scan <url>` exits with a message telling you to install it.
 

--- a/benchmarks/RESULTS.md
+++ b/benchmarks/RESULTS.md
@@ -41,7 +41,7 @@ params tuple), a bare `text()` i18n alias, `subprocess` without `shell=True`,
 constant-path `open()`, fixed-URL requests (Python) — none flagged. Cross-checked
 against isitsecure's own 164 Python files (which contain real `subprocess`,
 `requests`/`httpx`, and `open()` call sites): **0 false positives**. This is the
-baseline the taint layer and future rule packs (#94) must hold.
+baseline the taint layer and future rule packs must hold.
 
 > Juice Shop recall is scored **per challenge** — a finding must match the class
 > signature AND land on the right endpoint — over the 45 DAST-detectable

--- a/docs/scanners/semgrep-taint.md
+++ b/docs/scanners/semgrep-taint.md
@@ -6,7 +6,7 @@
 
 Runs [Semgrep](https://semgrep.dev) with isitsecure's own taint/sink rule packs over your cloned repo and maps the results to findings. It is a **deterministic injection floor beneath the LLM code reviewer**: the same input always produces the same findings, instantly and at no token cost.
 
-Two rule packs ship today — **JavaScript/TypeScript** (`semgrep_rules/injection-js.yaml`, #4) and **Python** (`semgrep_rules/injection-python.yaml`, #93). Semgrep applies each rule only to its declared language, so a repo of either (or both) is covered.
+Two rule packs ship today — **JavaScript/TypeScript** (`semgrep_rules/injection-js.yaml`, #4) and **Python** (`semgrep_rules/injection-python.yaml`, #93). The analyzer **auto-selects the packs whose languages are present in the repo** (#94): a JS-only repo runs only the JS pack, a Python-only repo only the Python pack, a mixed repo both. (Semgrep also scopes each rule to its declared language, so selection is about not loading irrelevant rules — faster, and ready for per-framework packs later.)
 
 **JavaScript/TypeScript** — six classes:
 
@@ -76,4 +76,4 @@ const rows = await sql`SELECT * FROM users WHERE id = ${id}`;
 
 ## Configuration
 
-No configuration. The analyzer auto-runs on any code-only/full scan when the `semgrep` binary is available and the repo has JS/TS files. The rule packs live in `isitsecure/engine/code_analysis/semgrep_rules/`.
+No configuration. The analyzer auto-runs on any code-only/full scan when the `semgrep` binary is available and the repo has files a rule pack covers (JS/TS or Python) — selecting the matching packs automatically. The rule packs live in `isitsecure/engine/code_analysis/semgrep_rules/`; register a new one in `_RULE_PACKS` in `semgrep_analyzer.py`.

--- a/docs/taint-analysis.md
+++ b/docs/taint-analysis.md
@@ -94,10 +94,13 @@ popular vibe-coder stacks:
 Written once, applied to every app on that stack. This is how Semgrep / CodeQL /
 Snyk all work — packs per ecosystem, never per app.
 
-**We already detect the stack.** The scan reports `framework: nextjs`,
-`backend: supabase`, etc., so we **auto-select the matching rule packs per scan**
-— no user config. Apps on an uncatalogued library fall through to the LLM
-backstop (the whole point of the layered design).
+**We auto-select the matching rule packs per scan** — no user config (#94). Today
+selection is by **language present** (a JS-only repo runs only the JS pack; a
+Python-only repo only the Python pack), via the `_RULE_PACKS` registry in
+`semgrep_analyzer.py`. When packs are split per **framework** (e.g. Next.js vs
+Express), the registry grows a `frameworks` field matched against the scan's
+already-detected `framework`/`backend`. Apps on an uncatalogued library fall
+through to the LLM backstop (the whole point of the layered design).
 
 ## Why Semgrep (vs. alternatives)
 
@@ -117,7 +120,7 @@ backstop (the whole point of the layered design).
 
 A new `SemgrepAnalyzer` behind the existing SAST scanner interface:
 
-1. On a code-only scan, detect the stack (already done) → select rule packs.
+1. On a code-only scan, select the rule packs matching the repo's languages (#94).
 2. Shell out to the bundled `semgrep` binary with those packs (`--json`), scoped
    to the cloned repo. No network (rules ship with us).
 3. Parse Semgrep's output → map each result to a `CodeFinding` (category from the

--- a/isitsecure/engine/code_analysis/semgrep_analyzer.py
+++ b/isitsecure/engine/code_analysis/semgrep_analyzer.py
@@ -19,8 +19,10 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import os
 import shutil
 import sys
+from dataclasses import dataclass
 from pathlib import Path
 
 from isitsecure.engine.code_analysis.models import CodeFinding
@@ -30,10 +32,32 @@ from isitsecure.engine.enums import FindingCategory, SeverityLevel
 logger = logging.getLogger(__name__)
 
 _RULES_DIR = Path(__file__).parent / "semgrep_rules"
-# Extensions the shipped rule packs cover (JS/TS #4, Python #93). Semgrep applies
-# each rule only to its declared language, so running the whole rules dir is safe.
-_SUPPORTED_EXT = (".js", ".jsx", ".ts", ".tsx", ".mjs", ".cjs", ".py")
 _SCAN_TIMEOUT_S = 120.0
+
+
+@dataclass(frozen=True)
+class _RulePack:
+    """A shipped rule pack and the repo file extensions that activate it."""
+
+    name: str                    # for logging
+    filename: str                # under semgrep_rules/
+    extensions: tuple[str, ...]  # a repo file with one of these enables the pack
+
+
+# Registry of shipped packs. Selected per scan (#94) so a JS-only repo never loads
+# the Python rules and vice-versa — fewer rules parsed, no cross-stack surprises.
+# Today selection is by language (file extension); when packs are split per
+# framework (e.g. Next.js vs Express), add a `frameworks` field and match on
+# RepoSnapshot.framework here.
+_RULE_PACKS: tuple[_RulePack, ...] = (
+    _RulePack("javascript/typescript", "injection-js.yaml",
+              (".js", ".jsx", ".ts", ".tsx", ".mjs", ".cjs")),
+    _RulePack("python", "injection-python.yaml", (".py",)),
+)
+
+# Dirs semgrep ignores by default; skipping them bounds the language-detection
+# walk without ever under-selecting (semgrep wouldn't scan them either).
+_WALK_SKIP_DIRS = frozenset({"node_modules", ".git"})
 
 _SEVERITY_MAP = {
     "critical": SeverityLevel.CRITICAL,
@@ -62,10 +86,11 @@ class SemgrepAnalyzer:
         if not semgrep:
             logger.debug("semgrep not installed — skipping taint analysis (isitsecure[taint])")
             return []
-        if not self._has_supported_files(repo):
-            return []
+        packs = self._select_packs(repo)
+        if not packs:
+            return []  # no rule pack covers this repo's languages
 
-        raw = await self._run_semgrep(semgrep, repo.clone_path)
+        raw = await self._run_semgrep(semgrep, repo.clone_path, packs)
         if raw is None:
             return []
         return self._to_findings(raw, repo)
@@ -84,14 +109,57 @@ class SemgrepAnalyzer:
             return str(candidate)
         return shutil.which("semgrep")
 
-    def _has_supported_files(self, repo: RepoSnapshot) -> bool:
-        """Only run when there are files a rule pack covers (JS/TS or Python)."""
-        return any(p.endswith(_SUPPORTED_EXT) for p in repo.file_index)
+    def _select_packs(self, repo: RepoSnapshot) -> list[Path]:
+        """Pick the rule packs whose languages appear in the repo (#94).
 
-    async def _run_semgrep(self, semgrep: str, clone_path: str) -> dict | None:
-        cmd = [
-            semgrep, "scan",
-            "--config", str(self._rules_dir),
+        Language presence is read from the actual on-disk tree (what semgrep will
+        scan) — NOT the curated ``file_index``, which drops oversized files and
+        skip-dirs semgrep would still scan. Over-selecting a pack is harmless;
+        under-selecting would silently lose findings, so we err toward inclusion.
+        """
+        present = self._extensions_on_disk(repo.clone_path)
+        selected: list[Path] = []
+        for pack in _RULE_PACKS:
+            if not any(ext in present for ext in pack.extensions):
+                continue
+            path = self._rules_dir / pack.filename
+            if not path.is_file():
+                logger.warning("semgrep_taint: rule pack %s missing — skipping", pack.filename)
+                continue
+            selected.append(path)
+        if selected:
+            logger.debug("semgrep_taint: selected packs %s", [p.name for p in selected])
+        return selected
+
+    @staticmethod
+    def _extensions_on_disk(clone_path: str) -> set[str]:
+        """Extensions present under ``clone_path`` that any rule pack cares about.
+
+        Case-sensitive (mirrors semgrep, which skips e.g. ``.PY``). Walk stops
+        early once every wanted extension has been seen.
+        """
+        wanted = {ext for pack in _RULE_PACKS for ext in pack.extensions}
+        found: set[str] = set()
+        try:
+            for _root, dirs, files in os.walk(clone_path):
+                dirs[:] = [d for d in dirs if d not in _WALK_SKIP_DIRS]
+                for f in files:
+                    ext = os.path.splitext(f)[1]
+                    if ext in wanted:
+                        found.add(ext)
+                        if found >= wanted:
+                            return found
+        except OSError:  # unreadable tree — let semgrep decide, select nothing here
+            return found
+        return found
+
+    async def _run_semgrep(
+        self, semgrep: str, clone_path: str, packs: list[Path]
+    ) -> dict | None:
+        cmd = [semgrep, "scan"]
+        for pack in packs:
+            cmd += ["--config", str(pack)]
+        cmd += [
             "--json", "--quiet",
             "--metrics", "off",       # no telemetry
             "--disable-version-check",
@@ -171,7 +239,8 @@ class SemgrepAnalyzer:
 
     # Rule id → vuln class, so the sqli sink + sqli taint rules dedup together but
     # different classes on the same line don't. Substring match on our rule ids.
-    _RULE_CLASSES = ("sqli", "reflected-xss", "dom-xss", "ssrf", "path-traversal", "command")
+    _RULE_CLASSES = ("sqli", "reflected-xss", "dom-xss", "ssrf", "path-traversal",
+                     "command", "ssti")
 
     @classmethod
     def _rule_class(cls, check_id: str) -> str:

--- a/tests/engine/test_semgrep_analyzer.py
+++ b/tests/engine/test_semgrep_analyzer.py
@@ -6,12 +6,15 @@ are mocked so the suite is deterministic in CI (no `[taint]` extra required).
 """
 
 import json
+import pathlib
 
 import pytest
 
 from isitsecure.engine.code_analysis.protocols import RepoSnapshot
 from isitsecure.engine.code_analysis.semgrep_analyzer import SemgrepAnalyzer
 from isitsecure.engine.enums import FindingCategory, SeverityLevel
+
+_PACKS = [pathlib.Path("injection-js.yaml")]  # dummy pack arg for _run_semgrep tests
 
 
 def _snapshot(files: dict[str, str], clone_path: str = "/repo") -> RepoSnapshot:
@@ -29,6 +32,16 @@ def _snapshot(files: dict[str, str], clone_path: str = "/repo") -> RepoSnapshot:
         total_files=len(files),
         total_size_bytes=0,
     )
+
+
+def _disk_snapshot(tmp_path, names: list[str]) -> RepoSnapshot:
+    """A snapshot whose clone_path is a real dir containing `names` on disk —
+    `_select_packs` walks the disk (not file_index), so pack tests need real files."""
+    for n in names:
+        p = tmp_path / n
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text("x = 1\n")
+    return _snapshot({}, clone_path=str(tmp_path))
 
 
 def _result(
@@ -66,7 +79,7 @@ class TestGracefulNoOp:
         assert findings == []
 
     @pytest.mark.asyncio
-    async def test_no_supported_files_skips_run(self, monkeypatch):
+    async def test_no_supported_files_skips_run(self, monkeypatch, tmp_path):
         """A repo with no rule-pack-covered files (no JS/TS/Python) skips semgrep."""
         monkeypatch.setattr(SemgrepAnalyzer, "_find_semgrep", staticmethod(lambda: "/bin/semgrep"))
 
@@ -75,34 +88,86 @@ class TestGracefulNoOp:
 
         monkeypatch.setattr(SemgrepAnalyzer, "_run_semgrep", _boom)
         analyzer = SemgrepAnalyzer()
-        findings = await analyzer.scan(_snapshot({"main.go": "", "README.md": ""}))
+        findings = await analyzer.scan(_disk_snapshot(tmp_path, ["main.go", "README.md"]))
         assert findings == []
 
     @pytest.mark.asyncio
-    async def test_python_files_trigger_run(self, monkeypatch):
-        """A Python-only repo runs semgrep (the #93 Python rule pack)."""
+    async def test_python_files_trigger_run(self, monkeypatch, tmp_path):
+        """A Python-only repo runs semgrep with the #93 Python rule pack only."""
         monkeypatch.setattr(SemgrepAnalyzer, "_find_semgrep", staticmethod(lambda: "/bin/semgrep"))
         ran = {}
 
-        async def _fake(self, semgrep, clone_path):
-            ran["called"] = True
+        async def _fake(self, semgrep, clone_path, packs):
+            ran["packs"] = [p.name for p in packs]
             return {"results": []}
 
         monkeypatch.setattr(SemgrepAnalyzer, "_run_semgrep", _fake)
-        await SemgrepAnalyzer().scan(_snapshot({"app/views.py": ""}))
-        assert ran.get("called") is True
+        await SemgrepAnalyzer().scan(_disk_snapshot(tmp_path, ["app/views.py"]))
+        assert ran.get("packs") == ["injection-python.yaml"]  # not the JS pack
 
     @pytest.mark.asyncio
-    async def test_semgrep_crash_returns_empty(self, monkeypatch):
+    async def test_semgrep_crash_returns_empty(self, monkeypatch, tmp_path):
         """_run_semgrep returning None (crash/timeout) degrades to no findings."""
         monkeypatch.setattr(SemgrepAnalyzer, "_find_semgrep", staticmethod(lambda: "/bin/semgrep"))
 
-        async def _none(self, semgrep, clone_path):
+        async def _none(self, semgrep, clone_path, packs):
             return None
 
         monkeypatch.setattr(SemgrepAnalyzer, "_run_semgrep", _none)
-        findings = await SemgrepAnalyzer().scan(_snapshot({"src/x.ts": ""}))
+        findings = await SemgrepAnalyzer().scan(_disk_snapshot(tmp_path, ["src/x.ts"]))
         assert findings == []
+
+
+class TestPackSelection:
+    """#94 — only the packs whose languages appear in the repo are run.
+
+    Selection walks the on-disk tree (what semgrep scans), not the curated
+    file_index — so these use real files.
+    """
+
+    def test_js_only(self, tmp_path):
+        packs = SemgrepAnalyzer()._select_packs(_disk_snapshot(tmp_path, ["src/a.ts", "b.jsx"]))
+        assert [p.name for p in packs] == ["injection-js.yaml"]
+
+    def test_python_only(self, tmp_path):
+        packs = SemgrepAnalyzer()._select_packs(_disk_snapshot(tmp_path, ["app/x.py"]))
+        assert [p.name for p in packs] == ["injection-python.yaml"]
+
+    def test_mixed_repo_gets_both(self, tmp_path):
+        packs = SemgrepAnalyzer()._select_packs(_disk_snapshot(tmp_path, ["a.ts", "b.py"]))
+        assert {p.name for p in packs} == {"injection-js.yaml", "injection-python.yaml"}
+
+    def test_unsupported_language_gets_nothing(self, tmp_path):
+        packs = SemgrepAnalyzer()._select_packs(_disk_snapshot(tmp_path, ["main.go", "README.md"]))
+        assert packs == []
+
+    def test_selects_lang_in_dir_dropped_from_file_index(self, tmp_path):
+        """Regression guard: a .py only under a build/ dir (excluded from
+        file_index but still scanned by semgrep) must still select the Python
+        pack — selection reads the disk, not file_index."""
+        packs = SemgrepAnalyzer()._select_packs(
+            _disk_snapshot(tmp_path, ["a.ts", "build/generated.py"]))
+        assert {p.name for p in packs} == {"injection-js.yaml", "injection-python.yaml"}
+
+    def test_skips_node_modules(self, tmp_path):
+        """A language present only under node_modules is not selected (semgrep
+        skips node_modules too, so this can't lose a real finding)."""
+        packs = SemgrepAnalyzer()._select_packs(
+            _disk_snapshot(tmp_path, ["a.ts", "node_modules/pkg/x.py"]))
+        assert [p.name for p in packs] == ["injection-js.yaml"]
+
+    def test_cjs_is_selected(self, tmp_path):
+        """`.cjs` (a real JS extension semgrep scans) selects the JS pack."""
+        packs = SemgrepAnalyzer()._select_packs(_disk_snapshot(tmp_path, ["server.cjs"]))
+        assert [p.name for p in packs] == ["injection-js.yaml"]
+
+    def test_missing_pack_file_skipped(self, monkeypatch, tmp_path):
+        """A stale registry entry (file gone) is skipped, not fatal to the scan."""
+        import isitsecure.engine.code_analysis.semgrep_analyzer as mod
+        bogus = mod._RulePack("bogus", "does-not-exist.yaml", (".rb",))
+        monkeypatch.setattr(mod, "_RULE_PACKS", (*mod._RULE_PACKS, bogus))
+        packs = SemgrepAnalyzer()._select_packs(_disk_snapshot(tmp_path, ["a.ts", "x.rb"]))
+        assert [p.name for p in packs] == ["injection-js.yaml"]  # bogus dropped
 
 
 class TestFindSemgrep:
@@ -127,8 +192,12 @@ class TestFindSemgrep:
 class TestFindingMapping:
     async def _run(self, monkeypatch, results):
         monkeypatch.setattr(SemgrepAnalyzer, "_find_semgrep", staticmethod(lambda: "/bin/semgrep"))
+        # These test result→CodeFinding mapping, not selection — force a pack so
+        # scan() proceeds without touching the (fake) clone_path on disk.
+        monkeypatch.setattr(SemgrepAnalyzer, "_select_packs",
+                            lambda self, repo: [pathlib.Path("injection-js.yaml")])
 
-        async def _fake(self, semgrep, clone_path):
+        async def _fake(self, semgrep, clone_path, packs):
             return {"results": results}
 
         monkeypatch.setattr(SemgrepAnalyzer, "_run_semgrep", _fake)
@@ -211,6 +280,35 @@ class TestRunSemgrepBoundary:
     """Exercise _run_semgrep's parsing/timeout via a fake subprocess (no binary)."""
 
     @pytest.mark.asyncio
+    async def test_builds_one_config_arg_per_pack(self, monkeypatch):
+        """Each selected pack becomes its own --config <path> in the argv."""
+        captured = {}
+
+        class _Proc:
+            returncode = 0
+
+            async def communicate(self):
+                return b'{"results": []}', b""
+
+            def kill(self):  # pragma: no cover
+                pass
+
+        async def _fake_exec(*cmd, **k):
+            captured["cmd"] = cmd
+            return _Proc()
+
+        monkeypatch.setattr(
+            "isitsecure.engine.code_analysis.semgrep_analyzer.asyncio.create_subprocess_exec",
+            _fake_exec,
+        )
+        packs = [pathlib.Path("injection-js.yaml"), pathlib.Path("injection-python.yaml")]
+        await SemgrepAnalyzer()._run_semgrep("/bin/semgrep", "/repo", packs)
+        cmd = list(captured["cmd"])
+        assert cmd.count("--config") == 2
+        assert str(packs[0]) in cmd and str(packs[1]) in cmd
+        assert cmd[-1] == "/repo"
+
+    @pytest.mark.asyncio
     async def test_parses_stdout_json(self, monkeypatch):
         payload = json.dumps({"results": [_result()]}).encode()
 
@@ -230,7 +328,7 @@ class TestRunSemgrepBoundary:
             "isitsecure.engine.code_analysis.semgrep_analyzer.asyncio.create_subprocess_exec",
             _fake_exec,
         )
-        raw = await SemgrepAnalyzer()._run_semgrep("/bin/semgrep", "/repo")
+        raw = await SemgrepAnalyzer()._run_semgrep("/bin/semgrep", "/repo", _PACKS)
         assert raw is not None and len(raw["results"]) == 1
 
     @pytest.mark.asyncio
@@ -251,7 +349,7 @@ class TestRunSemgrepBoundary:
             "isitsecure.engine.code_analysis.semgrep_analyzer.asyncio.create_subprocess_exec",
             _fake_exec,
         )
-        assert await SemgrepAnalyzer()._run_semgrep("/bin/semgrep", "/repo") is None
+        assert await SemgrepAnalyzer()._run_semgrep("/bin/semgrep", "/repo", _PACKS) is None
 
     @pytest.mark.asyncio
     async def test_subprocess_exception_returns_none(self, monkeypatch):
@@ -262,7 +360,7 @@ class TestRunSemgrepBoundary:
             "isitsecure.engine.code_analysis.semgrep_analyzer.asyncio.create_subprocess_exec",
             _boom,
         )
-        assert await SemgrepAnalyzer()._run_semgrep("/bin/semgrep", "/repo") is None
+        assert await SemgrepAnalyzer()._run_semgrep("/bin/semgrep", "/repo", _PACKS) is None
 
     @pytest.mark.asyncio
     async def test_malformed_json_returns_none(self, monkeypatch):
@@ -279,7 +377,7 @@ class TestRunSemgrepBoundary:
             "isitsecure.engine.code_analysis.semgrep_analyzer.asyncio.create_subprocess_exec",
             lambda *a, **k: _fake_awaitable(_Proc()),
         )
-        assert await SemgrepAnalyzer()._run_semgrep("/bin/semgrep", "/repo") is None
+        assert await SemgrepAnalyzer()._run_semgrep("/bin/semgrep", "/repo", _PACKS) is None
 
     @pytest.mark.asyncio
     async def test_non_dict_json_returns_none(self, monkeypatch):
@@ -296,7 +394,7 @@ class TestRunSemgrepBoundary:
             "isitsecure.engine.code_analysis.semgrep_analyzer.asyncio.create_subprocess_exec",
             lambda *a, **k: _fake_awaitable(_Proc()),
         )
-        assert await SemgrepAnalyzer()._run_semgrep("/bin/semgrep", "/repo") is None
+        assert await SemgrepAnalyzer()._run_semgrep("/bin/semgrep", "/repo", _PACKS) is None
 
     @pytest.mark.asyncio
     async def test_timeout_kills_and_reaps_child(self, monkeypatch):
@@ -326,7 +424,7 @@ class TestRunSemgrepBoundary:
             "isitsecure.engine.code_analysis.semgrep_analyzer.asyncio.create_subprocess_exec",
             lambda *a, **k: _fake_awaitable(_Proc()),
         )
-        result = await SemgrepAnalyzer()._run_semgrep("/bin/semgrep", "/repo")
+        result = await SemgrepAnalyzer()._run_semgrep("/bin/semgrep", "/repo", _PACKS)
         assert result is None
         assert killed["kill"] and killed["wait"]  # no orphan, no zombie
 
@@ -355,7 +453,7 @@ class TestRunSemgrepBoundary:
             lambda *a, **k: _fake_awaitable(_Proc()),
         )
         with pytest.raises(_a.CancelledError):
-            await SemgrepAnalyzer()._run_semgrep("/bin/semgrep", "/repo")
+            await SemgrepAnalyzer()._run_semgrep("/bin/semgrep", "/repo", _PACKS)
         assert killed["kill"]  # child killed even on cancellation
 
 


### PR DESCRIPTION
Closes #94. `SemgrepAnalyzer` now auto-selects rule packs by the languages present in the repo, instead of always loading the whole `semgrep_rules/` directory.

## What's in it
- **`_RULE_PACKS` registry** (`_RulePack` dataclass: name, filename, extensions) + `_select_packs(repo)` → only the packs whose languages appear in the repo (JS-only → JS pack, Python-only → Python, mixed → both). Passed as individual `--config <pack>` args. Structured to grow a `frameworks` field for per-framework selection later.

## Adversarial review → fixed a real regression
The code review found (and demonstrated) a **findings-regression** in the first version: it selected packs from the *curated* `file_index`, but semgrep scans the *whole on-disk tree*. A language present only in files `file_index` drops — oversized (>500KB), skip-dirs (`build/`, `coverage/`), or the `.cjs` extension ingestion doesn't index — would lose its pack.

**Fix:** selection walks the **actual `clone_path`** (what semgrep scans), skipping only `node_modules`/`.git` (semgrep ignores them too), case-sensitive to mirror semgrep, early-exiting once all languages are seen. It **over-selects safely, never under-selects**. A missing/stale pack file is skipped with a warning, not fatal to the scan.

Regression-guard tests added: a `.py` only in `build/` still selects the Python pack; `.cjs` selects JS; missing pack skipped; one `--config` per pack in the argv.

## Verification (superset-preserving optimization)
- **Benchmark: 27/27 recall, 0 FP** — unchanged.
- test-app (JS-only) still selects only the JS pack → same 15 findings.
- 83 tests pass; ruff clean.

## Honest scope note
With only two *language* packs, the practical win is small (semgrep already language-scopes rules internally) — the real value is the **registry as the foundation for per-framework packs**. Correct and regression-free either way.

Completes the #4 taint roadmap (#4 JS/TS floor → #92 benchmark → #93 Python → #94 pack selection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)