### PR TITLE
feat(sast): Kotlin/Spring taint/injection rule pack for the Semgrep layer (#104)

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ isitsecure setup
 | `pip install -e ".[browser]"` | Adds DAST / live-URL scanning (requires `isitsecure setup` to install Chromium) |
 | `pip install -e ".[llm]"` | Adds LLM code review, triage, and AI fixes (requires an API key) |
 | `pip install -e ".[all]"` | Everything except `[taint]` (see below) |
-| `pip install -e ".[taint]"` | Deterministic Semgrep taint/injection SAST for JS/TS, Python, and Java. **Install separately** — semgrep's pinned dependencies don't co-resolve with `[all]`. The analyzer only needs the `semgrep` binary on PATH, so `pipx install semgrep` (or brew) works too; it falls back to LLM-only if absent |
+| `pip install -e ".[taint]"` | Deterministic Semgrep taint/injection SAST for JS/TS, Python, Java, and Kotlin. **Install separately** — semgrep's pinned dependencies don't co-resolve with `[all]`. The analyzer only needs the `semgrep` binary on PATH, so `pipx install semgrep` (or brew) works too; it falls back to LLM-only if absent |
 
 URL/DAST scanning needs the `[browser]` extra — without it, `isitsecure scan <url>` exits with a message telling you to install it.
 
@@ -225,7 +225,7 @@ The scan narrates each phase and every scanner as it runs (with elapsed time), s
 
 | Scanner | What It Finds |
 |---|---|
-| Semgrep Taint Analyzer | Deterministic source→sink injection for JS/TS, Python, and Java — SQLi, XSS, SSRF, path traversal, command injection, SSTI (a reproducible floor beneath the LLM reviewer; needs the `[taint]` extra, no-ops without the `semgrep` binary) |
+| Semgrep Taint Analyzer | Deterministic source→sink injection for JS/TS, Python, Java, and Kotlin — SQLi, XSS, SSRF, path traversal, command injection, SSTI (a reproducible floor beneath the LLM reviewer; needs the `[taint]` extra, no-ops without the `semgrep` binary) |
 | Git Secret Scanner | API keys, tokens, and credentials in git history (not just HEAD) |
 | Route Auth Analyzer | Next.js/Express/Django/FastAPI/Spring routes missing authentication |
 | RLS Policy Analyzer | Supabase tables without Row Level Security enabled |
@@ -369,7 +369,7 @@ isitsecure is not a replacement for enterprise security platforms. It's designed
 
 | Need | Best specialized tool | How isitsecure compares |
 |---|---|---|
-| Deep SAST (30+ languages) | [Semgrep](https://semgrep.dev) | We embed Semgrep for deterministic JS/TS, Python, and Java injection taint (opt-in `[taint]`) and add LLM review on top; Semgrep's own registry covers far more languages and rules |
+| Deep SAST (30+ languages) | [Semgrep](https://semgrep.dev) | We embed Semgrep for deterministic JS/TS, Python, Java, and Kotlin injection taint (opt-in `[taint]`) and add LLM review on top; Semgrep's own registry covers far more languages and rules |
 | DAST with advanced exploitation | [OWASP ZAP](https://zaproxy.org) / [Burp Suite](https://portswigger.net) | Our DAST is simpler — fewer payloads, no WAF evasion |
 | Secret scanning (800+ patterns) | [TruffleHog](https://github.com/trufflesecurity/trufflehog) / [Gitleaks](https://github.com/gitleaks/gitleaks) | Our git scanner covers common patterns, not exhaustive |
 | Container + IaC scanning | [Trivy](https://github.com/aquasecurity/trivy) / [Checkov](https://github.com/bridgecrewio/checkov) | Our IaC/Docker scanners are basic — use Trivy for depth |
@@ -390,7 +390,7 @@ isitsecure works well alongside other tools. Run `isitsecure scan` for the combi
 
 ## What It Does NOT Cover
 
-- **Inter-procedural taint analysis** — The opt-in Semgrep taint layer (`[taint]`) does intra-file source→sink dataflow for JS/TS, Python, and Java injection; cross-function/cross-file tracking (Semgrep Pro territory) still falls back to LLM reasoning
+- **Inter-procedural taint analysis** — The opt-in Semgrep taint layer (`[taint]`) does intra-file source→sink dataflow for JS/TS, Python, Java, and Kotlin injection; cross-function/cross-file tracking (Semgrep Pro territory) still falls back to LLM reasoning
 - **WAF evasion** — DAST payloads don't include advanced bypass techniques
 - **Compliance mapping** — No OWASP Top 10, CWE, or PCI-DSS tagging (yet)
 - **Network-level scanning** — No port scanning, TLS analysis, or infrastructure enumeration
@@ -624,7 +624,7 @@ python benchmarks/run_benchmarks.py sast-injection  # taint recall/FP (code-only
 python benchmarks/run_benchmarks.py --all       # + NodeGoat + crAPI + Juice Shop (heavy)
 ```
 
-Most targets spin the app up in Docker, run a DAST scan, score against a known ground truth, and tear it down (require Docker). The `sast-injection` target is **code-only** (no Docker) — it scores the deterministic Semgrep taint layer on a JS/TS + Python + Java injection fixture (**37/37 recall, 0 FP**) and needs the `semgrep` binary instead; it's included in the default run. Measured results are tracked in [benchmarks/RESULTS.md](benchmarks/RESULTS.md); see [benchmarks/README.md](benchmarks/README.md) for targets and how scoring works.
+Most targets spin the app up in Docker, run a DAST scan, score against a known ground truth, and tear it down (require Docker). The `sast-injection` target is **code-only** (no Docker) — it scores the deterministic Semgrep taint layer on a JS/TS + Python + Java + Kotlin injection fixture (**46/46 recall, 0 FP**) and needs the `semgrep` binary instead; it's included in the default run. Measured results are tracked in [benchmarks/RESULTS.md](benchmarks/RESULTS.md); see [benchmarks/README.md](benchmarks/README.md) for targets and how scoring works.
 
 ## Privacy
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -84,15 +84,16 @@ python benchmarks/sast_injection.py findings.json    # score an existing code-on
 The fixtures **are** the ground truth (no separate file to drift):
 
 - `fixtures/sast-injection/vulnerable/*` — each sink line tagged with a trailing
-  `EXPECT <class>` marker (`//` for JS/TS and Java, `#` for Python; classes: `sqli |
-  reflected-xss | dom-xss | ssrf | path-traversal | command-injection | ssti`)
-  is a bug the taint layer must flag (recall). Covers **JS/TS (#4)**,
-  **Python (#93)**, and **Java/Spring (#102)**.
+  `EXPECT <class>` marker (`//` for JS/TS, Java, and Kotlin; `#` for Python;
+  classes: `sqli | reflected-xss | dom-xss | ssrf | path-traversal |
+  command-injection | ssti`) is a bug the taint layer must flag (recall). Covers
+  **JS/TS (#4)**, **Python (#93)**, **Java/Spring (#102)**, and
+  **Kotlin/Spring (#104)**.
 - `fixtures/sast-injection/safe/*` — benign near-misses. JS: parameterized
   queries, constant-path writes, non-DB `.query()`, escaped output, fixed-URL
   fetch. Python: bound/parameterized queries (including request-derived values in
   the params tuple), a bare `text()` i18n alias, `subprocess` without
-  `shell=True`, constant-path `open()`, fixed-URL requests. Java:
+  `shell=True`, constant-path `open()`, fixed-URL requests. Java/Kotlin:
   `PreparedStatement`/bound `JdbcTemplate` queries, constant SQL, constant-path
   `File`. Any injection finding here — or on an unmarked line in a vulnerable
   file — is a **false positive**.

--- a/benchmarks/RESULTS.md
+++ b/benchmarks/RESULTS.md
@@ -18,33 +18,34 @@ _Runs: 2026-07 · `--llm none` (pure DAST detection, no LLM) · Juice Shop pinne
 | `vampi-vulnerable` | url-only | **3/3** (SQLi, IDOR, headers) | — | 14–16 |
 | `vampi-secure` | url-only | — | **2** (IDOR) | 13–15 |
 | `nodegoat-auth` | authenticated | **2/3** (headers, XSS; injection missed) | unmeasured | 28 |
-| `sast-injection` | code-only | **37/37 (100%)** — taint, per-class, deterministic | **0** | 37 |
+| `sast-injection` | code-only | **46/46 (100%)** — taint, per-class, deterministic | **0** | 46 |
 
-### SAST injection (`sast-injection`, code-only, taint layer #4 + #93 + #102)
+### SAST injection (`sast-injection`, code-only, taint layer #4 + #93 + #102 + #104)
 
 The deterministic Semgrep taint layer scored on an independent injection fixture
 (not `test-app`, which the JS rules were tuned on) covering **JS/TS (#4)**,
-**Python (#93)**, and **Java/Spring (#102)**. Recall **37/37** with **0 false
-positives** across all classes, deterministic across runs:
+**Python (#93)**, **Java/Spring (#102)**, and **Kotlin/Spring (#104)** — the
+languages isitsecure supports for the rest of the scan. Recall **46/46** with
+**0 false positives** across all classes, deterministic across runs:
 
-| Class | JS/TS | Python | Java | Class | JS/TS | Python | Java |
-|---|--:|--:|--:|---|--:|--:|--:|
-| sqli | 5/5 | 7/7 | 5/5 | path-traversal | 1/1 | 2/2 | 1/1 |
-| reflected-xss | 2/2 | — | — | command-injection | 1/1 | 3/3 | 2/2 |
-| dom-xss | 2/2 | — | — | ssti | — | 1/1 | — |
-| ssrf | 1/1 | 2/2 | 2/2 | | | | |
+| Class | JS/TS | Python | Java | Kotlin | Class | JS/TS | Python | Java | Kotlin |
+|---|--:|--:|--:|--:|---|--:|--:|--:|--:|
+| sqli | 5/5 | 7/7 | 5/5 | 4/4 | path-traversal | 1/1 | 2/2 | 1/1 | 2/2 |
+| reflected-xss | 2/2 | — | — | — | command-injection | 1/1 | 3/3 | 2/2 | 2/2 |
+| dom-xss | 2/2 | — | — | — | ssti | — | 1/1 | — | — |
+| ssrf | 1/1 | 2/2 | 2/2 | 1/1 | | | | | |
 
 The FP side is exercised by benign near-misses in each language — parameterized
 queries, constant-path writes, non-DB `.query()`, escaped output, fixed-URL
 fetch (JS); parameterized/bound queries (including request-derived values in the
 params tuple), a bare `text()` i18n alias, `subprocess` without `shell=True`,
 constant-path `open()`, fixed-URL requests (Python); `PreparedStatement`/bound
-`JdbcTemplate` queries, constant SQL, constant-path `File` (Java) — none flagged.
-Cross-checked against the real, non-vulnerable **spring-petclinic** (30 Java
-files, 10 `@RequestParam`/`@PathVariable`, 8 query/File/exec call sites): **0 FP**;
-and isitsecure's own 164 Python files (which contain real `subprocess`,
-`requests`/`httpx`, and `open()` call sites): **0 false positives**. This is the
-baseline the taint layer and future rule packs must hold.
+`JdbcTemplate` queries, constant SQL, constant-path `File` (Java/Kotlin) — none
+flagged. Cross-checked against the real, non-vulnerable **spring-petclinic** (30
+Java files, 10 `@RequestParam`/`@PathVariable`, 8 query/File/exec call sites) and
+**spring-petclinic-kotlin** (24 Kotlin files, 7 annotated params): **0 FP** each;
+and isitsecure's own 164 Python files (real `subprocess`/`requests`/`open`): **0
+FP**. This is the baseline the taint layer and future rule packs must hold.
 
 > Juice Shop recall is scored **per challenge** — a finding must match the class
 > signature AND land on the right endpoint — over the 45 DAST-detectable

--- a/benchmarks/fixtures/sast-injection/safe/SafeControllerKt.kt
+++ b/benchmarks/fixtures/sast-injection/safe/SafeControllerKt.kt
@@ -1,0 +1,33 @@
+// Injection benchmark fixture — Kotlin/Spring SAFE / benign near-misses.
+// NOTHING here may be flagged — the false-positive side for Kotlin.
+package com.example.safe
+
+import java.io.File
+import java.sql.Connection
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.web.bind.annotation.RequestParam
+
+class SafeControllerKt(val conn: Connection, val jdbc: JdbcTemplate) {
+
+    // SAFE: PreparedStatement with a bind parameter
+    fun search(@RequestParam name: String) {
+        val ps = conn.prepareStatement("SELECT * FROM users WHERE name = ?")
+        ps.setString(1, name)
+        ps.executeQuery()
+    }
+
+    // SAFE: JdbcTemplate parameterized (? + args)
+    fun byRole(@RequestParam role: String) {
+        jdbc.queryForList("SELECT * FROM users WHERE role = ?", role)
+    }
+
+    // SAFE: constant SQL, no user input
+    fun all() {
+        conn.createStatement().executeQuery("SELECT * FROM users")
+    }
+
+    // SAFE: constant-path file read
+    fun config() {
+        File("/etc/app/config.yaml").readText()
+    }
+}

--- a/benchmarks/fixtures/sast-injection/vulnerable/InjectionControllerKt.kt
+++ b/benchmarks/fixtures/sast-injection/vulnerable/InjectionControllerKt.kt
@@ -1,0 +1,36 @@
+// Injection benchmark fixture — Kotlin/Spring command injection, SSRF, path
+// traversal (VULNERABLE). Constructor sinks use Kotlin's no-`new` form.
+package com.example.vuln
+
+import java.io.File
+import java.net.URL
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestParam
+
+class InjectionControllerKt {
+
+    @GetMapping("/run")
+    fun run(@RequestParam cmd: String) {
+        ProcessBuilder("sh", "-c", cmd).start() // EXPECT command-injection
+    }
+
+    @GetMapping("/exec")
+    fun exec(@RequestParam host: String) {
+        Runtime.getRuntime().exec("ping -c 1 " + host) // EXPECT command-injection
+    }
+
+    @GetMapping("/fetch")
+    fun fetch(@RequestParam url: String) {
+        URL(url).openConnection().getInputStream() // EXPECT ssrf
+    }
+
+    @GetMapping("/read")
+    fun read(@RequestParam name: String) {
+        File("/data/" + name).readText() // EXPECT path-traversal
+    }
+
+    // Kotlin single-expression function (no braces) — the param is still a source
+    @GetMapping("/download")
+    fun download(@RequestParam file: String) =
+        File("/data/" + file).readText() // EXPECT path-traversal
+}

--- a/benchmarks/fixtures/sast-injection/vulnerable/SqliControllerKt.kt
+++ b/benchmarks/fixtures/sast-injection/vulnerable/SqliControllerKt.kt
@@ -1,0 +1,34 @@
+// Injection benchmark fixture — Kotlin/Spring SQL injection (VULNERABLE).
+// Each trailing marker on a sink line is a bug the taint layer must flag.
+// Kotlin shares the JVM/Spring stack with Java; string concat uses `+`, no `new`.
+package com.example.vuln
+
+import java.sql.Connection
+import javax.servlet.http.HttpServletRequest
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestParam
+
+class SqliControllerKt(val conn: Connection, val jdbc: JdbcTemplate) {
+
+    fun search(request: HttpServletRequest) {
+        val name = request.getParameter("name")
+        conn.createStatement().executeQuery("SELECT * FROM users WHERE name = " + name) // EXPECT sqli
+    }
+
+    @GetMapping("/del")
+    fun del(@RequestParam id: String) {
+        conn.createStatement().executeUpdate("DELETE FROM users WHERE id = " + id) // EXPECT sqli
+    }
+
+    @GetMapping("/role")
+    fun byRole(@RequestParam role: String) {
+        jdbc.queryForList("SELECT * FROM users WHERE role = '" + role + "'") // EXPECT sqli
+    }
+
+    // Kotlin string template (idiomatic, not `+`) — still injectable
+    @GetMapping("/email")
+    fun byEmail(@RequestParam email: String) {
+        conn.createStatement().executeQuery("SELECT * FROM users WHERE email = '$email'") // EXPECT sqli
+    }
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -99,7 +99,7 @@ The repository is cloned (shallow, to temp dir) and indexed:
    - `GraphQLRouteMapper`: schema definitions → query/mutation types
 4. **File indexing** — reads all source files into memory (filtered by extension, size limit, skip `node_modules`)
 
-18 SAST scanners then run in parallel against the indexed codebase (plus the LLM-powered Semantic Rule Verifier when an API key is available). One of them, the **Semgrep Taint Analyzer** (`semgrep_taint`), is a deterministic source→sink injection floor for JS/TS, Python, and Java that sits beneath the LLM code reviewer: it catches the mechanical SQLi/XSS/SSRF/path-traversal/command-injection/SSTI cases reproducibly and for free, leaving the LLM to cover business logic and uncatalogued libraries. It is opt-in (`[taint]` extra) and no-ops if the `semgrep` binary is absent.
+18 SAST scanners then run in parallel against the indexed codebase (plus the LLM-powered Semantic Rule Verifier when an API key is available). One of them, the **Semgrep Taint Analyzer** (`semgrep_taint`), is a deterministic source→sink injection floor for JS/TS, Python, Java, and Kotlin that sits beneath the LLM code reviewer: it catches the mechanical SQLi/XSS/SSRF/path-traversal/command-injection/SSTI cases reproducibly and for free, leaving the LLM to cover business logic and uncatalogued libraries. It is opt-in (`[taint]` extra) and no-ops if the `semgrep` binary is absent.
 
 ### Phase 7.5: LSP Validation
 

--- a/docs/scanners/README.md
+++ b/docs/scanners/README.md
@@ -38,7 +38,7 @@ These scanners require authentication or use specialized techniques.
 
 These scanners analyze your source code without running it.
 
-- [Semgrep Taint Analyzer](./semgrep-taint.md) — Deterministic source→sink injection for JS/TS, Python, and Java (SQLi, XSS, SSRF, path traversal, command injection, SSTI)
+- [Semgrep Taint Analyzer](./semgrep-taint.md) — Deterministic source→sink injection for JS/TS, Python, Java, and Kotlin (SQLi, XSS, SSRF, path traversal, command injection, SSTI)
 - [Git Secret Scanner](./git-secret-scanner.md) — Secrets in git history
 - [Route Auth Analyzer](./route-auth-analyzer.md) — Routes missing authentication
 - [RLS Policy Analyzer](./rls-policy-analyzer.md) — Missing Supabase Row Level Security

--- a/docs/scanners/semgrep-taint.md
+++ b/docs/scanners/semgrep-taint.md
@@ -6,7 +6,7 @@
 
 Runs [Semgrep](https://semgrep.dev) with isitsecure's own taint/sink rule packs over your cloned repo and maps the results to findings. It is a **deterministic injection floor beneath the LLM code reviewer**: the same input always produces the same findings, instantly and at no token cost.
 
-Three rule packs ship today — **JavaScript/TypeScript** (`injection-js.yaml`, #4), **Python** (`injection-python.yaml`, #93), and **Java/Spring** (`injection-java.yaml`, #102). The analyzer **auto-selects the packs whose languages are present in the repo** (#94): a JS-only repo runs only the JS pack, a mixed repo the relevant ones. (Semgrep also scopes each rule to its declared language, so selection is about not loading irrelevant rules — faster, and ready for per-framework packs later.)
+Four rule packs ship today — **JavaScript/TypeScript** (`injection-js.yaml`, #4), **Python** (`injection-python.yaml`, #93), **Java/Spring** (`injection-java.yaml`, #102), and **Kotlin/Spring** (`injection-kotlin.yaml`, #104). Java and Kotlin share the JVM/Spring stack and the same rule shape, but Semgrep needs a separate pack per language (a rule can only hold patterns valid in every language it lists, and Kotlin's syntax differs — `name: Type` params, no `new`). The analyzer **auto-selects the packs whose languages are present in the repo** (#94): a JS-only repo runs only the JS pack, a mixed repo the relevant ones. (Semgrep also scopes each rule to its declared language, so selection is about not loading irrelevant rules — faster, and ready for per-framework packs later.)
 
 **JavaScript/TypeScript** — six classes:
 
@@ -25,7 +25,7 @@ Three rule packs ship today — **JavaScript/TypeScript** (`injection-js.yaml`, 
 4. **Path traversal** — request-derived path → `open(...)`.
 5. **SSTI** — request input → `render_template_string(...)`.
 
-**Java** (Spring MVC / servlet request sources: `@RequestParam`/`@PathVariable`/`@RequestHeader` params, `HttpServletRequest.getParameter`/`getHeader`) — four classes:
+**Java and Kotlin** (Spring MVC / servlet request sources: `@RequestParam`/`@PathVariable`/`@RequestHeader` params, `HttpServletRequest.getParameter`/`getHeader`) — four classes each (the Kotlin pack mirrors the Java pack with Kotlin-syntax sources and no-`new` constructor sinks):
 
 1. **SQL injection** — string-concatenated queries in JDBC `Statement.execute*`, JPA `EntityManager.createQuery`/`createNativeQuery`, Spring `JdbcTemplate.query*`/`update`, plus a taint rule focused on the query-string argument (bound parameters are safe).
 2. **Command injection** — request input → `Runtime.getRuntime().exec(...)` / `new ProcessBuilder(...)`.
@@ -48,14 +48,14 @@ It is **best-effort and self-contained**:
 
 - If the `semgrep` binary isn't installed, the analyzer **no-ops and returns nothing** — the LLM layer still runs, exactly as before.
 - A crash or timeout in Semgrep **never fails the scan**; it logs and returns no findings. The subprocess is always killed and reaped (never orphaned), even if the overall scan is cancelled.
-- It only runs when the repo contains JS/TS, Python, or Java files.
+- It only runs when the repo contains JS/TS, Python, Java, or Kotlin files.
 - No network: the rule packs ship with isitsecure; Semgrep runs with `--metrics off`.
 
 ## Why It Matters
 
 Before this analyzer, injection detection (SQLi/XSS/SSRF/path-traversal/command-injection) rested **entirely on the LLM**, which is non-deterministic (finding counts wobble run-to-run), costs tokens, and is slow. The Semgrep layer gives a reproducible, instant, free floor for the mechanical source→sink cases, while the LLM keeps covering business-logic flaws and the long tail of libraries without rules.
 
-See [docs/taint-analysis.md](../taint-analysis.md) for the full design rationale, the spike results, and the per-stack rule model. The layer has its own recall/FP scorecard — **37/37 recall, 0 false positives** on an independent JS/TS + Python + Java injection fixture — via `python benchmarks/run_benchmarks.py sast-injection` (see [benchmarks/RESULTS.md](../../benchmarks/RESULTS.md)).
+See [docs/taint-analysis.md](../taint-analysis.md) for the full design rationale, the spike results, and the per-stack rule model. The layer has its own recall/FP scorecard — **46/46 recall, 0 false positives** on an independent JS/TS + Python + Java + Kotlin injection fixture — via `python benchmarks/run_benchmarks.py sast-injection` (see [benchmarks/RESULTS.md](../../benchmarks/RESULTS.md)).
 
 ## What Vulnerable Code Looks Like
 
@@ -77,11 +77,11 @@ const rows = await sql`SELECT * FROM users WHERE id = ${id}`;
 ## Limitations
 
 - **Intra-file only.** OSS Semgrep taint tracks dataflow within a single file. A route that hands user input to a helper in another file which then reaches a sink (inter-procedural) is not tracked — that path falls back to the LLM reviewer. (Inter-file taint is Semgrep Pro territory.)
-- **JS/TS, Python, and Java today.** Other stacks (Go, Ruby, …) are future rule-pack work; those apps rely on the LLM layer meanwhile. Python and Java server-side XSS (template-autoescaping nuance) is not yet covered.
+- **JS/TS, Python, Java, and Kotlin today** — the languages isitsecure supports for the rest of the scan. Other stacks (Go, Ruby, …) are DAST-only (no SAST support), so no taint pack. Python/Java/Kotlin server-side XSS (template-autoescaping nuance) is not yet covered.
 - **Python taint sources are Flask/Django** (`request.*`); FastAPI endpoint parameters aren't yet tracked, so FastAPI command-injection/SSRF/path/SSTI fall to the LLM layer (string-built SQL is still caught on any stack).
-- **Java taint sources are Spring MVC / servlet** (`@RequestParam`/`@PathVariable`/`getParameter`); other Java web frameworks (JAX-RS, `@RequestBody` fields, etc.) fall to the LLM layer. String-concatenated SQL on the unambiguous DB verbs (`executeQuery`/`executeUpdate`/`prepareStatement`/`createNativeQuery`/`queryFor*`) is still caught source-free; the generic verbs (`execute`/`createQuery`/`update`) need a recognized Spring source to fire.
+- **Java/Kotlin taint sources are Spring MVC / servlet** (`@RequestParam`/`@PathVariable`/`getParameter`); other JVM web frameworks (JAX-RS, `@RequestBody` fields, etc.) fall to the LLM layer. String-concatenated SQL on the unambiguous DB verbs (`executeQuery`/`executeUpdate`/`prepareStatement`/`createNativeQuery`/`queryFor*`) is still caught source-free; the generic verbs (`execute`/`createQuery`/`update`) need a recognized Spring source to fire.
 - **Per-stack rules.** Sinks for libraries we haven't catalogued won't fire deterministically (again, the LLM backstops them).
 
 ## Configuration
 
-No configuration. The analyzer auto-runs on any code-only/full scan when the `semgrep` binary is available and the repo has files a rule pack covers (JS/TS, Python, or Java) — selecting the matching packs automatically. The rule packs live in `isitsecure/engine/code_analysis/semgrep_rules/`; register a new one in `_RULE_PACKS` in `semgrep_analyzer.py`.
+No configuration. The analyzer auto-runs on any code-only/full scan when the `semgrep` binary is available and the repo has files a rule pack covers (JS/TS, Python, Java, or Kotlin) — selecting the matching packs automatically. The rule packs live in `isitsecure/engine/code_analysis/semgrep_rules/`; register a new one in `_RULE_PACKS` in `semgrep_analyzer.py`.

--- a/docs/taint-analysis.md
+++ b/docs/taint-analysis.md
@@ -166,7 +166,7 @@ Note: the original benchmark was DAST-oriented, so this work added a **SAST
 injection benchmark** — a fixture set with known source→sink bugs giving the taint
 layer its own recall/FP scorecard. **Delivered** (#92): `benchmarks/sast_injection.py`
 + `benchmarks/fixtures/sast-injection/`, run via `python benchmarks/run_benchmarks.py
-sast-injection`. Baseline **37/37 recall, 0 FP** across JS/TS, Python, and Java ([benchmarks/RESULTS.md](../benchmarks/RESULTS.md)).
+sast-injection`. Baseline **46/46 recall, 0 FP** across JS/TS, Python, Java, and Kotlin ([benchmarks/RESULTS.md](../benchmarks/RESULTS.md)).
 
 ## Risks & open questions
 
@@ -177,13 +177,15 @@ sast-injection`. Baseline **37/37 recall, 0 FP** across JS/TS, Python, and Java 
 - **Binary dependency** — bundling/pinning Semgrep; graceful fallback when absent.
 - **Semgrep licensing** — OSS engine + our own rules are fine; confirm no
   reliance on registry rules with restrictive terms (we ship our own packs).
-- **Language coverage** — JS/TS (#4), Python/Flask/Django (#93), and Java/Spring
-  (#102) ship today; other stacks (Go, Ruby, …) are future packs.
+- **Language coverage** — JS/TS (#4), Python/Flask/Django (#93), Java/Spring
+  (#102), and Kotlin/Spring (#104) ship today — matching the languages isitsecure
+  supports for the rest of the scan. Go/Ruby/Rust are DAST-only (no SAST support),
+  so no taint pack.
 
 ## Phasing
 
 1. ✅ **SAST injection benchmark fixtures** + a recall/FP harness (#92) — the
-   `sast-injection` target, baseline 37/37 recall / 0 FP (JS/TS, Python, Java).
+   `sast-injection` target, baseline 46/46 recall / 0 FP (JS/TS, Python, Java, Kotlin).
 2. ✅ **`SemgrepAnalyzer`** (subprocess → parse → `CodeFinding`) with a first rule
    pack for the top stack (Next.js/Express + postgres/Prisma/Drizzle + DOM) — #4.
 3. ✅ **Benchmark**: proved it adds recall without FP vs. LLM-only. Shipped in #4.
@@ -191,5 +193,7 @@ sast-injection`. Baseline **37/37 recall, 0 FP** across JS/TS, Python, and Java 
    the **Python** pack (Flask/Django; DB-API/SQLAlchemy/Django ORM, os/subprocess,
    requests/urllib, Jinja; SQLi/cmdi/SSRF/path/SSTI); #102 adds the **Java/Spring**
    pack (Spring MVC/servlet sources; JDBC/JPA/JdbcTemplate, Runtime/ProcessBuilder,
-   URL/RestTemplate, java.io.File; SQLi/cmdi/SSRF/path). Further stacks continue here.
+   URL/RestTemplate, java.io.File; SQLi/cmdi/SSRF/path); #104 adds the **Kotlin/Spring**
+   pack (same shape, Kotlin syntax — separate pack since a rule's patterns must be
+   valid in every language it lists). Further stacks continue here.
 5. **Keep the LLM layer** as the long-tail + business-logic backstop throughout.

--- a/isitsecure/engine/code_analysis/semgrep_analyzer.py
+++ b/isitsecure/engine/code_analysis/semgrep_analyzer.py
@@ -54,6 +54,7 @@ _RULE_PACKS: tuple[_RulePack, ...] = (
               (".js", ".jsx", ".ts", ".tsx", ".mjs", ".cjs")),
     _RulePack("python", "injection-python.yaml", (".py",)),
     _RulePack("java", "injection-java.yaml", (".java",)),
+    _RulePack("kotlin", "injection-kotlin.yaml", (".kt",)),
 )
 
 # Dirs semgrep ignores by default; skipping them bounds the language-detection

--- a/isitsecure/engine/code_analysis/semgrep_rules/injection-kotlin.yaml
+++ b/isitsecure/engine/code_analysis/semgrep_rules/injection-kotlin.yaml
@@ -1,0 +1,119 @@
+# isitsecure taint/sink rules for Kotlin injection (#104).
+# Kotlin shares the JVM/Spring stack with Java, but the syntax differs enough
+# (params are `name: Type`, constructors have no `new`, functions use `fun`) that
+# Semgrep needs a separate `languages: [kotlin]` pack — a rule can only hold
+# patterns valid in every language it lists. Mirrors injection-java.yaml.
+rules:
+  # ---- SQL injection: dangerous query construction (pattern) ----
+  - id: isitsecure-kotlin-sqli
+    languages: [kotlin]
+    severity: ERROR
+    metadata: {category: injection_risk, isitsecure-severity: critical}
+    message: "Raw SQL built from string concatenation — SQL injection. Use a parameterized query."
+    patterns:
+      - pattern-either:
+          - pattern: $S.executeQuery("..." + ...)
+          - pattern: $S.executeUpdate("..." + ...)
+          - pattern: $C.prepareStatement("..." + ...)
+          - pattern: $E.createNativeQuery("..." + ...)
+          - pattern: $J.queryForList("..." + ...)
+          - pattern: $J.queryForObject("..." + ...)
+          - pattern: $J.queryForMap("..." + ...)
+
+  # ---- SQL injection: user input → query STRING (intra-file taint) ----
+  - id: isitsecure-kotlin-sqli-taint
+    mode: taint
+    languages: [kotlin]
+    severity: ERROR
+    metadata: {category: injection_risk, isitsecure-severity: critical}
+    message: "User input flows into a raw SQL query — SQL injection."
+    pattern-sources: &kotlin_sources
+      # Servlet request accessors (method-call sources — same as Java)
+      - pattern: $REQ.getParameter(...)
+      - pattern: $REQ.getParameterValues(...)
+      - pattern: $REQ.getHeader(...)
+      - pattern: $REQ.getQueryString()
+      # Spring controller params — Kotlin `fun name(@RequestParam p: Type)`. Match
+      # both block bodies (`{...}`) and single-expression bodies (`= ...`), which
+      # are idiomatic Kotlin and have no braces.
+      - patterns:
+          - pattern-either:
+              - pattern-inside: "fun $M(..., @RequestParam $P: $T, ...) {...}"
+              - pattern-inside: "fun $M(..., @RequestParam $P: $T, ...) = ..."
+          - focus-metavariable: $P
+      - patterns:
+          - pattern-either:
+              - pattern-inside: "fun $M(..., @RequestParam(...) $P: $T, ...) {...}"
+              - pattern-inside: "fun $M(..., @RequestParam(...) $P: $T, ...) = ..."
+          - focus-metavariable: $P
+      - patterns:
+          - pattern-either:
+              - pattern-inside: "fun $M(..., @PathVariable $P: $T, ...) {...}"
+              - pattern-inside: "fun $M(..., @PathVariable $P: $T, ...) = ..."
+          - focus-metavariable: $P
+      - patterns:
+          - pattern-either:
+              - pattern-inside: "fun $M(..., @PathVariable(...) $P: $T, ...) {...}"
+              - pattern-inside: "fun $M(..., @PathVariable(...) $P: $T, ...) = ..."
+          - focus-metavariable: $P
+      - patterns:
+          - pattern-either:
+              - pattern-inside: "fun $M(..., @RequestHeader $P: $T, ...) {...}"
+              - pattern-inside: "fun $M(..., @RequestHeader $P: $T, ...) = ..."
+          - focus-metavariable: $P
+    pattern-sinks:
+      - patterns:
+          - pattern-either:
+              - pattern: $S.executeQuery($Q)
+              - pattern: $S.executeUpdate($Q)
+              - pattern: $S.execute($Q)
+              - pattern: $C.prepareStatement($Q)
+              - pattern: $E.createNativeQuery($Q)
+              - pattern: $E.createQuery($Q)
+              - pattern: $J.queryForList($Q, ...)
+              - pattern: $J.queryForObject($Q, ...)
+              - pattern: $J.update($Q, ...)
+          - focus-metavariable: $Q
+
+  # ---- Command injection: user input → shell ----
+  - id: isitsecure-kotlin-command-injection
+    mode: taint
+    languages: [kotlin]
+    severity: ERROR
+    metadata: {category: injection_risk, isitsecure-severity: critical}
+    message: "User input flows into a shell command — command injection."
+    pattern-sources: *kotlin_sources
+    pattern-sinks:
+      - pattern: Runtime.getRuntime().exec(...)
+      - pattern: ProcessBuilder(...)   # Kotlin: no `new`
+
+  # ---- SSRF: user-controlled URL → outbound request ----
+  - id: isitsecure-kotlin-ssrf
+    mode: taint
+    languages: [kotlin]
+    severity: ERROR
+    metadata: {category: injection_risk, isitsecure-severity: high}
+    message: "User-controlled URL flows into an outbound request — SSRF."
+    pattern-sources: *kotlin_sources
+    pattern-sinks:
+      - pattern: URL(...)              # Kotlin: no `new`
+      - pattern: $R.getForObject(...)
+      - pattern: $R.getForEntity(...)
+      - pattern: $R.exchange(...)
+
+  # ---- Path traversal: request-derived path → file access ----
+  # Note: the bare no-`new` sinks (File/URL/ProcessBuilder) match on callee name,
+  # so a same-named domain type or factory fn receiving request input directly
+  # could false-positive. It's taint-gated (needs a source in the same function),
+  # which bounds the blast radius; revisit with import-scoping if seen in the wild.
+  - id: isitsecure-kotlin-path-traversal
+    mode: taint
+    languages: [kotlin]
+    severity: WARNING
+    metadata: {category: injection_risk, isitsecure-severity: high}
+    message: "File accessed with a request-derived path — path traversal."
+    pattern-sources: *kotlin_sources
+    pattern-sinks:
+      - pattern: File(...)             # Kotlin: no `new`
+      - pattern: FileInputStream(...)
+      - pattern: FileReader(...)

--- a/tests/benchmarks/test_sast_injection_scorer.py
+++ b/tests/benchmarks/test_sast_injection_scorer.py
@@ -52,6 +52,7 @@ class TestGroundTruth:
         assert any(f.endswith(".ts") for f in files)     # JS/TS (#4)
         assert any(f.endswith(".py") for f in files)     # Python (#93)
         assert any(f.endswith(".java") for f in files)   # Java (#102)
+        assert any(f.endswith(".kt") for f in files)     # Kotlin (#104)
 
     def test_marker_regex_accepts_both_comment_styles(self):
         assert si.EXPECT_RE.search("foo()  // EXPECT sqli").group(1) == "sqli"

--- a/tests/engine/test_semgrep_analyzer.py
+++ b/tests/engine/test_semgrep_analyzer.py
@@ -137,11 +137,16 @@ class TestPackSelection:
         packs = SemgrepAnalyzer()._select_packs(_disk_snapshot(tmp_path, ["src/App.java"]))
         assert [p.name for p in packs] == ["injection-java.yaml"]
 
+    def test_kotlin_only(self, tmp_path):
+        packs = SemgrepAnalyzer()._select_packs(_disk_snapshot(tmp_path, ["src/App.kt"]))
+        assert [p.name for p in packs] == ["injection-kotlin.yaml"]
+
     def test_mixed_repo_gets_all_present(self, tmp_path):
         packs = SemgrepAnalyzer()._select_packs(
-            _disk_snapshot(tmp_path, ["a.ts", "b.py", "C.java"]))
+            _disk_snapshot(tmp_path, ["a.ts", "b.py", "C.java", "D.kt"]))
         assert {p.name for p in packs} == {
-            "injection-js.yaml", "injection-python.yaml", "injection-java.yaml"}
+            "injection-js.yaml", "injection-python.yaml",
+            "injection-java.yaml", "injection-kotlin.yaml"}
 
     def test_unsupported_language_gets_nothing(self, tmp_path):
         packs = SemgrepAnalyzer()._select_packs(_disk_snapshot(tmp_path, ["main.go", "README.md"]))


### PR DESCRIPTION
Closes #104. Completes the taint layer's language coverage to **match the languages isitsecure supports for the rest of the scan** — JS/TS (#4), Python (#93), Java (#102), Kotlin (#104). Go/Ruby/Rust are DAST-only (no SAST support), so no pack for them.

## What's in it
- **`injection-kotlin.yaml`** (`languages: [kotlin]`) — SQLi, command-injection, SSRF, path-traversal, mirroring the Java pack. Kotlin needs a **separate pack**: a Semgrep rule's patterns must be valid in *every* language it lists, and Kotlin syntax differs (`name: Type` params, `fun`, no `new`).
  - Sources: servlet `getParameter`/`getHeader` (shared) + Spring `@RequestParam`/`@PathVariable`/`@RequestHeader` params matched on the enclosing function — covering **both block (`{...}`) and single-expression (`= ...`) bodies**.
  - Constructor sinks use the Kotlin no-`new` forms; SQLi keeps the pattern + focus-metavariable taint split (bound params + Kotlin string templates handled).
- **`_RULE_PACKS`** registers the Kotlin pack (`.kt`). No new scanner — still `semgrep_taint`, opt-in `[taint]`; **SAST count stays 18**.

## Benchmark
**46/46 recall, 0 FP** across all four languages (Kotlin: sqli 4, cmdi 2, ssrf 1, path 2). Cross-checked on the real, non-vulnerable **spring-petclinic-kotlin** (24 files, 7 annotated params): **0 FP**.

## Adversarial review → fixed
The code review found (and semgrep-verified) a real recall gap: **Kotlin single-expression functions** (`fun f(...) = expr`, no braces — idiomatic) bypassed *all* taint rules because the source pattern required `{...}` — so cmdi/ssrf/path silently vanished for expression-body controllers. Fixed by matching both body forms (verified), with a fixture to guard it. Also self-caught + added a **Kotlin string-template SQLi** fixture (`"...$id..."`). Documented the taint-gated FP risk on same-named domain types with a code comment.

## Verification
85 tests pass; ruff clean; all four packs ship in the wheel; `python benchmarks/run_benchmarks.py sast-injection` → 46/46, 0 FP.

The taint layer now covers every SAST-supported language. 🎉

🤖 Generated with [Claude Code](https://claude.com/claude-code)