### PR TITLE
docs(taint): fill remaining JS/TS-only gaps left by the Python pack (#93)

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,7 +369,7 @@ isitsecure is not a replacement for enterprise security platforms. It's designed
 
 | Need | Best specialized tool | How isitsecure compares |
 |---|---|---|
-| Deep SAST (30+ languages) | [Semgrep](https://semgrep.dev) | We embed Semgrep for deterministic JS/TS injection taint (opt-in `[taint]`) and add LLM review on top; Semgrep's own registry covers far more languages and rules |
+| Deep SAST (30+ languages) | [Semgrep](https://semgrep.dev) | We embed Semgrep for deterministic JS/TS and Python injection taint (opt-in `[taint]`) and add LLM review on top; Semgrep's own registry covers far more languages and rules |
 | DAST with advanced exploitation | [OWASP ZAP](https://zaproxy.org) / [Burp Suite](https://portswigger.net) | Our DAST is simpler — fewer payloads, no WAF evasion |
 | Secret scanning (800+ patterns) | [TruffleHog](https://github.com/trufflesecurity/trufflehog) / [Gitleaks](https://github.com/gitleaks/gitleaks) | Our git scanner covers common patterns, not exhaustive |
 | Container + IaC scanning | [Trivy](https://github.com/aquasecurity/trivy) / [Checkov](https://github.com/bridgecrewio/checkov) | Our IaC/Docker scanners are basic — use Trivy for depth |

--- a/docs/scanners/README.md
+++ b/docs/scanners/README.md
@@ -38,7 +38,7 @@ These scanners require authentication or use specialized techniques.
 
 These scanners analyze your source code without running it.
 
-- [Semgrep Taint Analyzer](./semgrep-taint.md) — Deterministic source→sink injection for JS/TS (SQLi, XSS, SSRF, path traversal, command injection)
+- [Semgrep Taint Analyzer](./semgrep-taint.md) — Deterministic source→sink injection for JS/TS and Python (SQLi, XSS, SSRF, path traversal, command injection, SSTI)
 - [Git Secret Scanner](./git-secret-scanner.md) — Secrets in git history
 - [Route Auth Analyzer](./route-auth-analyzer.md) — Routes missing authentication
 - [RLS Policy Analyzer](./rls-policy-analyzer.md) — Missing Supabase Row Level Security

--- a/docs/taint-analysis.md
+++ b/docs/taint-analysis.md
@@ -66,8 +66,8 @@ and (b) rules must match the framework's *actual* code shapes (destructured
 **Don't replace the LLM — put a deterministic floor beneath it.**
 
 - **Semgrep taint/sink rules** handle the *mechanical* source→sink injections
-  (SQLi/XSS/SSRF/path-traversal/command-injection) on the stacks we've
-  catalogued: deterministic, cheap, same every run.
+  (SQLi/XSS/SSRF/path-traversal/command-injection, plus SSTI on Python) on the
+  stacks we've catalogued: deterministic, cheap, same every run.
 - **The LLM code reviewer** keeps doing what only it can: business-logic flaws,
   the long tail of libraries we haven't written rules for, and nuanced cases.
 


### PR DESCRIPTION
A consistency sweep of the taint docs (after #4/#92/#93/#94) found three narrative surfaces still describing the analyzer as JS/TS-only, while the authoritative surfaces (scanner page class lists, README scanner row, architecture, benchmark results) were already correct:

- **README "How We Compare" row** → "JS/TS and Python injection taint".
- **docs/scanners/README.md index entry** → add Python + SSTI to the class list.
- **taint-analysis.md design capability line** → note SSTI (Python).

Docs-only, no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)