### PR TITLE
feat(dast): give error-based SQLi findings a baseline for the adjudicator (#125)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -178,7 +178,7 @@ The **injection adjudicator** (`engine/triage/injection_adjudicator.py`) runs be
 - It **fails open** on any LLM or parse error (a failed/malformed response keeps every finding), and the prompt resolves genuine uncertainty to "genuine." It is a precision filter, not a hard guarantee: a confident-but-wrong `benign` verdict can still drop a true positive, so it trades a little recall for fewer false positives. The target's response bodies are fenced as untrusted data in the prompt so a hostile target cannot inject a "benign" verdict to suppress its own findings.
 - It is a **strict no-op without an LLM client**, so the deterministic `--llm none` scan (and the benchmark floor) is unaffected — the false positives it removes are a with-API-key precision improvement, not a change to the rule-based detection.
 
-To make this possible, the scanner attaches the baseline response body to size-oracle findings (`DeepFinding.baseline_response_preview`) so the model has both sides to compare.
+To make this possible, the scanner attaches the baseline (safe-value) response body to the borderline findings — the NoSQL size-oracle findings and the error-based SQLi findings (`DeepFinding.baseline_response_preview`) — so the model has both sides to compare. For error-based SQLi this lets it separate a real injection (the SQL error appears only under the payload) from a false positive (the "error" text is already in the baseline, or isn't really a query error) — the flaky `vampi-secure` SQLi false positives (#125). As with the rest of this phase, that clean-up only happens when an API key is present; the `--llm none` scan still emits the raw finding.
 
 ### Phase 9.5: LLM Triage
 

--- a/isitsecure/engine/constants.py
+++ b/isitsecure/engine/constants.py
@@ -1447,8 +1447,13 @@ class InjectionConfig:
     # Minimum baseline response size to compare against
     NOSQL_MIN_BASELINE_SIZE = 20
     # Chars of the injected AND baseline responses stored on the finding, so the
-    # LLM injection adjudicator can compare the two response bodies (#5).
-    NOSQL_EVIDENCE_CHARS = 1500
+    # LLM injection adjudicator can compare the two response bodies (#5, #125).
+    INJECTION_EVIDENCE_CHARS = 1500
+
+    # Benign value used to fetch a baseline response for error-based SQLi, so the
+    # adjudicator can compare "injected produced a SQL error the baseline lacked"
+    # against "the baseline already contains this text" (a false positive). #125
+    SQLI_BASELINE_VALUE = "1"
 
     # --- Authentication-bypass (boolean) SQLi ---
     # Login POST endpoints are rarely recoverable from a minified SPA bundle, so
@@ -5713,7 +5718,7 @@ class InjectionAdjudicatorConfig:
     MAX_TOKENS = 1200
     BATCH_SIZE = 8               # findings per LLM call
     # Per response body included in the prompt. Matches the amount the scanner
-    # stores on the finding (InjectionConfig.NOSQL_EVIDENCE_CHARS).
+    # stores on the finding (InjectionConfig.INJECTION_EVIDENCE_CHARS).
     MAX_EVIDENCE_CHARS = 1500
 
     # Only these DAST injection titles are borderline enough to adjudicate. The

--- a/isitsecure/engine/models.py
+++ b/isitsecure/engine/models.py
@@ -177,9 +177,10 @@ class DeepFinding(BaseModel):
     http_method: str | None = None
     request_payload: str | None = None
     response_preview: str | None = None
-    # Baseline (safe-value) response, for differential findings (e.g. the NoSQL
-    # size oracle). Lets the LLM injection adjudicator compare baseline vs.
-    # injected instead of guessing from the injected response alone (#5).
+    # Baseline (safe-value) response, for differential findings (the NoSQL size
+    # oracle and error-based SQLi). Lets the LLM injection adjudicator compare
+    # baseline vs. injected instead of guessing from the injected response alone
+    # (#5, #125).
     baseline_response_preview: str | None = None
 
     # SAST-specific fields

--- a/isitsecure/engine/scanners/active_injection_scanner.py
+++ b/isitsecure/engine/scanners/active_injection_scanner.py
@@ -367,6 +367,16 @@ class ActiveInjectionScanner(AuthAwareScanner):
                     elapsed_ms=response.elapsed.total_seconds() * 1000,
                     scanner_name=self.scanner_name,
                 )
+                # Fetch a baseline (benign value) so the adjudicator can tell a
+                # real error-based SQLi (error appears only under the payload)
+                # from a false positive (the error text is in the baseline too,
+                # or isn't really a SQL error). Lazy: only when a match fires. #125
+                baseline_body = ""
+                baseline_resp = await self._probe(
+                    client, endpoint, param_name, InjectionConfig.SQLI_BASELINE_VALUE
+                )
+                if baseline_resp is not None:
+                    baseline_body = baseline_resp.text
                 return DeepFinding(
                     source=FindingSource.DAST_URL,
                     category=FindingCategory.INJECTION_RISK,
@@ -382,7 +392,10 @@ class ActiveInjectionScanner(AuthAwareScanner):
                     endpoint_url=endpoint.url,
                     http_method=endpoint.method.value,
                     request_payload=f"{param_name}={payload}",
-                    response_preview=body[:300],
+                    response_preview=body[:InjectionConfig.INJECTION_EVIDENCE_CHARS],
+                    baseline_response_preview=(
+                        baseline_body[:InjectionConfig.INJECTION_EVIDENCE_CHARS] or None
+                    ),
                     probe_captures=[capture],
                 )
         return None
@@ -655,9 +668,9 @@ class ActiveInjectionScanner(AuthAwareScanner):
             endpoint_url=endpoint.url,
             http_method=endpoint.method.value,
             request_payload=f"{param_name}={payload}",
-            response_preview=body[:InjectionConfig.NOSQL_EVIDENCE_CHARS],
+            response_preview=body[:InjectionConfig.INJECTION_EVIDENCE_CHARS],
             baseline_response_preview=(
-                baseline_body[:InjectionConfig.NOSQL_EVIDENCE_CHARS] or None
+                baseline_body[:InjectionConfig.INJECTION_EVIDENCE_CHARS] or None
             ),
         )
 

