### PR TITLE
feat(dast): run a lightweight reflected XSS pass at quick depth (#118)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Built for developers and **vibe coders** shipping web apps who need to know if t
 
 ## What It Does
 
-isitsecure runs **41 rule-based scanners by default** — up to **45 with `--depth deep`** — (plus optional AI code review) against your web app in a single command. It combines four approaches that commercial tools sell separately:
+isitsecure runs **42 rule-based scanners by default** — up to **45 with `--depth deep`** — (plus optional AI code review) against your web app in a single command. It combines four approaches that commercial tools sell separately:
 
 - **SAST (Static Analysis)** — scans your source code for vulnerabilities without running it
 - **DAST (Dynamic Analysis)** — tests your live app by sending real HTTP requests
@@ -147,7 +147,7 @@ isitsecure is free and open source. The only cost is LLM API tokens for the AI-p
 | **Code-only + LLM review** | Yes | ~$5–8 |
 | **Full scan** (SAST + DAST + LLM) | Yes | ~$10–15 |
 
-Without an API key, you still get all rule-based scanners — **41 in the default `quick` depth** (15 DAST + 8 special DAST + 18 SAST), or **45 with `--depth deep`** (which adds 4 slower/aggressive DAST scanners). The LLM adds business logic review, semantic rule verification, and intelligent triage — things no pattern matcher can do.
+Without an API key, you still get all rule-based scanners — **42 in the default `quick` depth** (16 DAST + 8 special DAST + 18 SAST), or **45 with `--depth deep`** (which adds 3 slower/aggressive DAST scanners). The LLM adds business logic review, semantic rule verification, and intelligent triage — things no pattern matcher can do.
 
 **Supported LLM providers:** Anthropic (Claude), Google (Gemini)
 
@@ -167,8 +167,8 @@ Orthogonal to mode, `--depth` trades speed for coverage:
 
 | Depth | What runs | When to use |
 |---|---|---|
-| `quick` (default) | Structural + config checks, error-based injection, and the snapshot-based scanners (headers, CORS, RLS, source-map, SRI, client-exposure, redirects…). Fast. | Everyday scans — a solid first pass in a fraction of the time. |
-| `deep` | Everything in `quick` **plus** the slow/aggressive probes: time-based (blind) SQL injection, active XSS, auth-bypass timing, rate-limit bursts, and password-reset flows. | When you want the full arsenal and can wait. |
+| `quick` (default) | Structural + config checks, error-based injection, a lightweight reflected + POST-body XSS pass, and the snapshot-based scanners (headers, CORS, RLS, source-map, SRI, client-exposure, redirects…). Fast. | Everyday scans — a solid first pass in a fraction of the time. |
+| `deep` | Everything in `quick` **plus** the slow/aggressive probes: time-based (blind) SQL injection, the full XSS pass (adds static DOM sink analysis), auth-bypass timing, rate-limit bursts, and password-reset flows. | When you want the full arsenal and can wait. |
 
 ```bash
 # Fast pass (default)
@@ -184,11 +184,11 @@ The scan narrates each phase and every scanner as it runs (with elapsed time), s
 
 ### DAST Scanners — Tests Your Live App
 
-**19 total** — 15 run in the default `quick` depth; the 4 marked **◆** (slower/aggressive probes) are added by `--depth deep`.
+**19 total** — 16 run in the default `quick` depth; the 3 marked **◆** (slower/aggressive probes) are added by `--depth deep`.
 
 | Scanner | What It Finds |
 |---|---|
-| XSS Scanner **◆** | Reflected, POST body, and DOM-based cross-site scripting |
+| XSS Scanner | Reflected, POST body, and DOM-based cross-site scripting (quick runs the reflected + POST-body network phases; `--depth deep` adds the static DOM sink pass) |
 | Active Injection Scanner | SQL injection (error + time-based, incl. SQLAlchemy/sqlite3/psycopg errors), command injection, NoSQL injection, XXE, SSTI — injects query, body, and path parameters |
 | CSRF Scanner | Cross-site request forgery on state-changing endpoints |
 | Rate Limit Scanner **◆** | Missing or bypassable rate limiting on auth endpoints |

--- a/benchmarks/RESULTS.md
+++ b/benchmarks/RESULTS.md
@@ -17,7 +17,7 @@ _Runs: 2026-07 · `--llm none` (pure DAST detection, no LLM) · Juice Shop pinne
 | `juiceshop` | url-only | **20/45 (44%)** — per-challenge, deterministic | not yet measured | ~25 |
 | `vampi-vulnerable` | url-only | **3/3** (SQLi, IDOR, headers) | — | 14–16 |
 | `vampi-secure` | url-only | — | **2** (IDOR) | 13–15 |
-| `nodegoat-auth` | authenticated | **2/3** (headers + injection; XSS missed) | unmeasured | 16 |
+| `nodegoat-auth` | authenticated | **3/3** (headers + injection + XSS) | unmeasured | 19 |
 | `sast-injection` | code-only | **46/46 (100%)** — taint, per-class, deterministic | **0** | 46 |
 
 ### SAST injection (`sast-injection`, code-only, taint layer #4 + #93 + #102 + #104)
@@ -124,27 +124,28 @@ walk ~32 pages, and discover **10 form endpoints**. NodeGoat is now **pinned to
 commit `c5cb68a`** for reproducibility (it's unversioned upstream, unlike Juice
 Shop's `v20.1.1` tag).
 
-Harness recall **2/3**: missing headers ✓, injection ✓, XSS ✗ (16 findings),
-up from **1/3** after the authenticated-DAST fix (#111 → #114 + #115).
+Harness recall **3/3**: missing headers ✓, injection ✓, XSS ✓ (19 findings),
+climbing from **1/3** (auth mechanism, #111 → #114 + #115) to **2/3** to the
+full **3/3** once reflected XSS was wired into the quick-depth set (#118).
 
-**Injection — now caught.** NodeGoat is a cookie-session app (no bearer token),
-so before the fix the HTTP DAST scanners probed *unauthenticated* and every
-protected endpoint bounced them to the login page — nothing to attack. The
+**Injection — caught (#114 + #115).** NodeGoat is a cookie-session app (no bearer
+token), so before the fix the HTTP DAST scanners probed *unauthenticated* and
+every protected endpoint bounced them to the login page — nothing to attack. The
 authenticated crawl now captures the session cookie (#114) and the orchestrator
 propagates it to every HTTP DAST scanner via the `AuthAwareScanner` mixin (#115),
 so `ActiveInjectionScanner` probes the protected endpoints behind the login wall
 and the injection surfaces.
 
-**XSS — still missed, separate gap.** NodeGoat's `POST /profile` reflected XSS
+**XSS — caught (#118).** NodeGoat's `POST /profile` reflected XSS
 (`firstName`/`lastName` echoed unescaped) is real, the form is discovered with
-its real field names, and the POST-body XSS scanner now tests the discovered
-fields (#110) with the session cookie attached — so the reflected XSS *is*
-detectable in isolation. But the full `XSSScanner` only runs at `--depth deep`;
-at the depth this benchmark uses, the quick HTTP DAST set doesn't include it
-(`DomXssScanner` is DOM-only, `ActiveInjectionScanner` targets SQLi/command
-injection). Wiring `XSSScanner` (or reflected-XSS coverage) into the quick-depth
-set is a separate follow-up. Juice Shop is stable at 20/45, so the DAST core is
-fine; this is specific to reflected XSS at quick depth.
+its real field names, and the POST-body XSS scanner tests the discovered fields
+(#110) with the session cookie attached. The last gap was that the full
+`XSSScanner` only ran at `--depth deep`. #118 adds a **lightweight XSS pass to the
+quick-depth set** (reflected + POST-body network phases on a tighter 2-min budget;
+the static DOM sink analysis stays deep-only), so the authenticated reflected XSS
+is now caught at the benchmark's default depth. Juice Shop stays stable and
+vampi-secure gains no false positives (the quick XSS pass is canary-based:
+unescaped reflection of a unique probe, which a hardened app doesn't produce).
 
 ## How to read these numbers
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -11,7 +11,7 @@ Phase 1:  URL Ingestion          ─── Playwright captures HTML + JS bundles
 Phase 2:  Endpoint Discovery     ─── JS bundles + OpenAPI specs + HTML forms + active probing
 Phase 3:  Authenticated Crawl    ─── Browser login + BFS page discovery
 Phase 3.5: OOB Registration      ─── Setup blind SSRF/injection callbacks
-Phase 4:  DAST Scanners          ─── 15 scanners run in parallel
+Phase 4:  DAST Scanners          ─── 16 scanners run in parallel (quick; deep adds 3)
 Phase 5:  Authenticated DAST     ─── JWT, RLS, privilege escalation, cross-user IDOR
 Phase 5.5: Probe Analysis        ─── Cross-scanner pattern detection on HTTP pairs
 Phase 5.6: OOB Collection        ─── Poll for blind vulnerability callbacks
@@ -61,7 +61,8 @@ After the crawl, the orchestrator hands the captured auth (bearer token and/or s
 
 ### Phase 4–5: DAST Scanners
 
-15 standard scanners run in parallel with per-scanner timeouts:
+16 standard scanners run in parallel at quick depth (deep adds 3 aggressive
+ones — rate-limit, auth-bypass, password-reset), each with per-scanner timeouts:
 
 ```
 ┌──────────────────────────────────────────────────────┐
@@ -280,7 +281,7 @@ async def run_scanner_safe(scanner_name, scan_coro, timeout_seconds):
         return []
 ```
 
-A single scanner failure never kills the scan. Timeouts are per-scanner-type (XSS gets 600s, headers get 60s).
+A single scanner failure never kills the scan. Timeouts are per-scanner-type (XSS gets a 600s outer timeout, headers get 60s). XSS also self-limits with an internal time budget that is tighter at quick depth (120s) than deep (600s), since quick skips the static DOM pass (#118).
 
 ### Event-Driven Progress
 
@@ -305,7 +306,7 @@ isitsecure/
 │   ├── constants.py            # All configuration constants
 │   ├── cross_referencer.py     # DAST ↔ SAST finding matcher
 │   ├── scan_config.py          # User-configurable scan settings
-│   ├── scanners/               # 15 DAST scanners + special scanners
+│   ├── scanners/               # 16 DAST scanners (quick) + special scanners
 │   ├── code_analysis/          # 18 SAST scanners + route mappers + LSP + semgrep_rules/
 │   │   └── category_classifier.py  # Maps LLM-review findings to their FindingCategory
 │   ├── fixes/                  # AI fix gen: safety_net, verifier, plain_results, pr_flow
@@ -350,7 +351,7 @@ isitsecure/
               │                │                │
     ┌─────────▼────────┐ ┌────▼────────┐ ┌─────▼──────────┐
     │  DAST Scanners   │ │ Auth DAST   │ │ Repo Ingestion │
-    │  (15 parallel)   │ │ (JWT, IDOR  │ │ (git clone +   │
+    │  (16 parallel)   │ │ (JWT, IDOR  │ │ (git clone +   │
     │                  │ │  RLS, PrivE) │ │  index)        │
     └─────────┬────────┘ └────┬────────┘ └─────┬──────────┘
               │               │                 │

--- a/docs/scanners/xss-scanner.md
+++ b/docs/scanners/xss-scanner.md
@@ -16,6 +16,8 @@ Three detection modes:
 
 The scanner is **context-aware**: if the canary lands inside an HTML attribute vs. a script block vs. raw HTML, it adjusts the severity and reports the injection context.
 
+**Scan depth (#118):** at `quick` depth (the default) the scanner runs the two network phases — reflected and POST-body — on a tighter 2-minute budget, so server-reflected XSS on protected endpoints is caught even in a fast pass. The static **DOM XSS** sink analysis (mode 3) is heavier and runs only at `--depth deep`; the deterministic Semgrep taint layer already provides a DOM-XSS floor at quick depth.
+
 ## Why It Matters
 
 XSS allows attackers to execute JavaScript in your users' browsers. This means they can:

--- a/isitsecure/engine/factory.py
+++ b/isitsecure/engine/factory.py
@@ -264,6 +264,9 @@ def create_deep_security_scan_agent(
     deep = depth == ScanDepth.DEEP
     dast_scanners = [
         ActiveInjectionScanner(time_based=deep),
+        # Reflected + POST-body XSS runs at both depths; quick uses a tighter
+        # budget and skips the static DOM pass (#118). Deep adds the DOM pass.
+        XSSScanner(deep=deep),
         CSRFScanner(),
         SessionScanner(),
         GraphQLScanner(),
@@ -283,7 +286,6 @@ def create_deep_security_scan_agent(
     # traffic, timing measurements, password-reset side effects).
     if deep:
         dast_scanners += [
-            XSSScanner(),
             RateLimitScanner(),
             AuthBypassScanner(),
             PasswordResetScanner(),

--- a/isitsecure/engine/scanners/xss_scanner.py
+++ b/isitsecure/engine/scanners/xss_scanner.py
@@ -43,7 +43,24 @@ class XSSScanner(AuthAwareScanner):
 
     Auth headers (bearer token and/or session Cookie) reach probes via the
     ``AuthAwareScanner`` mixin's ``_auth_headers`` slot (#111, generalized #115).
+
+    ``deep`` (default ``True``) selects the effort level. At quick depth (#118)
+    the scanner runs only the network reflected + POST-body phases on a tighter
+    time budget and skips the static DOM sink pass, so it fits the quick-depth
+    DAST set while still catching server-reflected XSS on protected endpoints.
     """
+
+    def __init__(self, deep: bool = True) -> None:
+        self._deep = deep
+
+    @property
+    def _active_budget_seconds(self) -> float:
+        """Per-phase time budget: full at deep depth, tighter at quick (#118)."""
+        return (
+            ScannerTimeouts.XSS_ACTIVE_SECONDS
+            if self._deep
+            else ScannerTimeouts.XSS_QUICK_SECONDS
+        )
 
     @property
     def scanner_name(self) -> str:
@@ -79,8 +96,9 @@ class XSSScanner(AuthAwareScanner):
         post_findings = await self._test_post_body_xss(endpoints)
         findings.extend(post_findings)
 
-        # Phase 3: DOM-based XSS analysis on JS content
-        if snapshot:
+        # Phase 3: DOM-based XSS analysis on JS content (deep only — static sink
+        # heuristic; the semgrep taint layer already covers DOM-XSS at quick).
+        if self._deep and snapshot:
             dom_findings = self._test_dom_xss(snapshot)
             findings.extend(dom_findings)
 
@@ -97,7 +115,7 @@ class XSSScanner(AuthAwareScanner):
         """Test endpoints for reflected XSS via query parameters."""
         findings: list[DeepFinding] = []
         testable = self._get_testable_endpoints(endpoints)
-        budget = TimeBudget(ScannerTimeouts.XSS_ACTIVE_SECONDS)
+        budget = TimeBudget(self._active_budget_seconds)
         candidates = rank(testable, PriorityDimension.XSS)[: XSSConfig.MAX_ENDPOINTS_TO_TEST]
 
         async with RateLimitedClient(
@@ -269,6 +287,10 @@ class XSSScanner(AuthAwareScanner):
         if not post_endpoints:
             return findings
 
+        # Shares the depth-aware budget with the reflected phase so the quick
+        # pass bounds BOTH network phases, not just the reflected one (#118).
+        budget = TimeBudget(self._active_budget_seconds)
+        candidates = rank(post_endpoints, PriorityDimension.XSS)[: XSSConfig.MAX_POST_ENDPOINTS_TO_TEST]
         async with RateLimitedClient(
             max_concurrent=XSSConfig.MAX_CONCURRENT,
             delay_seconds=XSSConfig.PROBE_DELAY,
@@ -276,7 +298,13 @@ class XSSScanner(AuthAwareScanner):
             user_agent=DeepScanConfig.USER_AGENT,
             extra_headers=self.auth_headers,
         ) as client:
-            for endpoint in rank(post_endpoints, PriorityDimension.XSS)[: XSSConfig.MAX_POST_ENDPOINTS_TO_TEST]:
+            for tested, endpoint in enumerate(candidates):
+                if budget.expired():
+                    logger.info(
+                        "XSSScanner: POST-body budget reached, tested %d/%d endpoints",
+                        tested, len(candidates),
+                    )
+                    break
                 finding = await self._test_single_post_body(client, endpoint)
                 if finding:
                     findings.append(finding)

--- a/isitsecure/engine/shared/scanner_runner.py
+++ b/isitsecure/engine/shared/scanner_runner.py
@@ -21,7 +21,8 @@ class ScannerTimeouts:
     LLM_CODE_REVIEW_SECONDS = 900  # 15 min — reviews in parallel batches (includes import-graph files)
     LSP_VALIDATION_SECONDS = 120   # 2 min — LSP init + auth flow tracing
     TRIAGE_SECONDS = 900           # 15 min — batched LLM triage + themes + owner summary
-    XSS_ACTIVE_SECONDS = 600       # 10 min — 20 endpoints × 5 params × 3 probe stages
+    XSS_ACTIVE_SECONDS = 600       # 10 min — 20 endpoints × 5 params × 3 probe stages (deep)
+    XSS_QUICK_SECONDS = 120        # 2 min — reflected + POST-body only, no DOM pass (quick, #118)
     INJECTION_ACTIVE_SECONDS = 900  # 15 min — 30 endpoints × 5 params, time-based SQLi (3s sleeps)
     AUTH_BYPASS_SECONDS = 300       # 5 min — multiple login attempts + timing measurements
     RATE_LIMIT_SECONDS = 300        # 5 min — 100+ burst requests

--- a/tests/engine/test_factory.py
+++ b/tests/engine/test_factory.py
@@ -15,9 +15,12 @@ from isitsecure.engine.scanners.endpoint_discovery import (
 )
 from isitsecure.engine.scanners.protocols import DASTScannerProtocol
 
-# DAST scanner counts. QUICK (default) runs the fast set; DEEP adds 4 slow /
-# aggressive scanners (XSS, rate-limit, auth-bypass, password-reset).
-EXPECTED_DAST_SCANNER_COUNT_QUICK = 15
+# DAST scanner counts. QUICK (default) runs the fast set — which now includes a
+# lightweight XSS pass (reflected + POST-body, no static DOM) so authenticated
+# reflected XSS is caught at quick depth (#118). DEEP adds 3 slow/aggressive
+# scanners (rate-limit, auth-bypass, password-reset) and upgrades XSS to the
+# full pass (adds the static DOM sink analysis).
+EXPECTED_DAST_SCANNER_COUNT_QUICK = 16
 EXPECTED_DAST_SCANNER_COUNT_DEEP = 19
 # Expected SAST scanner count based on factory.py sast_scanners list (without LLM)
 EXPECTED_SAST_SCANNER_COUNT = 18
@@ -58,10 +61,26 @@ class TestFactory:
         assert len(deep._dast_scanners) == EXPECTED_DAST_SCANNER_COUNT_DEEP
         deep_names = {s.scanner_name for s in deep._dast_scanners}
         quick_names = {s.scanner_name for s in quick._dast_scanners}
-        # XSS is deep-only; injection is present in both.
+        # The deep-only aggressive scanners are absent from the quick set.
+        for name in ("rate_limit_scanner", "auth_bypass_scanner", "password_reset_tester"):
+            assert name in deep_names
+            assert name not in quick_names
+        # XSS and injection now run at both depths (XSS at a lighter effort in
+        # quick — see test_quick_xss_is_non_deep); injection in both too.
         assert "xss_scanner" in deep_names
-        assert "xss_scanner" not in quick_names
+        assert "xss_scanner" in quick_names
         assert any("injection" in n for n in quick_names)
+
+    def test_quick_xss_is_non_deep(self):
+        """QUICK depth builds XSS with the lighter (non-deep) effort (#118)."""
+        from isitsecure.engine.enums import ScanDepth
+        from isitsecure.engine.scanners.xss_scanner import XSSScanner
+        quick = create_deep_security_scan_agent(depth=ScanDepth.QUICK)
+        deep = create_deep_security_scan_agent(depth=ScanDepth.DEEP)
+        q_xss = next(s for s in quick._dast_scanners if isinstance(s, XSSScanner))
+        d_xss = next(s for s in deep._dast_scanners if isinstance(s, XSSScanner))
+        assert q_xss._deep is False
+        assert d_xss._deep is True
 
     def test_quick_injection_has_time_based_disabled(self):
         """QUICK depth builds the injection scanner with time-based SQLi off."""

--- a/tests/engine/test_xss_scanner.py
+++ b/tests/engine/test_xss_scanner.py
@@ -761,3 +761,111 @@ async def test_post_body_xss_no_auth_headers_passes_none(monkeypatch):
     )
     await scanner._test_post_body_xss([ep])
     assert captured.get("extra_headers") is None
+
+
+class TestDepthBehavior:
+    """Quick vs deep depth behavior (#118).
+
+    At quick depth XSSScanner runs only the network reflected + POST-body
+    phases on a tighter budget and skips the static DOM sink pass, so it can
+    join the quick-depth DAST set and catch server-reflected XSS on protected
+    endpoints without the deep-only cost.
+    """
+
+    def test_deep_default_uses_full_budget(self) -> None:
+        from isitsecure.engine.shared.scanner_runner import ScannerTimeouts
+
+        assert XSSScanner()._active_budget_seconds == ScannerTimeouts.XSS_ACTIVE_SECONDS
+        assert XSSScanner(deep=True)._active_budget_seconds == ScannerTimeouts.XSS_ACTIVE_SECONDS
+
+    def test_quick_uses_tighter_budget(self) -> None:
+        from isitsecure.engine.shared.scanner_runner import ScannerTimeouts
+
+        assert XSSScanner(deep=False)._active_budget_seconds == ScannerTimeouts.XSS_QUICK_SECONDS
+        assert ScannerTimeouts.XSS_QUICK_SECONDS < ScannerTimeouts.XSS_ACTIVE_SECONDS
+
+    @pytest.mark.asyncio
+    async def test_quick_skips_static_dom_pass(self) -> None:
+        """A quick scanner must NOT run the static DOM sink heuristic even when a
+        code snapshot is present."""
+        scanner = XSSScanner(deep=False)
+        snapshot = _make_snapshot(
+            js_content='document.getElementById("o").innerHTML = userInput;'
+        )
+        with patch.object(scanner, "_test_dom_xss") as dom:
+            await scanner.scan([], snapshot=snapshot)
+            dom.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_deep_runs_static_dom_pass(self) -> None:
+        """A deep scanner runs the static DOM sink heuristic when a snapshot is
+        present."""
+        scanner = XSSScanner(deep=True)
+        snapshot = _make_snapshot(
+            js_content='document.getElementById("o").innerHTML = userInput;'
+        )
+        with patch.object(scanner, "_test_dom_xss", return_value=[]) as dom:
+            await scanner.scan([], snapshot=snapshot)
+            dom.assert_called_once_with(snapshot)
+
+    @pytest.mark.asyncio
+    async def test_both_network_phases_use_the_depth_budget(self) -> None:
+        """Both the reflected AND POST-body phases must build their TimeBudget
+        from the depth-aware value, so a quick pass actually bounds both (#118)."""
+        from isitsecure.engine.shared.scanner_runner import ScannerTimeouts
+
+        ep = DiscoveredEndpoint(
+            url="https://ex.com/profile", method=EndpointMethod.POST,
+            query_param_names=["firstName"],
+        )
+        get_ep = _make_endpoint("https://ex.com/search?q=1")
+
+        for deep, expected in ((False, ScannerTimeouts.XSS_QUICK_SECONDS),
+                               (True, ScannerTimeouts.XSS_ACTIVE_SECONDS)):
+            seen: list[float] = []
+
+            def _spy(seconds: float, _seen=seen):
+                _seen.append(seconds)
+                b = MagicMock()
+                b.expired.return_value = False
+                return b
+
+            scanner = XSSScanner(deep=deep)
+            with patch("isitsecure.engine.scanners.xss_scanner.TimeBudget", _spy), \
+                 patch("isitsecure.engine.scanners.xss_scanner.RateLimitedClient") as rc:
+                rc.return_value.__aenter__ = AsyncMock(return_value=AsyncMock())
+                rc.return_value.__aexit__ = AsyncMock(return_value=False)
+                await scanner.scan([get_ep, ep], snapshot=None)
+
+            # Two budgets built (reflected + POST-body), both at the depth value.
+            assert seen == [expected, expected], f"deep={deep}: {seen}"
+
+
+class TestFactoryDepthWiring:
+    """XSSScanner is wired into both depth sets with the right effort (#118)."""
+
+    def test_quick_set_includes_xss_scanner_non_deep(self) -> None:
+        from isitsecure.engine.enums import ScanDepth
+        from isitsecure.engine.factory import create_deep_security_scan_agent
+
+        agent = create_deep_security_scan_agent(depth=ScanDepth.QUICK)
+        xss = [s for s in agent._dast_scanners if isinstance(s, XSSScanner)]
+        assert len(xss) == 1
+        assert xss[0]._deep is False
+
+    def test_deep_set_includes_xss_scanner_deep(self) -> None:
+        from isitsecure.engine.enums import ScanDepth
+        from isitsecure.engine.factory import create_deep_security_scan_agent
+
+        agent = create_deep_security_scan_agent(depth=ScanDepth.DEEP)
+        xss = [s for s in agent._dast_scanners if isinstance(s, XSSScanner)]
+        assert len(xss) == 1
+        assert xss[0]._deep is True
+
+    def test_default_depth_is_quick_non_deep(self) -> None:
+        from isitsecure.engine.factory import create_deep_security_scan_agent
+
+        agent = create_deep_security_scan_agent()
+        xss = [s for s in agent._dast_scanners if isinstance(s, XSSScanner)]
+        assert len(xss) == 1
+        assert xss[0]._deep is False


### PR DESCRIPTION
Closes #118. Follow-up to #115/#117.

## Problem
`XSSScanner` ran only at `--depth deep`, so authenticated server-reflected XSS on protected endpoints was missed at the default (quick) depth — even though the form was discovered, its fields were tested (#110), and the session cookie was attached (#114 + #115). NodeGoat's `POST /profile` reflected XSS was the concrete miss.

## Change
- `XSSScanner` takes a **`deep: bool = True`** flag (mirroring `ActiveInjectionScanner(time_based=deep)`).
  - **Quick** (`deep=False`): runs only the reflected + POST-body network phases on a tighter budget (`XSS_QUICK_SECONDS=120` vs `XSS_ACTIVE_SECONDS=600`); **skips** the static DOM sink pass (the Semgrep taint layer already provides a DOM-XSS floor at quick).
  - **Deep**: unchanged — adds the full DOM analysis and the larger budget.
- The factory constructs `XSSScanner(deep=deep)` in the **base** DAST list instead of the deep-only block, so it runs at both depths.
- Both network phases now share the depth-aware `TimeBudget`, so the quick pass bounds **all** of its network work (the POST-body phase previously had no time budget).

## Benchmark (detection gate)
| Target | Before | After |
|---|--:|--:|
| `nodegoat-auth` | 2/3 | **3/3** — headers ✓, injection ✓, **XSS ✓** |
| `vampi-secure` (FP) | 2 (IDOR) | **2 (IDOR)** — no new FPs |
| `juiceshop` (recall) | 20/45 | **20/45** (XSS 1/7) — no regression |

- Authenticated reflected XSS is now caught at the default depth; **re-confirmed 3/3 after the POST-body budget fix**.
- The quick XSS pass is canary-based (unescaped reflection of a unique probe), so a hardened build (`vampi-secure`) produces no false positives.

## Quality gates
- Adversarial code + doc review run; all findings fixed — the code review's MAJOR (POST-body phase had no `TimeBudget`) and the doc review's stale scanner counts / deep-only XSS marker.
- Full engine test suite green (**1957 passed, 1 xfailed**); 15 XSS/factory/auth tests lock the depth flag, DOM-skip, budget usage, and factory wiring. Touched files add zero new ruff errors.

## Docs (ship with the code)
- `README.md` — scan-depth table + scanner counts (42 default, 16 quick DAST, deep adds 3); dropped the now-wrong deep-only ◆ on the XSS row.
- `docs/architecture.md` — DAST scanner counts (16) and the XSS timeout (120s quick / 600s deep).
- `docs/scanners/xss-scanner.md` — scan-depth note.
- `benchmarks/RESULTS.md` — nodegoat-auth 3/3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)