### PR TITLE
test(benchmarks): pin NodeGoat + correct stale nodegoat-auth recall (RCA)

### DIFF
--- a/benchmarks/RESULTS.md
+++ b/benchmarks/RESULTS.md
@@ -17,7 +17,7 @@ _Runs: 2026-07 · `--llm none` (pure DAST detection, no LLM) · Juice Shop pinne
 | `juiceshop` | url-only | **20/45 (44%)** — per-challenge, deterministic | not yet measured | ~25 |
 | `vampi-vulnerable` | url-only | **3/3** (SQLi, IDOR, headers) | — | 14–16 |
 | `vampi-secure` | url-only | — | **2** (IDOR) | 13–15 |
-| `nodegoat-auth` | authenticated | **2/3** (headers, XSS; injection missed) | unmeasured | 28 |
+| `nodegoat-auth` | authenticated | **1/3** (headers only; XSS + injection missed) | unmeasured | 22 |
 | `sast-injection` | code-only | **46/46 (100%)** — taint, per-class, deterministic | **0** | 46 |
 
 ### SAST injection (`sast-injection`, code-only, taint layer #4 + #93 + #102 + #104)
@@ -120,9 +120,21 @@ authenticated run finds **2 write BOLA** (email/password) with 0 FP.
 Server-rendered Express/EJS app — no JS API bundle, no OpenAPI spec. url-only
 discovery originally found **nothing**; HTML form/link discovery + a form-scoped
 login detector (identity field `userName`) now let a credentialed crawl log in,
-walk ~32 pages, and discover **10 form endpoints**. Harness recall **2/3**:
-missing headers ✓, XSS ✓, injection ✗ — the injection miss on the server-rendered
-forms is a real, reportable gap.
+walk ~32 pages, and discover **10 form endpoints**. NodeGoat is now **pinned to
+commit `c5cb68a`** for reproducibility (it's unversioned upstream, unlike Juice
+Shop's `v20.1.1` tag).
+
+Harness recall **1/3**: missing headers ✓, XSS ✗, injection ✗ — **deterministic
+across 4 consecutive runs** (22 findings each), down from a previously recorded
+2/3. **Root cause (investigated):** NodeGoat's `POST /profile` reflected XSS
+(`firstName`/`lastName` echoed unescaped) is real and the form *is* discovered
+with its real field names — but the **POST-body XSS scanner tests a fixed generic
+field list** (`name`/`comment`/…) instead of the form's discovered fields, so its
+canary lands in fields the app ignores. The reflected-XSS phase only tries those
+fields as *GET* params, which a POST-only form doesn't read. Net: reflected XSS
+in HTML form POSTs with app-specific field names is systematically missed —
+tracked as a detection gap. Juice Shop is stable at 20/45, so the DAST core is
+fine; this is specific to form-POST XSS.
 
 ## How to read these numbers
 

--- a/benchmarks/run_benchmarks.py
+++ b/benchmarks/run_benchmarks.py
@@ -100,6 +100,18 @@ HEADERS = dict(category="missing_headers")
 XSS = dict(scanners=("xss_scanner", "dom_xss_scanner"))
 INJECTION = dict(scanner="active_injection_scanner")
 
+# NodeGoat is unversioned upstream, so pin a commit for a reproducible benchmark
+# (like Juice Shop is pinned to v20.1.1). Shallow-fetch exactly this commit.
+NODEGOAT_COMMIT = "c5cb68a7084e4ae7dcc60e6a98768720a81841e8"
+_NODEGOAT_UP = ["bash", "-c",
+                "test -d benchmarks/_ext/NodeGoat || (mkdir -p benchmarks/_ext/NodeGoat && "
+                "cd benchmarks/_ext/NodeGoat && git init -q && "
+                "git remote add origin https://github.com/OWASP/NodeGoat && "
+                f"git fetch --depth 1 origin {NODEGOAT_COMMIT} && git checkout -q FETCH_HEAD); "
+                "cd benchmarks/_ext/NodeGoat && docker compose up -d"]
+_NODEGOAT_DOWN = ["bash", "-c",
+                  "cd benchmarks/_ext/NodeGoat 2>/dev/null && docker compose down -v || true"]
+
 
 TARGETS: list[Target] = [
     Target(
@@ -134,14 +146,10 @@ TARGETS: list[Target] = [
     #     contained via a shallow clone), so we track their real setup. ---
     Target(
         name="nodegoat",
-        up_cmd=["bash", "-c",
-                "test -d benchmarks/_ext/NodeGoat || git clone --depth 1 "
-                "https://github.com/OWASP/NodeGoat benchmarks/_ext/NodeGoat; "
-                "cd benchmarks/_ext/NodeGoat && docker compose up -d"],
+        up_cmd=_NODEGOAT_UP,
         url="http://localhost:4000",
         ready_url="http://localhost:4000/",
-        down_cmd=["bash", "-c",
-                  "cd benchmarks/_ext/NodeGoat 2>/dev/null && docker compose down -v || true"],
+        down_cmd=_NODEGOAT_DOWN,
         ready_timeout=300,
         expect=[
             Expectation("Missing security headers", **HEADERS),
@@ -152,14 +160,10 @@ TARGETS: list[Target] = [
     ),
     Target(
         name="nodegoat-auth",
-        up_cmd=["bash", "-c",
-                "test -d benchmarks/_ext/NodeGoat || git clone --depth 1 "
-                "https://github.com/OWASP/NodeGoat benchmarks/_ext/NodeGoat; "
-                "cd benchmarks/_ext/NodeGoat && docker compose up -d"],
+        up_cmd=_NODEGOAT_UP,
         url="http://localhost:4000",
         ready_url="http://localhost:4000/",
-        down_cmd=["bash", "-c",
-                  "cd benchmarks/_ext/NodeGoat 2>/dev/null && docker compose down -v || true"],
+        down_cmd=_NODEGOAT_DOWN,
         ready_timeout=300,
         scan_mode="authenticated",
         # Register a user so the browser-login crawl can authenticate.


### PR DESCRIPTION
Re-running the DAST benchmarks (Juice Shop + NodeGoat) surfaced a discrepancy; this lands the reproducibility fix + the corrected number, with the RCA.

## Changes
- **Pin NodeGoat to `c5cb68a`** (shallow-fetch that exact SHA) — it's unversioned upstream, so the benchmark wasn't reproducible (Juice Shop is pinned to `v20.1.1`). Also DRY'd the up/down commands shared by the `nodegoat` / `nodegoat-auth` targets.
- **Correct `nodegoat-auth`: 2/3 → 1/3** in RESULTS.md — deterministic across 4 consecutive runs (headers ✓, XSS ✗, injection ✗, 22 findings each). Juice Shop is stable at **20/45**, so the DAST core is fine.

## RCA (recorded in RESULTS.md)
NodeGoat's `POST /profile` reflected XSS (`firstName`/`lastName` echoed unescaped) is **real** and the form **is** discovered with its real fields — but the **POST-body XSS scanner tests a fixed generic field list** (`name`/`comment`/…) instead of the discovered fields, and the reflected phase only tries them as **GET** params (a POST-only form doesn't read those). So reflected XSS in HTML form POSTs with app-specific field names is systematically missed.

The scanner **fix** is tracked separately (detection logic → benchmark-gated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)