### PR TITLE
feat(dast): POST-body XSS uses the form's real fields + form/JSON transports (#109)

### DIFF
--- a/isitsecure/engine/constants.py
+++ b/isitsecure/engine/constants.py
@@ -1231,6 +1231,8 @@ class XSSConfig:
 
     # POST body XSS testing
     MAX_POST_ENDPOINTS_TO_TEST = 15
+    MAX_POST_BODY_FIELDS = 25  # cap canaried fields per endpoint (bounds body size)
+    # Fallback field names when an endpoint carried no discovered form fields.
     POST_BODY_FIELD_NAMES = (
         "name", "comment", "description", "title",
         "message", "bio", "content", "text",

--- a/isitsecure/engine/scanners/xss_scanner.py
+++ b/isitsecure/engine/scanners/xss_scanner.py
@@ -14,7 +14,7 @@ import json
 import logging
 import re
 import uuid
-from urllib.parse import parse_qs, urlparse
+from urllib.parse import parse_qs, urlencode, urlparse
 
 from isitsecure.engine.constants import DeepScanConfig, XSSConfig
 from isitsecure.engine.models import (
@@ -277,6 +277,39 @@ class XSSScanner:
 
         return findings
 
+    async def _post_body_variants(
+        self,
+        client: RateLimitedClient,
+        method: str,
+        url: str,
+        body_payload: dict[str, str],
+        canary_map: dict[str, str],
+    ) -> tuple[object | None, str, str]:
+        """POST the canary body as form-urlencoded, then JSON.
+
+        Real HTML forms are ``application/x-www-form-urlencoded``; APIs take JSON.
+        Returns the response that reflects a canary (or the last valid attempt),
+        the sent body string, and a content-type label for the finding.
+        """
+        json_body = json.dumps(body_payload)
+        attempts = [
+            ("form-urlencoded", urlencode(body_payload),
+             {"data": body_payload,
+              "headers": {"Content-Type": "application/x-www-form-urlencoded"}}),
+            ("JSON", json_body,
+             {"content": json_body, "headers": {"Content-Type": "application/json"}}),
+        ]
+        last: tuple[object | None, str, str] = (None, "", "")
+        for label, sent_body, kwargs in attempts:
+            try:
+                resp = await client.request(method, url, **kwargs)
+            except Exception:  # noqa: BLE001, S112 - try the next content-type
+                continue
+            last = (resp, sent_body, label)
+            if resp.status_code < 400 and any(c in resp.text for c in canary_map.values()):
+                return resp, sent_body, label
+        return last
+
     async def _test_single_post_body(
         self,
         client: RateLimitedClient,
@@ -289,10 +322,15 @@ class XSSScanner:
         """
         canary_id = uuid.uuid4().hex[:8]
 
-        # Build JSON body with a unique canary per field
+        # Canary the form's ACTUAL discovered fields (extracted from the crawled
+        # <form>'s <input name=...>), falling back to generic names only when the
+        # endpoint carried none. A fixed generic list misses app-specific fields
+        # like firstName/lastName, so real form-POST XSS goes undetected.
+        field_names = list(endpoint.query_param_names) or list(XSSConfig.POST_BODY_FIELD_NAMES)
+        field_names = field_names[: XSSConfig.MAX_POST_BODY_FIELDS]
         body_payload: dict[str, str] = {}
         field_canary_map: dict[str, str] = {}
-        for field_name in XSSConfig.POST_BODY_FIELD_NAMES:
+        for field_name in field_names:
             canary_value = f"<canary_xss_{canary_id}_{field_name}>"
             body_payload[field_name] = canary_value
             field_canary_map[field_name] = canary_value
@@ -300,14 +338,12 @@ class XSSScanner:
         http_method = endpoint.method.value
 
         try:
-            response = await client.request(
-                http_method,
-                endpoint.url,
-                content=json.dumps(body_payload),
-                headers={"Content-Type": "application/json"},
+            # Try form-urlencoded (most HTML forms) then JSON (APIs); use whichever
+            # reflects a canary so the finding reflects the real request.
+            response, sent_body, sent_desc = await self._post_body_variants(
+                client, http_method, endpoint.url, body_payload, field_canary_map,
             )
-
-            if response.status_code >= 400:
+            if response is None or response.status_code >= 400:
                 return None
 
             response_body = response.text
@@ -320,7 +356,7 @@ class XSSScanner:
                         method=http_method,
                         url=endpoint.url,
                         headers=dict(response.request.headers),
-                        body=json.dumps(body_payload),
+                        body=sent_body,
                         response_status=response.status_code,
                         response_headers=dict(response.headers),
                         response_body=response_body,
@@ -336,21 +372,21 @@ class XSSScanner:
                             url=endpoint.url, field=field_name
                         ),
                         technical_detail=(
-                            f"Sent {http_method} with JSON body containing "
+                            f"Sent {http_method} with {sent_desc} body containing "
                             f"canary in field '{field_name}'.\n"
                             f"Canary: {canary_value}\n"
                             f"Reflected unescaped in response body.\n"
                             f"Content-Type: {content_type}"
                         ),
                         evidence=(
-                            f"{http_method} {endpoint.url} with JSON body -> "
+                            f"{http_method} {endpoint.url} with {sent_desc} body -> "
                             f"canary in '{field_name}' reflected unescaped"
                         ),
                         confidence=XSSConfig.CONFIDENCE_POST_BODY_REFLECTED,
                         scanner_name=self.scanner_name,
                         endpoint_url=endpoint.url,
                         http_method=http_method,
-                        request_payload=json.dumps(body_payload),
+                        request_payload=sent_body,
                         response_preview=response_body[:300],
                         probe_captures=[capture],
                     )
@@ -372,19 +408,19 @@ class XSSScanner:
                             "Verify that encoding is applied in all contexts."
                         ),
                         technical_detail=(
-                            f"Sent {http_method} with JSON body containing "
+                            f"Sent {http_method} with {sent_desc} body containing "
                             f"canary in field '{field_name}'.\n"
                             f"Canary text reflected (HTML chars may be encoded)."
                         ),
                         evidence=(
-                            f"{http_method} {endpoint.url} with JSON body -> "
+                            f"{http_method} {endpoint.url} with {sent_desc} body -> "
                             f"canary in '{field_name}' partially reflected"
                         ),
                         confidence=XSSConfig.CONFIDENCE_REFLECTED_POSSIBLE,
                         scanner_name=self.scanner_name,
                         endpoint_url=endpoint.url,
                         http_method=http_method,
-                        request_payload=json.dumps(body_payload),
+                        request_payload=sent_body,
                     )
 
             # Stored XSS: the payload may reflect only when the resource is

--- a/tests/engine/test_xss_scanner.py
+++ b/tests/engine/test_xss_scanner.py
@@ -628,3 +628,75 @@ class TestStoredXss:
         f = await self._run("text/html",
                             "<div>&lt;canary_xss_abc_comment&gt;</div>")
         assert f is None
+
+
+# ---------------------------------------------------------------------------
+# POST-body XSS: use the form's discovered fields, try form + JSON (#109)
+# ---------------------------------------------------------------------------
+
+
+def _echoing_client(reflect_field: str, *, only_content_type: str | None = None):
+    """A mock RateLimitedClient whose request() echoes back a field's canary
+    (unescaped) — optionally only for one content-type — so we can assert the
+    scanner canaried that field via that transport."""
+    calls: list[dict] = []
+
+    async def _request(method, url, **kwargs):
+        ctype = kwargs.get("headers", {}).get("Content-Type", "")
+        calls.append({"method": method, "ctype": ctype, "kwargs": kwargs})
+        body = kwargs.get("data")
+        if body is None:  # JSON attempt carries a serialized string in `content`
+            import json as _j
+            try:
+                body = _j.loads(kwargs.get("content") or "{}")
+            except Exception:
+                body = {}
+        reflected = body.get(reflect_field, "")
+        blocked = only_content_type is not None and only_content_type not in ctype
+        html = "" if blocked else f"<html><input value='{reflected}'></html>"
+        return _make_html_response(html)
+
+    client = MagicMock()
+    client.request = AsyncMock(side_effect=_request)
+    client._calls = calls
+    return client
+
+
+@pytest.mark.asyncio
+async def test_post_body_xss_uses_discovered_form_fields():
+    """A form's real field (firstName) — not in the generic list — is canaried."""
+    assert "firstname" not in [f.lower() for f in XSSConfig.POST_BODY_FIELD_NAMES]
+    ep = DiscoveredEndpoint(
+        url="https://example.com/profile", method=EndpointMethod.POST,
+        query_param_names=["firstName", "lastName"],
+    )
+    client = _echoing_client("firstName")
+    finding = await XSSScanner()._test_single_post_body(client, ep)
+    assert finding is not None
+    assert finding.severity == SeverityLevel.HIGH
+    assert "firstName" in (finding.description + finding.evidence)
+
+
+@pytest.mark.asyncio
+async def test_post_body_xss_falls_back_to_generic_when_no_fields():
+    """Endpoints with no captured fields still use the generic list."""
+    ep = DiscoveredEndpoint(url="https://example.com/api", method=EndpointMethod.POST)
+    client = _echoing_client("comment")  # 'comment' is in the generic list
+    finding = await XSSScanner()._test_single_post_body(client, ep)
+    assert finding is not None and "comment" in finding.description
+
+
+@pytest.mark.asyncio
+async def test_post_body_xss_tries_form_then_json():
+    """Form-urlencoded is tried first; JSON is tried when the form doesn't reflect."""
+    ep = DiscoveredEndpoint(
+        url="https://example.com/profile", method=EndpointMethod.POST,
+        query_param_names=["firstName"],
+    )
+    # Only the JSON transport reflects -> scanner must fall through to it.
+    client = _echoing_client("firstName", only_content_type="application/json")
+    finding = await XSSScanner()._test_single_post_body(client, ep)
+    assert finding is not None
+    ctypes = [c["ctype"] for c in client._calls]
+    assert any("x-www-form-urlencoded" in c for c in ctypes)  # form tried first
+    assert any("application/json" in c for c in ctypes)        # json tried too


### PR DESCRIPTION
Partial fix for #109. The POST-body XSS test canaried a **fixed generic field list** (`name, comment, …`) with a **JSON body only** — so reflected XSS in real HTML form POSTs (app-specific fields like `firstName`/`lastName`, form-urlencoded) was systematically missed.

## Changes
- Canary the endpoint's **actual discovered fields** (`query_param_names`, extracted from the crawled `<form>`'s `<input name=…>`), falling back to the generic list only when none were captured (capped at `MAX_POST_BODY_FIELDS`).
- Try **both** `application/x-www-form-urlencoded` (most HTML forms) and JSON (APIs); use whichever reflects a canary, and report the real transport in the finding.

## Tests
3 new: discovered fields are used over the generic list; generic fallback still works; both content-types are attempted (form first, JSON fallback). 35 xss-scanner tests pass; ruff clean (no new violations).

## Scope note
This is a **real improvement** but does **not** on its own restore the NodeGoat authenticated XSS number — the XSS scanner also probes authenticated endpoints **without the session** (cookie-session auth isn't propagated to HTTP DAST scanners). That deeper, architectural gap is tracked separately (see #109's RCA). NodeGoat is also pinned + its number corrected in a separate PR (#108).

🤖 Generated with [Claude Code](https://claude.com/claude-code)