--- a/tests/engine/test_injection_scanner.py
+++ b/tests/engine/test_injection_scanner.py
@@ -246,8 +246,29 @@ class TestErrorBasedSQLi:
         )
 
         assert finding is not None
-        # Should have called get only once since first payload triggers match
-        assert mock_client.get.call_count == 1
+        # Stops at the first matching payload (does not iterate the rest), then
+        # fetches one baseline for the adjudicator (#125): 1 payload + 1 baseline.
+        assert mock_client.get.call_count == 2
+        # The baseline response is captured for genuine-vs-FP adjudication.
+        assert finding.baseline_response_preview is not None
+
+    async def test_finding_built_when_baseline_probe_fails(self) -> None:
+        """Fail-safe (#125): if the baseline probe errors, the SQLi finding is
+        still emitted with baseline_response_preview=None (never lost)."""
+        endpoint = _make_endpoint(query_param_names=["id"])
+        error_resp = _make_response(text="You have an error in your SQL syntax")
+
+        mock_client = _make_mock_client()
+        # 1st get = payload probe (matches); 2nd get = baseline probe (raises →
+        # _probe swallows it and returns None).
+        mock_client.get.side_effect = [error_resp, httpx.RequestError("boom")]
+
+        finding = await self.scanner._test_error_based_sqli(
+            mock_client, endpoint, "id"
+        )
+
+        assert finding is not None
+        assert finding.baseline_response_preview is None
 
 
 class TestTimeBasedSQLi:

--- a/tests/engine/test_triage/test_injection_adjudicator.py
+++ b/tests/engine/test_triage/test_injection_adjudicator.py
@@ -79,6 +79,20 @@ class TestCandidateSelection:
         llm.generate_with_system.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_error_based_sqli_finding_is_adjudicated(self):
+        """SQLi error-based findings are candidates too (#125), so an FP where
+        the SQL error text is in the baseline can be dropped."""
+        fp = _dast_injection(
+            "sqli", title="SQL injection vulnerability (error-based)",
+            endpoint="http://app/items",
+            injected="...near syntax error...", baseline="...near syntax error...",
+        )
+        llm = _llm(returns=_verdicts(("sqli", "benign")))
+        out = await InjectionAdjudicator(llm).adjudicate([fp])
+        assert out == []
+        llm.generate_with_system.assert_called_once()
+
+    @pytest.mark.asyncio
     async def test_unlisted_injection_title_is_ignored(self):
         weird = _dast_injection("w1", title="LDAP injection vulnerability")
         llm = _llm(returns=_verdicts(("w1", "benign")))


### PR DESCRIPTION
Extends the LLM injection adjudicator (v0.18.0) to cover error-based SQLi false positives. Refs #125.

## Problem
The adjudicator already lists `SQL injection` among the findings it judges, but the error-based SQLi scanner path attached **no baseline response** — so the adjudicator had nothing to compare and couldn't distinguish a real injection from a false positive.

## Change
When a SQL-error pattern matches, the scanner now **lazily fetches a baseline (benign-value) response** and attaches it as `baseline_response_preview`, so the adjudicator can separate:
- a **genuine** error-based SQLi (the DB error appears only under the payload), from
- a **false positive** (the "error" text is already in the baseline, or isn't a real query error).

Also renames `NOSQL_EVIDENCE_CHARS` → `INJECTION_EVIDENCE_CHARS` (shared by both paths).

**Only changes stored evidence, not detection** — same `matched_pattern` emit condition; the baseline probe is lazy (one extra request only on a confirmed match) and fail-safe (on error the finding is kept with `baseline_response_preview=None`).

## Validation — proven on the real FP, twice
Repeated vampi-secure scans caught the flaky `/createdb` SQLi FP: a benign `sqlalchemy.exc.IntegrityError: UNIQUE constraint failed` that the error-signature matcher misreads as SQLi. **Both times** the baseline (`{"message":"Database populated."}`) was captured and the adjudicator judged it **benign and dropped it**.

| Run | Finding | Baseline captured | Adjudicator |
|---|---|---|---|
| 1 | `/createdb` IntegrityError | ✓ | **DROPPED** |
| 2 | `/createdb` IntegrityError | ✓ | **DROPPED** |

Also: live — a genuine DB error (only under the payload) is **kept**; an error-in-baseline FP is **dropped**.

## Regression / tests
- **`--llm none` benchmark byte-identical:** juiceshop sqli 7/7 (20/45), vampi-vulnerable 3/3, vampi-secure no new FP — deterministic floor unchanged.
- Full engine suite **1980 passed** + a new baseline-`None` fail-safe test. Zero new ruff errors. Adversarial review clean.

## Scope (honest)
Like #5, this is a **with-API-key precision improvement**. Under `--llm none` the adjudicator is a no-op, so the raw flaky FP still emits and the benchmark number is unchanged — #125's deterministic-metric acceptance is intentionally out of scope here.

## Docs
Architecture Phase 9.4 section + `DeepFinding.baseline_response_preview` comment updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)