### PR TITLE
feat(dast): capture + propagate session-cookie auth to DAST scanners (#111)

### DIFF
--- a/isitsecure/engine/agent.py
+++ b/isitsecure/engine/agent.py
@@ -385,6 +385,15 @@ class DeepSecurityScanAgent:
                     if self._jwt_scanner:
                         self._jwt_scanner._auth_session = session_a
 
+                # Propagate the crawl's auth (bearer token AND/OR session cookie)
+                # to the HTTP DAST scanners so they probe protected endpoints
+                # authenticated — NOT gated on a bearer token, since cookie-session
+                # apps (traditional server-rendered web apps) have none. #111
+                if crawl_result.auth_headers:
+                    for dast_scanner in self._dast_scanners:
+                        if hasattr(dast_scanner, "_auth_headers"):
+                            dast_scanner._auth_headers = dict(crawl_result.auth_headers)
+
                 yield DeepScanEvent(
                     DeepScanPhase.AUTHENTICATING,
                     OrchestratorConfig.MSG_CRAWL_SUMMARY.format(

--- a/isitsecure/engine/constants.py
+++ b/isitsecure/engine/constants.py
@@ -13,6 +13,7 @@ class SharedPatterns:
     BEARER_PREFIX = "Bearer "
     HEADER_AUTHORIZATION = "Authorization"
     HEADER_APIKEY = "apikey"
+    HEADER_COOKIE = "Cookie"
     HEADER_CONTENT_TYPE = "Content-Type"
     CONTENT_TYPE_JSON = "application/json"
     HEADER_USER_AGENT = "User-Agent"

--- a/isitsecure/engine/scanners/authenticated_crawler.py
+++ b/isitsecure/engine/scanners/authenticated_crawler.py
@@ -256,6 +256,21 @@ class AuthenticatedCrawler:
             if apikey:
                 headers[SharedPatterns.HEADER_APIKEY] = apikey
 
+        # Session cookies: many traditional / server-rendered apps authenticate
+        # with a session cookie, not a bearer token. Capture the browser's
+        # cookies so downstream HTTP DAST scanners can probe protected endpoints
+        # authenticated (the crawl runs in an authed browser, but the follow-up
+        # httpx probes don't inherit its context). #111
+        try:
+            cookies = await page.context.cookies()  # type: ignore[union-attr]
+            cookie_header = "; ".join(
+                f"{c['name']}={c['value']}" for c in cookies if c.get("name")
+            )
+            if cookie_header:
+                headers[SharedPatterns.HEADER_COOKIE] = cookie_header
+        except Exception as exc:  # noqa: BLE001 - cookies are best-effort
+            logger.debug("Cookie capture failed: %s", exc)
+
         return headers
 
     # ------------------------------------------------------------------

--- a/isitsecure/engine/scanners/xss_scanner.py
+++ b/isitsecure/engine/scanners/xss_scanner.py
@@ -41,6 +41,11 @@ class XSSScanner:
     bodies) and static DOM sink analysis.
     """
 
+    def __init__(self) -> None:
+        # Auth headers (bearer token and/or session Cookie) injected by the
+        # authenticated scan path so probes reach protected endpoints. #111
+        self._auth_headers: dict[str, str] = {}
+
     @property
     def scanner_name(self) -> str:
         """Unique name identifying this scanner."""
@@ -101,6 +106,7 @@ class XSSScanner:
             delay_seconds=XSSConfig.PROBE_DELAY,
             timeout_seconds=XSSConfig.HTTP_TIMEOUT_SECONDS,
             user_agent=DeepScanConfig.USER_AGENT,
+            extra_headers=self._auth_headers or None,
         ) as client:
             for tested, endpoint in enumerate(candidates):
                 if budget.expired():
@@ -269,6 +275,7 @@ class XSSScanner:
             delay_seconds=XSSConfig.PROBE_DELAY,
             timeout_seconds=XSSConfig.HTTP_TIMEOUT_SECONDS,
             user_agent=DeepScanConfig.USER_AGENT,
+            extra_headers=self._auth_headers or None,
         ) as client:
             for endpoint in rank(post_endpoints, PriorityDimension.XSS)[: XSSConfig.MAX_POST_ENDPOINTS_TO_TEST]:
                 finding = await self._test_single_post_body(client, endpoint)

--- a/tests/engine/test_authenticated_crawler.py
+++ b/tests/engine/test_authenticated_crawler.py
@@ -554,3 +554,34 @@ class TestExtractAuthHeaders:
 
         headers = await crawler._extract_auth_headers(mock_page)
         assert "Bearer storage-token" in headers.get("Authorization", "")
+
+
+class TestExtractAuthHeadersCookies:
+    """#111 — capture session cookies (not just bearer tokens) for HTTP scanners."""
+
+    @pytest.mark.asyncio
+    async def test_captures_session_cookies(self):
+        crawler = _make_crawler()
+        page = MagicMock()
+        page.context.cookies = AsyncMock(return_value=[
+            {"name": "connect.sid", "value": "s%3Aabc"},
+            {"name": "csrf", "value": "xyz"},
+        ])
+        with patch(
+            "isitsecure.engine.scanners.authenticated_crawler.BrowserLoginHelper.extract_token",
+            AsyncMock(return_value=None),
+        ):
+            headers = await crawler._extract_auth_headers(page)
+        assert headers.get("Cookie") == "connect.sid=s%3Aabc; csrf=xyz"
+
+    @pytest.mark.asyncio
+    async def test_no_cookies_no_header(self):
+        crawler = _make_crawler()
+        page = MagicMock()
+        page.context.cookies = AsyncMock(return_value=[])
+        with patch(
+            "isitsecure.engine.scanners.authenticated_crawler.BrowserLoginHelper.extract_token",
+            AsyncMock(return_value=None),
+        ):
+            headers = await crawler._extract_auth_headers(page)
+        assert "Cookie" not in headers

--- a/tests/engine/test_xss_scanner.py
+++ b/tests/engine/test_xss_scanner.py
@@ -700,3 +700,64 @@ async def test_post_body_xss_tries_form_then_json():
     ctypes = [c["ctype"] for c in client._calls]
     assert any("x-www-form-urlencoded" in c for c in ctypes)  # form tried first
     assert any("application/json" in c for c in ctypes)        # json tried too
+
+
+@pytest.mark.asyncio
+async def test_post_body_xss_passes_auth_headers_to_client(monkeypatch):
+    """#111 — the scanner's _auth_headers (session cookie) reach its HTTP client."""
+    captured: dict = {}
+
+    class _FakeClient:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+        async def request(self, *a, **k):
+            return _make_html_response("")  # no reflection; we only check the ctor
+
+    monkeypatch.setattr(
+        "isitsecure.engine.scanners.xss_scanner.RateLimitedClient", _FakeClient
+    )
+    scanner = XSSScanner()
+    scanner._auth_headers = {"Cookie": "connect.sid=abc"}
+    ep = DiscoveredEndpoint(
+        url="https://ex.com/profile", method=EndpointMethod.POST,
+        query_param_names=["firstName"],
+    )
+    await scanner._test_post_body_xss([ep])
+    assert captured.get("extra_headers") == {"Cookie": "connect.sid=abc"}
+
+
+@pytest.mark.asyncio
+async def test_post_body_xss_no_auth_headers_passes_none(monkeypatch):
+    """Unauthenticated (url-only) scans pass no extra headers."""
+    captured: dict = {}
+
+    class _FakeClient:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+        async def request(self, *a, **k):
+            return _make_html_response("")
+
+    monkeypatch.setattr(
+        "isitsecure.engine.scanners.xss_scanner.RateLimitedClient", _FakeClient
+    )
+    scanner = XSSScanner()  # default _auth_headers = {}
+    ep = DiscoveredEndpoint(
+        url="https://ex.com/profile", method=EndpointMethod.POST,
+        query_param_names=["firstName"],
+    )
+    await scanner._test_post_body_xss([ep])
+    assert captured.get("extra_headers") is None


### PR DESCRIPTION
Partial fix for #111 — establishes the **cookie-session → DAST auth** mechanism.

## Problem
Authenticated DAST HTTP scanning only worked for token/bearer apps. The crawl captured only `Authorization: Bearer`/`apikey`, **never the session cookie** — so cookie-session apps (traditional server-rendered web apps) handed zero auth to the HTTP DAST scanners, which probed protected endpoints unauthenticated (302 → login).

## Changes
- **`_extract_auth_headers`** now also captures the browser context's session cookies into a `Cookie` header. Verified: for NodeGoat it yields `auth_headers keys=['Cookie']`.
- **`agent.py`** propagates the crawl's auth (bearer AND/OR cookie) to any DAST scanner exposing `_auth_headers` — not gated on a bearer token.
- **`XSSScanner`** opts in and threads the headers into its HTTP client. Verified in isolation: with the cookie + the form's real fields, it **catches** NodeGoat's authenticated `POST /profile` reflected XSS (1 HIGH).

## Tests
Crawler cookie capture (+ no-cookie case); XSS scanner passes/omits auth headers to its client. **113 tests pass.**

## Honest scope note
Deep RCA revealed the quick-depth benchmark can't yet validate this end-to-end: **`XSSScanner` is only wired into the scanner list at `--depth deep`**, and only it currently declares `_auth_headers`. So the quick-depth benchmark's HTTP DAST scanners (`ActiveInjectionScanner`, `MassAssignmentScanner`, …) don't yet inherit the session. This PR lands the **mechanism** (crawler capture + propagation + XSS opt-in); extending `_auth_headers` to the remaining HTTP DAST scanners — the change that restores the quick benchmark's authenticated coverage — is the tracked follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)