### PR TITLE
feat(dast): auth-aware mixin so quick-depth HTTP scanners probe authenticated (#115)

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ Without an API key, you still get all rule-based scanners — **41 in the defaul
 |---|---|---|
 | `url-only` | DAST scanners against a live URL | Target URL |
 | `code-only` | SAST scanners against source code | GitHub repo URL |
-| `authenticated` | DAST with login credentials (IDOR, cross-user BOLA, RLS, privilege escalation) | URL + credentials (add a second account for cross-user tests) |
+| `authenticated` | DAST with login credentials (IDOR, cross-user BOLA, RLS, privilege escalation) — plus the standard HTTP DAST scanners (injection, CSRF, SSRF, headers, …) now probe behind the login wall against protected endpoints | URL + credentials (add a second account for cross-user tests) |
 | `full` | Everything: SAST + DAST + authenticated + LLM review + cross-referencing | URL + repo + credentials + API key |
 | `auto` (default) | Detects mode from what you provide | Whatever you give it |
 

--- a/benchmarks/RESULTS.md
+++ b/benchmarks/RESULTS.md
@@ -17,7 +17,7 @@ _Runs: 2026-07 · `--llm none` (pure DAST detection, no LLM) · Juice Shop pinne
 | `juiceshop` | url-only | **20/45 (44%)** — per-challenge, deterministic | not yet measured | ~25 |
 | `vampi-vulnerable` | url-only | **3/3** (SQLi, IDOR, headers) | — | 14–16 |
 | `vampi-secure` | url-only | — | **2** (IDOR) | 13–15 |
-| `nodegoat-auth` | authenticated | **1/3** (headers only; XSS + injection missed) | unmeasured | 22 |
+| `nodegoat-auth` | authenticated | **2/3** (headers + injection; XSS missed) | unmeasured | 16 |
 | `sast-injection` | code-only | **46/46 (100%)** — taint, per-class, deterministic | **0** | 46 |
 
 ### SAST injection (`sast-injection`, code-only, taint layer #4 + #93 + #102 + #104)
@@ -124,17 +124,27 @@ walk ~32 pages, and discover **10 form endpoints**. NodeGoat is now **pinned to
 commit `c5cb68a`** for reproducibility (it's unversioned upstream, unlike Juice
 Shop's `v20.1.1` tag).
 
-Harness recall **1/3**: missing headers ✓, XSS ✗, injection ✗ — **deterministic
-across 4 consecutive runs** (22 findings each), down from a previously recorded
-2/3. **Root cause (investigated):** NodeGoat's `POST /profile` reflected XSS
-(`firstName`/`lastName` echoed unescaped) is real and the form *is* discovered
-with its real field names — but the **POST-body XSS scanner tests a fixed generic
-field list** (`name`/`comment`/…) instead of the form's discovered fields, so its
-canary lands in fields the app ignores. The reflected-XSS phase only tries those
-fields as *GET* params, which a POST-only form doesn't read. Net: reflected XSS
-in HTML form POSTs with app-specific field names is systematically missed —
-tracked as a detection gap. Juice Shop is stable at 20/45, so the DAST core is
-fine; this is specific to form-POST XSS.
+Harness recall **2/3**: missing headers ✓, injection ✓, XSS ✗ (16 findings),
+up from **1/3** after the authenticated-DAST fix (#111 → #114 + #115).
+
+**Injection — now caught.** NodeGoat is a cookie-session app (no bearer token),
+so before the fix the HTTP DAST scanners probed *unauthenticated* and every
+protected endpoint bounced them to the login page — nothing to attack. The
+authenticated crawl now captures the session cookie (#114) and the orchestrator
+propagates it to every HTTP DAST scanner via the `AuthAwareScanner` mixin (#115),
+so `ActiveInjectionScanner` probes the protected endpoints behind the login wall
+and the injection surfaces.
+
+**XSS — still missed, separate gap.** NodeGoat's `POST /profile` reflected XSS
+(`firstName`/`lastName` echoed unescaped) is real, the form is discovered with
+its real field names, and the POST-body XSS scanner now tests the discovered
+fields (#110) with the session cookie attached — so the reflected XSS *is*
+detectable in isolation. But the full `XSSScanner` only runs at `--depth deep`;
+at the depth this benchmark uses, the quick HTTP DAST set doesn't include it
+(`DomXssScanner` is DOM-only, `ActiveInjectionScanner` targets SQLi/command
+injection). Wiring `XSSScanner` (or reflected-XSS coverage) into the quick-depth
+set is a separate follow-up. Juice Shop is stable at 20/45, so the DAST core is
+fine; this is specific to reflected XSS at quick depth.
 
 ## How to read these numbers
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -57,6 +57,8 @@ If credentials are provided:
 
 For frontend-less REST APIs, `RestLoginAuthProvider` (the `token` auth provider) skips the browser entirely: it POSTs credentials to a login endpoint (auto-discovered, or given via `--login-url`), extracts the bearer token from the JSON response (or via JWT regex), and builds an authenticated session directly.
 
+After the crawl, the orchestrator hands the captured auth (bearer token and/or session cookie) to every HTTP DAST scanner that exposes `_auth_headers` (the `AuthAwareScanner` mixin in `engine/shared/auth_aware.py`). Each such scanner passes those headers as `extra_headers` to its `RateLimitedClient`, so the standard probes — injection, CSRF, SSRF, CORS, headers, open-redirect, mass-assignment, file-upload, GraphQL, HTTP-probe, source-map — run behind the login wall against protected endpoints instead of being redirected to the login page.
+
 ### Phase 4–5: DAST Scanners
 
 15 standard scanners run in parallel with per-scanner timeouts:

--- a/isitsecure/engine/scanners/active_injection_scanner.py
+++ b/isitsecure/engine/scanners/active_injection_scanner.py
@@ -40,11 +40,12 @@ from isitsecure.engine.shared.time_budget import TimeBudget
 from isitsecure.engine.shared.rate_limited_client import RateLimitedClient
 from isitsecure.engine.shared.url_utils import inject_query_param
 from isitsecure.engine.enums import FindingCategory, SeverityLevel
+from isitsecure.engine.shared.auth_aware import AuthAwareScanner
 
 logger = logging.getLogger(__name__)
 
 
-class ActiveInjectionScanner:
+class ActiveInjectionScanner(AuthAwareScanner):
     """Active injection scanner implementing DASTScannerProtocol.
 
     Scans discovered endpoints for SQL injection, NoSQL injection,
@@ -96,6 +97,7 @@ class ActiveInjectionScanner:
             delay_seconds=InjectionConfig.PROBE_DELAY,
             timeout_seconds=InjectionConfig.HTTP_TIMEOUT_SECONDS,
             user_agent=DeepScanConfig.USER_AGENT,
+            extra_headers=self.auth_headers,
         ) as client:
             # Target-level probe: auth-bypass SQLi on conventional login paths.
             # A login POST is rarely recoverable from a minified SPA bundle, so

--- a/isitsecure/engine/scanners/cors_scanner.py
+++ b/isitsecure/engine/scanners/cors_scanner.py
@@ -23,11 +23,12 @@ from isitsecure.engine.shared.probe_capture import build_probe_capture
 from isitsecure.engine.shared.rate_limited_client import RateLimitedClient
 from isitsecure.engine.enums import FindingCategory, SeverityLevel
 from isitsecure.engine.ingestion.snapshot import CodebaseSnapshot
+from isitsecure.engine.shared.auth_aware import AuthAwareScanner
 
 logger = logging.getLogger(__name__)
 
 
-class CORSScanner:
+class CORSScanner(AuthAwareScanner):
     """CORS misconfiguration scanner implementing DASTScannerProtocol.
 
     Sends preflight-style requests with various Origin headers to detect
@@ -73,6 +74,7 @@ class CORSScanner:
             delay_seconds=CORSConfig.PROBE_DELAY,
             timeout_seconds=CORSConfig.HTTP_TIMEOUT_SECONDS,
             user_agent=DeepScanConfig.USER_AGENT,
+            extra_headers=self.auth_headers,
         ) as client:
             for ep in representative:
                 ep_findings = await self._test_endpoint(client, ep)

--- a/isitsecure/engine/scanners/csrf_scanner.py
+++ b/isitsecure/engine/scanners/csrf_scanner.py
@@ -22,11 +22,12 @@ from isitsecure.engine.shared.endpoint_prioritizer import PriorityDimension, ran
 from isitsecure.engine.shared.rate_limited_client import RateLimitedClient
 from isitsecure.engine.enums import FindingCategory, SeverityLevel
 from isitsecure.engine.ingestion.snapshot import CodebaseSnapshot
+from isitsecure.engine.shared.auth_aware import AuthAwareScanner
 
 logger = logging.getLogger(__name__)
 
 
-class CSRFScanner:
+class CSRFScanner(AuthAwareScanner):
     """CSRF scanner implementing DASTScannerProtocol.
 
     Detects missing Cross-Site Request Forgery protections on
@@ -103,6 +104,7 @@ class CSRFScanner:
             delay_seconds=self.REQUEST_DELAY_SECONDS,
             timeout_seconds=CSRFConfig.HTTP_TIMEOUT_SECONDS,
             user_agent=DeepScanConfig.USER_AGENT,
+            extra_headers=self.auth_headers,
         ) as client:
             for ep in rank(endpoints, PriorityDimension.CSRF)[: CSRFConfig.MAX_ENDPOINTS_TO_TEST]:
                 finding = await self._test_forged_origin(client, ep)

--- a/isitsecure/engine/scanners/file_upload_scanner.py
+++ b/isitsecure/engine/scanners/file_upload_scanner.py
@@ -19,11 +19,12 @@ from isitsecure.engine.models import (
 from isitsecure.engine.shared.rate_limited_client import RateLimitedClient
 from isitsecure.engine.enums import FindingCategory, SeverityLevel
 from isitsecure.engine.ingestion.snapshot import CodebaseSnapshot
+from isitsecure.engine.shared.auth_aware import AuthAwareScanner
 
 logger = logging.getLogger(__name__)
 
 
-class FileUploadScanner:
+class FileUploadScanner(AuthAwareScanner):
     """Tests file upload endpoints for vulnerabilities.
 
     Detects upload endpoints from path indicators, then tests for
@@ -71,6 +72,7 @@ class FileUploadScanner:
             delay_seconds=FileUploadConfig.PROBE_DELAY,
             timeout_seconds=FileUploadConfig.HTTP_TIMEOUT_SECONDS,
             user_agent=DeepScanConfig.USER_AGENT,
+            extra_headers=self.auth_headers,
         ) as client:
             for endpoint in upload_endpoints:
                 ep_findings = await self._test_endpoint(client, endpoint)

--- a/isitsecure/engine/scanners/graphql_scanner.py
+++ b/isitsecure/engine/scanners/graphql_scanner.py
@@ -20,11 +20,12 @@ from isitsecure.engine.models import (
 from isitsecure.engine.shared.rate_limited_client import RateLimitedClient
 from isitsecure.engine.enums import FindingCategory, SeverityLevel
 from isitsecure.engine.ingestion.snapshot import CodebaseSnapshot
+from isitsecure.engine.shared.auth_aware import AuthAwareScanner
 
 logger = logging.getLogger(__name__)
 
 
-class GraphQLScanner:
+class GraphQLScanner(AuthAwareScanner):
     """Tests GraphQL endpoints for common vulnerabilities.
 
     Detects GraphQL endpoints from path indicators, then probes for
@@ -71,6 +72,7 @@ class GraphQLScanner:
             delay_seconds=GraphQLConfig.PROBE_DELAY,
             timeout_seconds=GraphQLConfig.HTTP_TIMEOUT_SECONDS,
             user_agent=DeepScanConfig.USER_AGENT,
+            extra_headers=self.auth_headers,
         ) as client:
             for endpoint in graphql_endpoints:
                 ep_findings = await self._test_endpoint(client, endpoint)

--- a/isitsecure/engine/scanners/http_probe_scanner.py
+++ b/isitsecure/engine/scanners/http_probe_scanner.py
@@ -31,11 +31,12 @@ from isitsecure.engine.shared.rate_limited_client import (
 from isitsecure.engine.shared.url_utils import inject_query_param
 from isitsecure.engine.enums import FindingCategory, SeverityLevel
 from isitsecure.engine.ingestion.snapshot import CodebaseSnapshot
+from isitsecure.engine.shared.auth_aware import AuthAwareScanner
 
 logger = logging.getLogger(__name__)
 
 
-class HTTPProbeScanner:
+class HTTPProbeScanner(AuthAwareScanner):
     """Probes HTTP configuration for misconfigurations and info leaks.
 
     Implements DASTScannerProtocol.
@@ -74,6 +75,7 @@ class HTTPProbeScanner:
             delay_seconds=HTTPProbeConfig.PROBE_DELAY,
             timeout_seconds=DeepScanConfig.HTTP_TIMEOUT_SECONDS,
             user_agent=DeepScanConfig.USER_AGENT,
+            extra_headers=self.auth_headers,
         ) as client:
             emit("http-probe: method tampering (OPTIONS/TRACE)")
             findings.extend(

--- a/isitsecure/engine/scanners/mass_assignment_scanner.py
+++ b/isitsecure/engine/scanners/mass_assignment_scanner.py
@@ -22,11 +22,12 @@ from isitsecure.engine.models import (
 from isitsecure.engine.shared.rate_limited_client import RateLimitedClient
 from isitsecure.engine.enums import FindingCategory, SeverityLevel
 from isitsecure.engine.ingestion.snapshot import CodebaseSnapshot
+from isitsecure.engine.shared.auth_aware import AuthAwareScanner
 
 logger = logging.getLogger(__name__)
 
 
-class MassAssignmentScanner:
+class MassAssignmentScanner(AuthAwareScanner):
     """Tests API endpoints for mass assignment vulnerabilities.
 
     Finds POST/PUT/PATCH endpoints and sends requests with extra
@@ -75,6 +76,7 @@ class MassAssignmentScanner:
             delay_seconds=MassAssignmentConfig.PROBE_DELAY,
             timeout_seconds=MassAssignmentConfig.HTTP_TIMEOUT_SECONDS,
             user_agent=DeepScanConfig.USER_AGENT,
+            extra_headers=self.auth_headers,
         ) as client:
             for endpoint in state_changing_endpoints:
                 ep_findings = await self._test_endpoint(client, endpoint)

--- a/isitsecure/engine/scanners/open_redirect_scanner.py
+++ b/isitsecure/engine/scanners/open_redirect_scanner.py
@@ -24,11 +24,12 @@ from isitsecure.engine.shared.rate_limited_client import RateLimitedClient
 from isitsecure.engine.shared.url_utils import inject_query_param
 from isitsecure.engine.enums import FindingCategory, SeverityLevel
 from isitsecure.engine.ingestion.snapshot import CodebaseSnapshot
+from isitsecure.engine.shared.auth_aware import AuthAwareScanner
 
 logger = logging.getLogger(__name__)
 
 
-class OpenRedirectScanner:
+class OpenRedirectScanner(AuthAwareScanner):
     """Open Redirect scanner implementing DASTScannerProtocol.
 
     Identifies endpoints that accept redirect-like parameters or reside
@@ -76,6 +77,7 @@ class OpenRedirectScanner:
             delay_seconds=OpenRedirectConfig.PROBE_DELAY,
             timeout_seconds=OpenRedirectConfig.HTTP_TIMEOUT_SECONDS,
             user_agent=DeepScanConfig.USER_AGENT,
+            extra_headers=self.auth_headers,
             follow_redirects=False,
         ) as client:
             for endpoint, param_name in testable:

--- a/isitsecure/engine/scanners/security_headers_scanner.py
+++ b/isitsecure/engine/scanners/security_headers_scanner.py
@@ -31,6 +31,7 @@ from isitsecure.engine.shared.rate_limited_client import (
 )
 from isitsecure.engine.enums import FindingCategory, SeverityLevel
 from isitsecure.engine.ingestion.snapshot import CodebaseSnapshot
+from isitsecure.engine.shared.auth_aware import AuthAwareScanner
 
 logger = logging.getLogger(__name__)
 
@@ -48,7 +49,7 @@ class _HeaderCheckType(str, Enum):
     X_POWERED_BY_PRESENT = "x_powered_by_present"
 
 
-class SecurityHeadersScanner:
+class SecurityHeadersScanner(AuthAwareScanner):
     """Security headers scanner implementing DASTScannerProtocol.
 
     Detects missing or misconfigured HTTP security headers by making
@@ -191,6 +192,7 @@ class SecurityHeadersScanner:
             delay_seconds=self.REQUEST_DELAY_SECONDS,
             timeout_seconds=SecurityHeadersScannerConfig.HTTP_TIMEOUT_SECONDS,
             user_agent=DeepScanConfig.USER_AGENT,
+            extra_headers=self.auth_headers,
         ) as client:
             for url in urls:
                 url_findings = await self._check_single_endpoint(client, url)

--- a/isitsecure/engine/scanners/source_map_scanner.py
+++ b/isitsecure/engine/scanners/source_map_scanner.py
@@ -32,6 +32,7 @@ from isitsecure.engine.models import (
 from isitsecure.engine.shared.rate_limited_client import RateLimitedClient
 from isitsecure.engine.enums import FindingCategory, SeverityLevel
 from isitsecure.engine.ingestion.snapshot import CodebaseSnapshot
+from isitsecure.engine.shared.auth_aware import AuthAwareScanner
 
 logger = logging.getLogger(__name__)
 
@@ -50,7 +51,7 @@ _SOURCE_MAP_MARKERS = ('"sources":', '"mappings":')
 _JS_SUFFIXES = (".js", ".mjs", ".cjs")
 
 
-class SourceMapScanner:
+class SourceMapScanner(AuthAwareScanner):
     """Detects exposed JavaScript source maps.
 
     SRP: This scanner is responsible ONLY for confirming reachable,
@@ -97,6 +98,7 @@ class SourceMapScanner:
             delay_seconds=_REQUEST_DELAY_SECONDS,
             timeout_seconds=_HTTP_TIMEOUT_SECONDS,
             user_agent=DeepScanConfig.USER_AGENT,
+            extra_headers=self.auth_headers,
         ) as client:
             for map_url in candidates:
                 if map_url in seen:

--- a/isitsecure/engine/scanners/ssrf_scanner.py
+++ b/isitsecure/engine/scanners/ssrf_scanner.py
@@ -20,11 +20,12 @@ from isitsecure.engine.shared.rate_limited_client import RateLimitedClient
 from isitsecure.engine.shared.url_utils import inject_query_param
 from isitsecure.engine.enums import FindingCategory, SeverityLevel
 from isitsecure.engine.ingestion.snapshot import CodebaseSnapshot
+from isitsecure.engine.shared.auth_aware import AuthAwareScanner
 
 logger = logging.getLogger(__name__)
 
 
-class SSRFScanner:
+class SSRFScanner(AuthAwareScanner):
     """Tests for Server-Side Request Forgery vulnerabilities.
 
     Identifies endpoints with URL-accepting parameters and injects
@@ -70,6 +71,7 @@ class SSRFScanner:
             delay_seconds=SSRFConfig.PROBE_DELAY,
             timeout_seconds=SSRFConfig.HTTP_TIMEOUT_SECONDS,
             user_agent=DeepScanConfig.USER_AGENT,
+            extra_headers=self.auth_headers,
         ) as client:
             for endpoint, param_name in testable:
                 ep_findings = await self._test_endpoint_param(

--- a/isitsecure/engine/scanners/xss_scanner.py
+++ b/isitsecure/engine/scanners/xss_scanner.py
@@ -22,6 +22,7 @@ from isitsecure.engine.models import (
     DiscoveredEndpoint,
     FindingSource,
 )
+from isitsecure.engine.shared.auth_aware import AuthAwareScanner
 from isitsecure.engine.shared.endpoint_prioritizer import PriorityDimension, rank
 from isitsecure.engine.shared.probe_capture import build_probe_capture
 from isitsecure.engine.shared.rate_limited_client import RateLimitedClient
@@ -34,17 +35,15 @@ from isitsecure.engine.ingestion.snapshot import CodebaseSnapshot
 logger = logging.getLogger(__name__)
 
 
-class XSSScanner:
+class XSSScanner(AuthAwareScanner):
     """Active XSS scanner implementing DASTScannerProtocol.
 
     Performs canary-based reflected XSS testing (GET query params and POST
     bodies) and static DOM sink analysis.
-    """
 
-    def __init__(self) -> None:
-        # Auth headers (bearer token and/or session Cookie) injected by the
-        # authenticated scan path so probes reach protected endpoints. #111
-        self._auth_headers: dict[str, str] = {}
+    Auth headers (bearer token and/or session Cookie) reach probes via the
+    ``AuthAwareScanner`` mixin's ``_auth_headers`` slot (#111, generalized #115).
+    """
 
     @property
     def scanner_name(self) -> str:
@@ -106,7 +105,7 @@ class XSSScanner:
             delay_seconds=XSSConfig.PROBE_DELAY,
             timeout_seconds=XSSConfig.HTTP_TIMEOUT_SECONDS,
             user_agent=DeepScanConfig.USER_AGENT,
-            extra_headers=self._auth_headers or None,
+            extra_headers=self.auth_headers,
         ) as client:
             for tested, endpoint in enumerate(candidates):
                 if budget.expired():
@@ -275,7 +274,7 @@ class XSSScanner:
             delay_seconds=XSSConfig.PROBE_DELAY,
             timeout_seconds=XSSConfig.HTTP_TIMEOUT_SECONDS,
             user_agent=DeepScanConfig.USER_AGENT,
-            extra_headers=self._auth_headers or None,
+            extra_headers=self.auth_headers,
         ) as client:
             for endpoint in rank(post_endpoints, PriorityDimension.XSS)[: XSSConfig.MAX_POST_ENDPOINTS_TO_TEST]:
                 finding = await self._test_single_post_body(client, endpoint)

--- a/isitsecure/engine/shared/auth_aware.py
+++ b/isitsecure/engine/shared/auth_aware.py
@@ -1,0 +1,26 @@
+"""Auth-aware DAST scanner mixin (#115).
+
+DAST HTTP scanners that probe endpoints inherit this so the authenticated scan
+path can hand them the session's auth (bearer token and/or session cookie). The
+orchestrator sets ``_auth_headers`` on every scanner exposing it after an
+authenticated crawl; each scanner passes ``self.auth_headers`` as
+``extra_headers`` to its ``RateLimitedClient`` so probes reach protected
+endpoints instead of being redirected to login.
+
+``_auth_headers`` is a class-level default so ``hasattr(scanner, "_auth_headers")``
+is always true (the orchestrator's propagation guard); the orchestrator assigns a
+fresh per-instance dict, so the shared default is only ever read, never mutated.
+"""
+
+from __future__ import annotations
+
+
+class AuthAwareScanner:
+    """Mixin giving a DAST scanner an injectable auth-headers slot."""
+
+    _auth_headers: dict[str, str] = {}
+
+    @property
+    def auth_headers(self) -> dict[str, str] | None:
+        """Auth headers for the scanner's HTTP client, or None when unauthenticated."""
+        return self._auth_headers or None

--- a/tests/engine/test_auth_aware.py
+++ b/tests/engine/test_auth_aware.py
@@ -1,0 +1,135 @@
+"""Tests for the auth-aware DAST scanner mixin (#115)."""
+
+import datetime
+
+import httpx
+import pytest
+
+from isitsecure.engine.enums import EndpointMethod
+from isitsecure.engine.factory import create_deep_security_scan_agent
+from isitsecure.engine.models import DiscoveredEndpoint
+from isitsecure.engine.scanners.csrf_scanner import CSRFScanner
+from isitsecure.engine.shared.auth_aware import AuthAwareScanner
+
+# The HTTP-probing quick-depth DAST scanners that must carry the session (#115).
+_HTTP_DAST = {
+    "ActiveInjectionScanner", "CSRFScanner", "SSRFScanner", "MassAssignmentScanner",
+    "OpenRedirectScanner", "HTTPProbeScanner", "FileUploadScanner", "GraphQLScanner",
+    "CORSScanner", "SecurityHeadersScanner", "SourceMapScanner",
+}
+
+
+class TestMixin:
+    def test_default_is_none(self):
+        assert AuthAwareScanner().auth_headers is None
+
+    def test_returns_set_headers(self):
+        s = AuthAwareScanner()
+        s._auth_headers = {"Cookie": "connect.sid=abc"}
+        assert s.auth_headers == {"Cookie": "connect.sid=abc"}
+
+    def test_empty_dict_is_none(self):
+        s = AuthAwareScanner()
+        s._auth_headers = {}
+        assert s.auth_headers is None
+
+
+def test_http_dast_scanners_are_auth_aware():
+    """Every HTTP-probing quick-depth DAST scanner inherits the mixin, so the
+    authenticated scan path can hand it the session."""
+    agent = create_deep_security_scan_agent()
+    aware = {type(s).__name__ for s in agent._dast_scanners if isinstance(s, AuthAwareScanner)}
+    missing = _HTTP_DAST - aware
+    assert not missing, f"HTTP DAST scanners missing auth support: {missing}"
+
+
+@pytest.mark.asyncio
+async def test_csrf_scanner_passes_auth_headers_to_client(monkeypatch):
+    """A representative scanner threads its _auth_headers into the HTTP client."""
+    captured: dict = {}
+
+    class _FakeClient:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+        async def request(self, *a, **k):
+            r = httpx.Response(200, headers={"content-type": "text/html"}, text="",
+                               request=httpx.Request("POST", "https://ex.com/x"))
+            r.elapsed = datetime.timedelta(milliseconds=1)
+            return r
+
+        async def get(self, *a, **k):
+            return await self.request("GET", *a, **k)
+
+    monkeypatch.setattr(
+        "isitsecure.engine.scanners.csrf_scanner.RateLimitedClient", _FakeClient
+    )
+    scanner = CSRFScanner()
+    scanner._auth_headers = {"Cookie": "connect.sid=abc"}
+    ep = DiscoveredEndpoint(url="https://ex.com/transfer", method=EndpointMethod.POST)
+    await scanner.scan([ep], snapshot=None)
+    assert captured.get("extra_headers") == {"Cookie": "connect.sid=abc"}
+
+
+@pytest.mark.asyncio
+async def test_unauthenticated_scanner_passes_none_to_client(monkeypatch):
+    """With no auth injected, the scanner must pass extra_headers=None (not {})
+    so an unauthenticated scan behaves exactly as before #115."""
+    captured: dict = {}
+
+    class _FakeClient:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+        async def request(self, *a, **k):
+            r = httpx.Response(200, headers={"content-type": "text/html"}, text="",
+                               request=httpx.Request("POST", "https://ex.com/x"))
+            r.elapsed = datetime.timedelta(milliseconds=1)
+            return r
+
+        async def get(self, *a, **k):
+            return await self.request("GET", *a, **k)
+
+    monkeypatch.setattr(
+        "isitsecure.engine.scanners.csrf_scanner.RateLimitedClient", _FakeClient
+    )
+    scanner = CSRFScanner()  # _auth_headers left at the empty default
+    ep = DiscoveredEndpoint(url="https://ex.com/transfer", method=EndpointMethod.POST)
+    await scanner.scan([ep], snapshot=None)
+    assert captured.get("extra_headers") is None
+
+
+def test_propagation_gives_each_scanner_an_isolated_copy():
+    """Mirror the orchestrator's propagation (agent.py): the guard hits every
+    HTTP DAST scanner, and each gets its OWN copy of the crawl auth — mutating
+    one scanner's headers must not leak into another or into the source dict."""
+    agent = create_deep_security_scan_agent()
+    crawl_auth = {"Cookie": "connect.sid=abc"}
+
+    # This is exactly the loop in agent.py's authenticated path.
+    for scanner in agent._dast_scanners:
+        if hasattr(scanner, "_auth_headers"):
+            scanner._auth_headers = dict(crawl_auth)
+
+    aware = [s for s in agent._dast_scanners if isinstance(s, AuthAwareScanner)]
+    assert aware, "expected some auth-aware scanners"
+    for s in aware:
+        assert s.auth_headers == {"Cookie": "connect.sid=abc"}
+        assert s._auth_headers is not crawl_auth  # fresh per-instance copy
+
+    # Mutating one scanner's copy leaks nowhere.
+    aware[0]._auth_headers["Cookie"] = "tampered"
+    assert crawl_auth == {"Cookie": "connect.sid=abc"}
+    assert aware[1].auth_headers == {"Cookie": "connect.sid=abc"}


### PR DESCRIPTION
Closes #115. Follow-up to #111/#114.

## Problem
Cookie-session apps (no bearer token — traditional server-rendered web apps like NodeGoat) bounced the quick-depth HTTP DAST scanners to the login page, so **protected endpoints went untested**. #114 gave the crawler cookie capture + orchestrator propagation; this wires up the receiving end so the scanners actually carry the session.

## Change
- **New `AuthAwareScanner` mixin** (`engine/shared/auth_aware.py`) — an injectable `_auth_headers` slot + `auth_headers` property (returns the dict or `None`).
- **11 HTTP-probing quick-depth scanners** inherit it and pass `extra_headers=self.auth_headers` to their `RateLimitedClient`: active-injection, CSRF, SSRF, mass-assignment, CORS, open-redirect, HTTP-probe, file-upload, GraphQL, security-headers, source-map.
- The orchestrator (#114) already sets `_auth_headers` on every scanner exposing it after an authenticated crawl (`hasattr` guard, fresh per-instance dict copy).
- **`XSSScanner` (#111) refactored onto the same mixin**, removing its hand-rolled duplicate (`__init__` + two `extra_headers` sites).
- Static-only scanners (session, mixed-content, SRI, client-exposure) construct no HTTP client and are correctly excluded.

## Benchmark (detection gate)
| Target | Before | After |
|---|--:|--:|
| `nodegoat-auth` | 1/3 (headers only) | **2/3** — headers ✓, **injection ✓**, XSS ✗ |
| `vampi-secure` (FP) | 2 (IDOR) | **2 (IDOR)** — no new FPs |

- **Injection now caught**: `ActiveInjectionScanner` reaches NodeGoat's protected endpoints with the session cookie.
- **XSS still missed at quick depth** — the full `XSSScanner` only runs at `--depth deep`; the quick set doesn't include it. Separate, pre-existing gap → filed as a follow-up.
- **No new FPs**: the vampi-secure baseline (2 IDOR) reproduced on-branch; a one-off SQLi in an earlier run was active-injection flakiness, confirmed by a matching re-run against `main`. The change is a provable no-op in url-only mode (no crawl → `_auth_headers` stays empty → `extra_headers=None`).

## Quality gates
- Adversarial code + doc review run; all warranted fixes applied (XSS de-dup, blank-line cleanup, negative + propagation-isolation tests, README/architecture/RESULTS doc updates).
- Full engine test suite green (1946 passed); 12 auth-aware tests. New files ruff-clean; touched scanners add zero new ruff errors.

## Docs (ship with the code)
- `README.md` — `authenticated` scan-mode row now notes the standard HTTP scanners probe behind the login wall.
- `docs/architecture.md` — Phase 3→4 auth-propagation paragraph + the new mixin.
- `benchmarks/RESULTS.md` — nodegoat-auth 2/3 with the XSS-at-quick-depth explanation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)