### PR TITLE
feat(sast): Java/Spring taint/injection rule pack for the Semgrep layer (#102)

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ isitsecure setup
 | `pip install -e ".[browser]"` | Adds DAST / live-URL scanning (requires `isitsecure setup` to install Chromium) |
 | `pip install -e ".[llm]"` | Adds LLM code review, triage, and AI fixes (requires an API key) |
 | `pip install -e ".[all]"` | Everything except `[taint]` (see below) |
-| `pip install -e ".[taint]"` | Deterministic Semgrep taint/injection SAST for JS/TS and Python. **Install separately** — semgrep's pinned dependencies don't co-resolve with `[all]`. The analyzer only needs the `semgrep` binary on PATH, so `pipx install semgrep` (or brew) works too; it falls back to LLM-only if absent |
+| `pip install -e ".[taint]"` | Deterministic Semgrep taint/injection SAST for JS/TS, Python, and Java. **Install separately** — semgrep's pinned dependencies don't co-resolve with `[all]`. The analyzer only needs the `semgrep` binary on PATH, so `pipx install semgrep` (or brew) works too; it falls back to LLM-only if absent |
 
 URL/DAST scanning needs the `[browser]` extra — without it, `isitsecure scan <url>` exits with a message telling you to install it.
 
@@ -225,7 +225,7 @@ The scan narrates each phase and every scanner as it runs (with elapsed time), s
 
 | Scanner | What It Finds |
 |---|---|
-| Semgrep Taint Analyzer | Deterministic source→sink injection for JS/TS and Python — SQLi, XSS, SSRF, path traversal, command injection, SSTI (a reproducible floor beneath the LLM reviewer; needs the `[taint]` extra, no-ops without the `semgrep` binary) |
+| Semgrep Taint Analyzer | Deterministic source→sink injection for JS/TS, Python, and Java — SQLi, XSS, SSRF, path traversal, command injection, SSTI (a reproducible floor beneath the LLM reviewer; needs the `[taint]` extra, no-ops without the `semgrep` binary) |
 | Git Secret Scanner | API keys, tokens, and credentials in git history (not just HEAD) |
 | Route Auth Analyzer | Next.js/Express/Django/FastAPI/Spring routes missing authentication |
 | RLS Policy Analyzer | Supabase tables without Row Level Security enabled |
@@ -369,7 +369,7 @@ isitsecure is not a replacement for enterprise security platforms. It's designed
 
 | Need | Best specialized tool | How isitsecure compares |
 |---|---|---|
-| Deep SAST (30+ languages) | [Semgrep](https://semgrep.dev) | We embed Semgrep for deterministic JS/TS and Python injection taint (opt-in `[taint]`) and add LLM review on top; Semgrep's own registry covers far more languages and rules |
+| Deep SAST (30+ languages) | [Semgrep](https://semgrep.dev) | We embed Semgrep for deterministic JS/TS, Python, and Java injection taint (opt-in `[taint]`) and add LLM review on top; Semgrep's own registry covers far more languages and rules |
 | DAST with advanced exploitation | [OWASP ZAP](https://zaproxy.org) / [Burp Suite](https://portswigger.net) | Our DAST is simpler — fewer payloads, no WAF evasion |
 | Secret scanning (800+ patterns) | [TruffleHog](https://github.com/trufflesecurity/trufflehog) / [Gitleaks](https://github.com/gitleaks/gitleaks) | Our git scanner covers common patterns, not exhaustive |
 | Container + IaC scanning | [Trivy](https://github.com/aquasecurity/trivy) / [Checkov](https://github.com/bridgecrewio/checkov) | Our IaC/Docker scanners are basic — use Trivy for depth |
@@ -390,7 +390,7 @@ isitsecure works well alongside other tools. Run `isitsecure scan` for the combi
 
 ## What It Does NOT Cover
 
-- **Inter-procedural taint analysis** — The opt-in Semgrep taint layer (`[taint]`) does intra-file source→sink dataflow for JS/TS and Python injection; cross-function/cross-file tracking (Semgrep Pro territory) still falls back to LLM reasoning
+- **Inter-procedural taint analysis** — The opt-in Semgrep taint layer (`[taint]`) does intra-file source→sink dataflow for JS/TS, Python, and Java injection; cross-function/cross-file tracking (Semgrep Pro territory) still falls back to LLM reasoning
 - **WAF evasion** — DAST payloads don't include advanced bypass techniques
 - **Compliance mapping** — No OWASP Top 10, CWE, or PCI-DSS tagging (yet)
 - **Network-level scanning** — No port scanning, TLS analysis, or infrastructure enumeration
@@ -624,7 +624,7 @@ python benchmarks/run_benchmarks.py sast-injection  # taint recall/FP (code-only
 python benchmarks/run_benchmarks.py --all       # + NodeGoat + crAPI + Juice Shop (heavy)
 ```
 
-Most targets spin the app up in Docker, run a DAST scan, score against a known ground truth, and tear it down (require Docker). The `sast-injection` target is **code-only** (no Docker) — it scores the deterministic Semgrep taint layer on a JS/TS + Python injection fixture (**27/27 recall, 0 FP**) and needs the `semgrep` binary instead; it's included in the default run. Measured results are tracked in [benchmarks/RESULTS.md](benchmarks/RESULTS.md); see [benchmarks/README.md](benchmarks/README.md) for targets and how scoring works.
+Most targets spin the app up in Docker, run a DAST scan, score against a known ground truth, and tear it down (require Docker). The `sast-injection` target is **code-only** (no Docker) — it scores the deterministic Semgrep taint layer on a JS/TS + Python + Java injection fixture (**37/37 recall, 0 FP**) and needs the `semgrep` binary instead; it's included in the default run. Measured results are tracked in [benchmarks/RESULTS.md](benchmarks/RESULTS.md); see [benchmarks/README.md](benchmarks/README.md) for targets and how scoring works.
 
 ## Privacy
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -84,16 +84,18 @@ python benchmarks/sast_injection.py findings.json    # score an existing code-on
 The fixtures **are** the ground truth (no separate file to drift):
 
 - `fixtures/sast-injection/vulnerable/*` — each sink line tagged with a trailing
-  `EXPECT <class>` marker (`//` for JS/TS, `#` for Python; classes: `sqli |
+  `EXPECT <class>` marker (`//` for JS/TS and Java, `#` for Python; classes: `sqli |
   reflected-xss | dom-xss | ssrf | path-traversal | command-injection | ssti`)
-  is a bug the taint layer must flag (recall). Covers **JS/TS (#4)** and
-  **Python (#93)**.
+  is a bug the taint layer must flag (recall). Covers **JS/TS (#4)**,
+  **Python (#93)**, and **Java/Spring (#102)**.
 - `fixtures/sast-injection/safe/*` — benign near-misses. JS: parameterized
   queries, constant-path writes, non-DB `.query()`, escaped output, fixed-URL
   fetch. Python: bound/parameterized queries (including request-derived values in
   the params tuple), a bare `text()` i18n alias, `subprocess` without
-  `shell=True`, constant-path `open()`, fixed-URL requests. Any injection finding
-  here — or on an unmarked line in a vulnerable file — is a **false positive**.
+  `shell=True`, constant-path `open()`, fixed-URL requests. Java:
+  `PreparedStatement`/bound `JdbcTemplate` queries, constant SQL, constant-path
+  `File`. Any injection finding here — or on an unmarked line in a vulnerable
+  file — is a **false positive**.
 
 The scorer (`sast_injection.py`) matches findings to expected bugs by file and
 line (±1, since Semgrep can report the statement head), reports per-class recall,

--- a/benchmarks/RESULTS.md
+++ b/benchmarks/RESULTS.md
@@ -18,28 +18,31 @@ _Runs: 2026-07 · `--llm none` (pure DAST detection, no LLM) · Juice Shop pinne
 | `vampi-vulnerable` | url-only | **3/3** (SQLi, IDOR, headers) | — | 14–16 |
 | `vampi-secure` | url-only | — | **2** (IDOR) | 13–15 |
 | `nodegoat-auth` | authenticated | **2/3** (headers, XSS; injection missed) | unmeasured | 28 |
-| `sast-injection` | code-only | **27/27 (100%)** — taint, per-class, deterministic | **0** | 27 |
+| `sast-injection` | code-only | **37/37 (100%)** — taint, per-class, deterministic | **0** | 37 |
 
-### SAST injection (`sast-injection`, code-only, taint layer #4 + #93)
+### SAST injection (`sast-injection`, code-only, taint layer #4 + #93 + #102)
 
 The deterministic Semgrep taint layer scored on an independent injection fixture
-(not `test-app`, which the JS rules were tuned on) covering **JS/TS (#4)** and
-**Python (#93)**. Recall **27/27** with **0 false positives** across all classes,
-deterministic across runs:
+(not `test-app`, which the JS rules were tuned on) covering **JS/TS (#4)**,
+**Python (#93)**, and **Java/Spring (#102)**. Recall **37/37** with **0 false
+positives** across all classes, deterministic across runs:
 
-| Class | JS/TS | Python | Class | JS/TS | Python |
-|---|--:|--:|---|--:|--:|
-| sqli | 5/5 | 7/7 | path-traversal | 1/1 | 2/2 |
-| reflected-xss | 2/2 | — | command-injection | 1/1 | 3/3 |
-| dom-xss | 2/2 | — | ssti | — | 1/1 |
-| ssrf | 1/1 | 2/2 | | | |
+| Class | JS/TS | Python | Java | Class | JS/TS | Python | Java |
+|---|--:|--:|--:|---|--:|--:|--:|
+| sqli | 5/5 | 7/7 | 5/5 | path-traversal | 1/1 | 2/2 | 1/1 |
+| reflected-xss | 2/2 | — | — | command-injection | 1/1 | 3/3 | 2/2 |
+| dom-xss | 2/2 | — | — | ssti | — | 1/1 | — |
+| ssrf | 1/1 | 2/2 | 2/2 | | | | |
 
-The FP side is exercised by benign near-misses in both languages — parameterized
+The FP side is exercised by benign near-misses in each language — parameterized
 queries, constant-path writes, non-DB `.query()`, escaped output, fixed-URL
 fetch (JS); parameterized/bound queries (including request-derived values in the
 params tuple), a bare `text()` i18n alias, `subprocess` without `shell=True`,
-constant-path `open()`, fixed-URL requests (Python) — none flagged. Cross-checked
-against isitsecure's own 164 Python files (which contain real `subprocess`,
+constant-path `open()`, fixed-URL requests (Python); `PreparedStatement`/bound
+`JdbcTemplate` queries, constant SQL, constant-path `File` (Java) — none flagged.
+Cross-checked against the real, non-vulnerable **spring-petclinic** (30 Java
+files, 10 `@RequestParam`/`@PathVariable`, 8 query/File/exec call sites): **0 FP**;
+and isitsecure's own 164 Python files (which contain real `subprocess`,
 `requests`/`httpx`, and `open()` call sites): **0 false positives**. This is the
 baseline the taint layer and future rule packs must hold.
 

--- a/benchmarks/fixtures/sast-injection/safe/SafeController.java
+++ b/benchmarks/fixtures/sast-injection/safe/SafeController.java
@@ -1,0 +1,40 @@
+// Injection benchmark fixture — Java SAFE / benign near-misses.
+// NOTHING here may be flagged — this is the false-positive side for Java.
+package com.example.safe;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import javax.servlet.http.HttpServletRequest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.web.bind.annotation.RequestParam;
+
+public class SafeController {
+    Connection conn;
+    JdbcTemplate jdbc;
+
+    // SAFE: PreparedStatement with a bind parameter (not string-built)
+    public void search(HttpServletRequest request) throws SQLException {
+        String name = request.getParameter("name");
+        PreparedStatement ps = conn.prepareStatement("SELECT * FROM users WHERE name = ?");
+        ps.setString(1, name);
+        ps.executeQuery();
+    }
+
+    // SAFE: JdbcTemplate with a ? placeholder + args (parameterized)
+    public void byRole(@RequestParam String role) {
+        jdbc.queryForList("SELECT * FROM users WHERE role = ?", role);
+    }
+
+    // SAFE: a constant SQL string (no user input)
+    public void all() throws SQLException {
+        conn.createStatement().executeQuery("SELECT * FROM users");
+    }
+
+    // SAFE: constant-path file read (not user-derived)
+    public void config() throws Exception {
+        new FileInputStream(new File("/etc/app/config.yaml"));
+    }
+}

--- a/benchmarks/fixtures/sast-injection/vulnerable/InjectionController.java
+++ b/benchmarks/fixtures/sast-injection/vulnerable/InjectionController.java
@@ -1,0 +1,43 @@
+// Injection benchmark fixture — Java command injection, SSRF, path traversal
+// (VULNERABLE). Sources: Spring @RequestParam / HttpServletRequest.
+package com.example.vuln;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.net.URL;
+import javax.servlet.http.HttpServletRequest;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.client.RestTemplate;
+
+public class InjectionController {
+    RestTemplate rest;
+
+    // --- Command injection ---
+    public void ping(HttpServletRequest request) throws Exception {
+        String host = request.getParameter("host");
+        Runtime.getRuntime().exec("ping -c 1 " + host); // EXPECT command-injection
+    }
+
+    @GetMapping("/run")
+    public void run(@RequestParam String cmd) throws Exception {
+        new ProcessBuilder("sh", "-c", cmd).start(); // EXPECT command-injection
+    }
+
+    // --- SSRF ---
+    @GetMapping("/fetch")
+    public void fetch(@RequestParam String url) throws Exception {
+        new URL(url).openConnection().getInputStream(); // EXPECT ssrf
+    }
+
+    @GetMapping("/proxy")
+    public String proxy(@RequestParam String target) {
+        return rest.getForObject(target, String.class); // EXPECT ssrf
+    }
+
+    // --- Path traversal ---
+    @GetMapping("/read")
+    public void read(@RequestParam String name) throws Exception {
+        new FileInputStream(new File("/data/" + name)); // EXPECT path-traversal
+    }
+}

--- a/benchmarks/fixtures/sast-injection/vulnerable/SqliController.java
+++ b/benchmarks/fixtures/sast-injection/vulnerable/SqliController.java
@@ -1,0 +1,51 @@
+// Injection benchmark fixture — Java SQL injection (VULNERABLE).
+// Each trailing marker on a sink line is a bug the taint layer must flag.
+// Stack shapes: JDBC Statement, JPA EntityManager, Spring JdbcTemplate.
+package com.example.vuln;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Statement;
+import javax.persistence.EntityManager;
+import javax.servlet.http.HttpServletRequest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+public class SqliController {
+    Connection conn;
+    EntityManager em;
+    JdbcTemplate jdbc;
+
+    // JDBC Statement with string concatenation
+    public void search(HttpServletRequest request) throws SQLException {
+        String name = request.getParameter("name");
+        Statement stmt = conn.createStatement();
+        stmt.executeQuery("SELECT * FROM users WHERE name = '" + name + "'"); // EXPECT sqli
+    }
+
+    // executeUpdate built from a request param
+    @GetMapping("/del")
+    public void del(@RequestParam String id) throws SQLException {
+        Statement stmt = conn.createStatement();
+        stmt.executeUpdate("DELETE FROM users WHERE id = " + id); // EXPECT sqli
+    }
+
+    // JPA native query with concatenation
+    public void jpa(@RequestParam String email) {
+        em.createNativeQuery("SELECT * FROM users WHERE email = '" + email + "'"); // EXPECT sqli
+    }
+
+    // Spring JdbcTemplate with concatenation
+    public void jdbcQuery(@RequestParam String role) {
+        jdbc.queryForList("SELECT * FROM users WHERE role = '" + role + "'"); // EXPECT sqli
+    }
+
+    // PreparedStatement built by concatenation is still injectable
+    public void prepared(@RequestParam String user) throws SQLException {
+        PreparedStatement ps = conn.prepareStatement(
+            "SELECT * FROM users WHERE u = '" + user + "'"); // EXPECT sqli
+        ps.executeQuery();
+    }
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -99,7 +99,7 @@ The repository is cloned (shallow, to temp dir) and indexed:
    - `GraphQLRouteMapper`: schema definitions → query/mutation types
 4. **File indexing** — reads all source files into memory (filtered by extension, size limit, skip `node_modules`)
 
-18 SAST scanners then run in parallel against the indexed codebase (plus the LLM-powered Semantic Rule Verifier when an API key is available). One of them, the **Semgrep Taint Analyzer** (`semgrep_taint`), is a deterministic source→sink injection floor for JS/TS and Python that sits beneath the LLM code reviewer: it catches the mechanical SQLi/XSS/SSRF/path-traversal/command-injection/SSTI cases reproducibly and for free, leaving the LLM to cover business logic and uncatalogued libraries. It is opt-in (`[taint]` extra) and no-ops if the `semgrep` binary is absent.
+18 SAST scanners then run in parallel against the indexed codebase (plus the LLM-powered Semantic Rule Verifier when an API key is available). One of them, the **Semgrep Taint Analyzer** (`semgrep_taint`), is a deterministic source→sink injection floor for JS/TS, Python, and Java that sits beneath the LLM code reviewer: it catches the mechanical SQLi/XSS/SSRF/path-traversal/command-injection/SSTI cases reproducibly and for free, leaving the LLM to cover business logic and uncatalogued libraries. It is opt-in (`[taint]` extra) and no-ops if the `semgrep` binary is absent.
 
 ### Phase 7.5: LSP Validation
 

--- a/docs/scanners/README.md
+++ b/docs/scanners/README.md
@@ -38,7 +38,7 @@ These scanners require authentication or use specialized techniques.
 
 These scanners analyze your source code without running it.
 
-- [Semgrep Taint Analyzer](./semgrep-taint.md) — Deterministic source→sink injection for JS/TS and Python (SQLi, XSS, SSRF, path traversal, command injection, SSTI)
+- [Semgrep Taint Analyzer](./semgrep-taint.md) — Deterministic source→sink injection for JS/TS, Python, and Java (SQLi, XSS, SSRF, path traversal, command injection, SSTI)
 - [Git Secret Scanner](./git-secret-scanner.md) — Secrets in git history
 - [Route Auth Analyzer](./route-auth-analyzer.md) — Routes missing authentication
 - [RLS Policy Analyzer](./rls-policy-analyzer.md) — Missing Supabase Row Level Security

--- a/docs/scanners/semgrep-taint.md
+++ b/docs/scanners/semgrep-taint.md
@@ -6,7 +6,7 @@
 
 Runs [Semgrep](https://semgrep.dev) with isitsecure's own taint/sink rule packs over your cloned repo and maps the results to findings. It is a **deterministic injection floor beneath the LLM code reviewer**: the same input always produces the same findings, instantly and at no token cost.
 
-Two rule packs ship today — **JavaScript/TypeScript** (`semgrep_rules/injection-js.yaml`, #4) and **Python** (`semgrep_rules/injection-python.yaml`, #93). The analyzer **auto-selects the packs whose languages are present in the repo** (#94): a JS-only repo runs only the JS pack, a Python-only repo only the Python pack, a mixed repo both. (Semgrep also scopes each rule to its declared language, so selection is about not loading irrelevant rules — faster, and ready for per-framework packs later.)
+Three rule packs ship today — **JavaScript/TypeScript** (`injection-js.yaml`, #4), **Python** (`injection-python.yaml`, #93), and **Java/Spring** (`injection-java.yaml`, #102). The analyzer **auto-selects the packs whose languages are present in the repo** (#94): a JS-only repo runs only the JS pack, a mixed repo the relevant ones. (Semgrep also scopes each rule to its declared language, so selection is about not loading irrelevant rules — faster, and ready for per-framework packs later.)
 
 **JavaScript/TypeScript** — six classes:
 
@@ -25,7 +25,14 @@ Two rule packs ship today — **JavaScript/TypeScript** (`semgrep_rules/injectio
 4. **Path traversal** — request-derived path → `open(...)`.
 5. **SSTI** — request input → `render_template_string(...)`.
 
-Rules target **framework/library APIs** (Next.js `searchParams`, Express `req.*`, the `postgres`/Prisma/Drizzle/Knex sinks, Node `fs`; Flask/Django `request.*`, DB-API/SQLAlchemy/Django ORM, `os`/`subprocess`, `requests`/`urllib`, Jinja), so they apply to **any app on those stacks — not per-app**. Apps on an uncatalogued library fall through to the LLM backstop.
+**Java** (Spring MVC / servlet request sources: `@RequestParam`/`@PathVariable`/`@RequestHeader` params, `HttpServletRequest.getParameter`/`getHeader`) — four classes:
+
+1. **SQL injection** — string-concatenated queries in JDBC `Statement.execute*`, JPA `EntityManager.createQuery`/`createNativeQuery`, Spring `JdbcTemplate.query*`/`update`, plus a taint rule focused on the query-string argument (bound parameters are safe).
+2. **Command injection** — request input → `Runtime.getRuntime().exec(...)` / `new ProcessBuilder(...)`.
+3. **SSRF** — request input → `new URL(...)` / `RestTemplate.getForObject`/`getForEntity`/`exchange`.
+4. **Path traversal** — request-derived path → `new File(...)` / `new FileInputStream(...)` / `new FileReader(...)`.
+
+Rules target **framework/library APIs** (Next.js `searchParams`, Express `req.*`, the `postgres`/Prisma/Drizzle/Knex sinks, Node `fs`; Flask/Django `request.*`, DB-API/SQLAlchemy/Django ORM, `os`/`subprocess`, `requests`/`urllib`, Jinja; Spring `@RequestParam`/`HttpServletRequest`, JDBC/JPA/JdbcTemplate, `Runtime`/`ProcessBuilder`, `URL`/`RestTemplate`, `java.io.File`), so they apply to **any app on those stacks — not per-app**. Apps on an uncatalogued library fall through to the LLM backstop.
 
 Findings are emitted with `scanner_name = "semgrep_taint"`, `confidence = 0.85`, and category `injection_risk`, then flow through the same triage → dedup → plain-English → grading pipeline as every other scanner.
 
@@ -41,14 +48,14 @@ It is **best-effort and self-contained**:
 
 - If the `semgrep` binary isn't installed, the analyzer **no-ops and returns nothing** — the LLM layer still runs, exactly as before.
 - A crash or timeout in Semgrep **never fails the scan**; it logs and returns no findings. The subprocess is always killed and reaped (never orphaned), even if the overall scan is cancelled.
-- It only runs when the repo contains JS/TS or Python files.
+- It only runs when the repo contains JS/TS, Python, or Java files.
 - No network: the rule packs ship with isitsecure; Semgrep runs with `--metrics off`.
 
 ## Why It Matters
 
 Before this analyzer, injection detection (SQLi/XSS/SSRF/path-traversal/command-injection) rested **entirely on the LLM**, which is non-deterministic (finding counts wobble run-to-run), costs tokens, and is slow. The Semgrep layer gives a reproducible, instant, free floor for the mechanical source→sink cases, while the LLM keeps covering business-logic flaws and the long tail of libraries without rules.
 
-See [docs/taint-analysis.md](../taint-analysis.md) for the full design rationale, the spike results, and the per-stack rule model. The layer has its own recall/FP scorecard — **27/27 recall, 0 false positives** on an independent JS/TS + Python injection fixture — via `python benchmarks/run_benchmarks.py sast-injection` (see [benchmarks/RESULTS.md](../../benchmarks/RESULTS.md)).
+See [docs/taint-analysis.md](../taint-analysis.md) for the full design rationale, the spike results, and the per-stack rule model. The layer has its own recall/FP scorecard — **37/37 recall, 0 false positives** on an independent JS/TS + Python + Java injection fixture — via `python benchmarks/run_benchmarks.py sast-injection` (see [benchmarks/RESULTS.md](../../benchmarks/RESULTS.md)).
 
 ## What Vulnerable Code Looks Like
 
@@ -70,10 +77,11 @@ const rows = await sql`SELECT * FROM users WHERE id = ${id}`;
 ## Limitations
 
 - **Intra-file only.** OSS Semgrep taint tracks dataflow within a single file. A route that hands user input to a helper in another file which then reaches a sink (inter-procedural) is not tracked — that path falls back to the LLM reviewer. (Inter-file taint is Semgrep Pro territory.)
-- **JS/TS and Python today.** Other stacks (Go, Ruby, Java, …) are future rule-pack work; those apps rely on the LLM layer meanwhile. Python reflected/stored XSS (template-autoescaping nuance) is also not yet covered.
-- **Python taint sources are Flask/Django** (`request.*`). FastAPI endpoint parameters aren't yet tracked as sources, so FastAPI command-injection/SSRF/path/SSTI fall to the LLM layer — though string-built SQL (the pattern rule) is still caught on any stack.
+- **JS/TS, Python, and Java today.** Other stacks (Go, Ruby, …) are future rule-pack work; those apps rely on the LLM layer meanwhile. Python and Java server-side XSS (template-autoescaping nuance) is not yet covered.
+- **Python taint sources are Flask/Django** (`request.*`); FastAPI endpoint parameters aren't yet tracked, so FastAPI command-injection/SSRF/path/SSTI fall to the LLM layer (string-built SQL is still caught on any stack).
+- **Java taint sources are Spring MVC / servlet** (`@RequestParam`/`@PathVariable`/`getParameter`); other Java web frameworks (JAX-RS, `@RequestBody` fields, etc.) fall to the LLM layer. String-concatenated SQL on the unambiguous DB verbs (`executeQuery`/`executeUpdate`/`prepareStatement`/`createNativeQuery`/`queryFor*`) is still caught source-free; the generic verbs (`execute`/`createQuery`/`update`) need a recognized Spring source to fire.
 - **Per-stack rules.** Sinks for libraries we haven't catalogued won't fire deterministically (again, the LLM backstops them).
 
 ## Configuration
 
-No configuration. The analyzer auto-runs on any code-only/full scan when the `semgrep` binary is available and the repo has files a rule pack covers (JS/TS or Python) — selecting the matching packs automatically. The rule packs live in `isitsecure/engine/code_analysis/semgrep_rules/`; register a new one in `_RULE_PACKS` in `semgrep_analyzer.py`.
+No configuration. The analyzer auto-runs on any code-only/full scan when the `semgrep` binary is available and the repo has files a rule pack covers (JS/TS, Python, or Java) — selecting the matching packs automatically. The rule packs live in `isitsecure/engine/code_analysis/semgrep_rules/`; register a new one in `_RULE_PACKS` in `semgrep_analyzer.py`.

--- a/docs/taint-analysis.md
+++ b/docs/taint-analysis.md
@@ -166,7 +166,7 @@ Note: the original benchmark was DAST-oriented, so this work added a **SAST
 injection benchmark** — a fixture set with known source→sink bugs giving the taint
 layer its own recall/FP scorecard. **Delivered** (#92): `benchmarks/sast_injection.py`
 + `benchmarks/fixtures/sast-injection/`, run via `python benchmarks/run_benchmarks.py
-sast-injection`. Baseline **27/27 recall, 0 FP** across JS/TS + Python ([benchmarks/RESULTS.md](../benchmarks/RESULTS.md)).
+sast-injection`. Baseline **37/37 recall, 0 FP** across JS/TS, Python, and Java ([benchmarks/RESULTS.md](../benchmarks/RESULTS.md)).
 
 ## Risks & open questions
 
@@ -177,18 +177,19 @@ sast-injection`. Baseline **27/27 recall, 0 FP** across JS/TS + Python ([benchma
 - **Binary dependency** — bundling/pinning Semgrep; graceful fallback when absent.
 - **Semgrep licensing** — OSS engine + our own rules are fine; confirm no
   reliance on registry rules with restrictive terms (we ship our own packs).
-- **Language coverage** — JS/TS (#4) and Python/Flask/Django (#93) ship today;
-  other stacks (Go, Ruby, Java) are future packs.
+- **Language coverage** — JS/TS (#4), Python/Flask/Django (#93), and Java/Spring
+  (#102) ship today; other stacks (Go, Ruby, …) are future packs.
 
 ## Phasing
 
 1. ✅ **SAST injection benchmark fixtures** + a recall/FP harness (#92) — the
-   `sast-injection` target, baseline 27/27 recall / 0 FP (JS/TS + Python).
+   `sast-injection` target, baseline 37/37 recall / 0 FP (JS/TS, Python, Java).
 2. ✅ **`SemgrepAnalyzer`** (subprocess → parse → `CodeFinding`) with a first rule
    pack for the top stack (Next.js/Express + postgres/Prisma/Drizzle + DOM) — #4.
 3. ✅ **Benchmark**: proved it adds recall without FP vs. LLM-only. Shipped in #4.
 4. 🚧 **Broaden rule packs** iteratively, each gated by the benchmark — #93 adds
-   the **Python** pack (Flask/Django sources; DB-API/SQLAlchemy/Django ORM, os/
-   subprocess, requests/urllib, Jinja sinks; SQLi/cmdi/SSRF/path/SSTI). Further
-   stacks/libraries continue here.
+   the **Python** pack (Flask/Django; DB-API/SQLAlchemy/Django ORM, os/subprocess,
+   requests/urllib, Jinja; SQLi/cmdi/SSRF/path/SSTI); #102 adds the **Java/Spring**
+   pack (Spring MVC/servlet sources; JDBC/JPA/JdbcTemplate, Runtime/ProcessBuilder,
+   URL/RestTemplate, java.io.File; SQLi/cmdi/SSRF/path). Further stacks continue here.
 5. **Keep the LLM layer** as the long-tail + business-logic backstop throughout.

--- a/isitsecure/engine/code_analysis/semgrep_analyzer.py
+++ b/isitsecure/engine/code_analysis/semgrep_analyzer.py
@@ -53,6 +53,7 @@ _RULE_PACKS: tuple[_RulePack, ...] = (
     _RulePack("javascript/typescript", "injection-js.yaml",
               (".js", ".jsx", ".ts", ".tsx", ".mjs", ".cjs")),
     _RulePack("python", "injection-python.yaml", (".py",)),
+    _RulePack("java", "injection-java.yaml", (".java",)),
 )
 
 # Dirs semgrep ignores by default; skipping them bounds the language-detection

--- a/isitsecure/engine/code_analysis/semgrep_rules/injection-java.yaml
+++ b/isitsecure/engine/code_analysis/semgrep_rules/injection-java.yaml
@@ -1,0 +1,111 @@
+# isitsecure taint/sink rules for Java injection (#102).
+# Rules target FRAMEWORK/LIBRARY APIs (Spring MVC request params / servlet
+# request as sources; JDBC/JPA/JdbcTemplate, Runtime/ProcessBuilder, URL/
+# RestTemplate, File/FileInputStream as sinks) — they apply to any app on these
+# stacks, not to a specific app.
+rules:
+  # ---- SQL injection: dangerous query construction (pattern) ----
+  - id: isitsecure-java-sqli
+    languages: [java]
+    severity: ERROR
+    metadata: {category: injection_risk, isitsecure-severity: critical}
+    message: "Raw SQL built from string concatenation — SQL injection. Use a parameterized query."
+    # Only DB-specific verbs are matched without a source. Generic verbs
+    # (execute/createQuery/update — common on non-SQL objects like HTTP/audit/
+    # cache/search clients) are left to the source-gated taint rule below, so
+    # `audit.update("event=" + id)` isn't a false alarm.
+    patterns:
+      - pattern-either:
+          - pattern: $S.executeQuery("..." + ...)
+          - pattern: $S.executeUpdate("..." + ...)
+          - pattern: $C.prepareStatement("..." + ...)
+          - pattern: $E.createNativeQuery("..." + ...)
+          - pattern: $J.queryForList("..." + ...)
+          - pattern: $J.queryForObject("..." + ...)
+          - pattern: $J.queryForMap("..." + ...)
+
+  # ---- SQL injection: user input → query STRING (intra-file taint) ----
+  # Focuses on the query-string argument, so a bound parameter (a request value
+  # passed as the args, not concatenated into the SQL) is NOT flagged.
+  - id: isitsecure-java-sqli-taint
+    mode: taint
+    languages: [java]
+    severity: ERROR
+    metadata: {category: injection_risk, isitsecure-severity: critical}
+    message: "User input flows into a raw SQL query — SQL injection."
+    pattern-sources: &java_sources
+      # Servlet request accessors (method-call sources)
+      - pattern: $REQ.getParameter(...)
+      - pattern: $REQ.getParameterValues(...)
+      - pattern: $REQ.getHeader(...)
+      - pattern: $REQ.getQueryString()
+      # Spring controller params — the annotated method parameter is the source.
+      # Matching the method and focusing the param is the correct idiom; a bare
+      # `(@RequestParam String $X)` pattern spuriously taints everything.
+      - patterns:
+          - pattern-inside: "$R $M(..., @RequestParam $T $P, ...) {...}"
+          - focus-metavariable: $P
+      - patterns:
+          - pattern-inside: "$R $M(..., @RequestParam(...) $T $P, ...) {...}"
+          - focus-metavariable: $P
+      - patterns:
+          - pattern-inside: "$R $M(..., @PathVariable $T $P, ...) {...}"
+          - focus-metavariable: $P
+      - patterns:
+          - pattern-inside: "$R $M(..., @PathVariable(...) $T $P, ...) {...}"
+          - focus-metavariable: $P
+      - patterns:
+          - pattern-inside: "$R $M(..., @RequestHeader $T $P, ...) {...}"
+          - focus-metavariable: $P
+    pattern-sinks:
+      - patterns:
+          - pattern-either:
+              - pattern: $S.executeQuery($Q)
+              - pattern: $S.executeUpdate($Q)
+              - pattern: $S.execute($Q)
+              - pattern: $C.prepareStatement($Q)
+              - pattern: $E.createNativeQuery($Q)
+              - pattern: $E.createQuery($Q)
+              - pattern: $J.queryForList($Q, ...)
+              - pattern: $J.queryForObject($Q, ...)
+              - pattern: $J.update($Q, ...)
+          - focus-metavariable: $Q
+
+  # ---- Command injection: user input → shell ----
+  - id: isitsecure-java-command-injection
+    mode: taint
+    languages: [java]
+    severity: ERROR
+    metadata: {category: injection_risk, isitsecure-severity: critical}
+    message: "User input flows into a shell command — command injection."
+    pattern-sources: *java_sources
+    pattern-sinks:
+      - pattern: Runtime.getRuntime().exec(...)
+      - pattern: new ProcessBuilder(...)
+
+  # ---- SSRF: user-controlled URL → outbound request ----
+  - id: isitsecure-java-ssrf
+    mode: taint
+    languages: [java]
+    severity: ERROR
+    metadata: {category: injection_risk, isitsecure-severity: high}
+    message: "User-controlled URL flows into an outbound request — SSRF."
+    pattern-sources: *java_sources
+    pattern-sinks:
+      - pattern: new URL(...)
+      - pattern: $R.getForObject(...)
+      - pattern: $R.getForEntity(...)
+      - pattern: $R.exchange(...)
+
+  # ---- Path traversal: request-derived path → file access ----
+  - id: isitsecure-java-path-traversal
+    mode: taint
+    languages: [java]
+    severity: WARNING
+    metadata: {category: injection_risk, isitsecure-severity: high}
+    message: "File accessed with a request-derived path — path traversal."
+    pattern-sources: *java_sources
+    pattern-sinks:
+      - pattern: new File(...)
+      - pattern: new FileInputStream(...)
+      - pattern: new FileReader(...)

--- a/tests/benchmarks/test_sast_injection_scorer.py
+++ b/tests/benchmarks/test_sast_injection_scorer.py
@@ -47,10 +47,11 @@ class TestGroundTruth:
         assert len(bugs) >= 25  # JS/TS + Python across 7 classes
         assert {b["class"] for b in bugs} == set(si.CLASSES)
 
-    def test_python_and_js_fixtures_both_present(self):
+    def test_all_language_fixtures_present(self):
         files = {b["file"] for b in si.expected_bugs()}
-        assert any(f.endswith(".py") for f in files)   # Python (#93)
-        assert any(f.endswith(".ts") for f in files)   # JS/TS (#4)
+        assert any(f.endswith(".ts") for f in files)     # JS/TS (#4)
+        assert any(f.endswith(".py") for f in files)     # Python (#93)
+        assert any(f.endswith(".java") for f in files)   # Java (#102)
 
     def test_marker_regex_accepts_both_comment_styles(self):
         assert si.EXPECT_RE.search("foo()  // EXPECT sqli").group(1) == "sqli"

--- a/tests/engine/test_semgrep_analyzer.py
+++ b/tests/engine/test_semgrep_analyzer.py
@@ -133,9 +133,15 @@ class TestPackSelection:
         packs = SemgrepAnalyzer()._select_packs(_disk_snapshot(tmp_path, ["app/x.py"]))
         assert [p.name for p in packs] == ["injection-python.yaml"]
 
-    def test_mixed_repo_gets_both(self, tmp_path):
-        packs = SemgrepAnalyzer()._select_packs(_disk_snapshot(tmp_path, ["a.ts", "b.py"]))
-        assert {p.name for p in packs} == {"injection-js.yaml", "injection-python.yaml"}
+    def test_java_only(self, tmp_path):
+        packs = SemgrepAnalyzer()._select_packs(_disk_snapshot(tmp_path, ["src/App.java"]))
+        assert [p.name for p in packs] == ["injection-java.yaml"]
+
+    def test_mixed_repo_gets_all_present(self, tmp_path):
+        packs = SemgrepAnalyzer()._select_packs(
+            _disk_snapshot(tmp_path, ["a.ts", "b.py", "C.java"]))
+        assert {p.name for p in packs} == {
+            "injection-js.yaml", "injection-python.yaml", "injection-java.yaml"}
 
     def test_unsupported_language_gets_nothing(self, tmp_path):
         packs = SemgrepAnalyzer()._select_packs(_disk_snapshot(tmp_path, ["main.go", "README.md"]))


### PR DESCRIPTION
Closes #102. Broadens the deterministic Semgrep taint floor beyond JS/TS (#4) and Python (#93) to **Java/Spring**, gated by the SAST injection benchmark (#92).

## What's in it
- **`injection-java.yaml`** — SQLi, command-injection, SSRF, path-traversal. Sources are Spring MVC / servlet (`@RequestParam`/`@PathVariable`/`@RequestHeader` params via `pattern-inside` + `focus-metavariable`; `HttpServletRequest.getParameter`/`getHeader`).
  - **SQLi** is pattern-based for *unambiguous* DB verbs (`executeQuery`/`executeUpdate`/`prepareStatement`/`createNativeQuery`/`queryFor*`) **plus** a taint rule whose sink **focuses on the query-string argument** — so build-then-execute is caught while bound parameters (JdbcTemplate query with args, `PreparedStatement.setString`) are not flagged.
- **`_RULE_PACKS`** registers the Java pack (`.java`). No new scanner — still `semgrep_taint`, still opt-in `[taint]`; **SAST count stays 18**.

## Benchmark
**37/37 recall, 0 FP** across JS/TS + Python + Java (Java: sqli 5, cmdi 2, ssrf 2, path 1). Cross-checked on the real, non-vulnerable **spring-petclinic** (30 files, 10 `@RequestParam`/`@PathVariable`, 8 query/File/exec call sites): **0 FP**.

## Adversarial review → fixed
Code review found (and semgrep-verified) a **critical FP**: the source-less SQLi rule matched generic verbs (`execute`/`createQuery`/`update`) on *any* receiver — `audit.update("event=" + id)`, `client.execute("GET " + path)` fired as critical SQLi. Fixed by keeping only unambiguous DB verbs source-free; the generic verbs stay in the source-gated taint rule (adversarial FP snippets → 0, no recall loss). Review also found **concatenated `prepareStatement` was missed** (the most common real Java SQLi shape) → added it to both rules + a fixture. Docs scoped honestly to Spring MVC (JAX-RS/`@RequestBody` noted as gaps).

The `@RequestParam`-as-source idiom needs `pattern-inside` + `focus-metavariable`; the naive `(@RequestParam String $X)` form silently taints *everything* (caught before the benchmark).

## Known v1 gaps (documented)
Spring MVC sources only (JAX-RS/`@RequestBody` → LLM layer); intra-file taint only; Java server-side XSS (template autoescaping) not covered.

## Verification
84 tests pass; ruff clean; all three packs ship in the wheel; `python benchmarks/run_benchmarks.py sast-injection` → 37/37, 0 FP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)