### PR TITLE
feat(trust): stable finding fingerprint + .isitsecureignore suppression (#51)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Built for developers and **vibe coders** shipping web apps who need to know if t
 - [Install](#install) · [Quick Start](#quick-start) · [What It Costs](#what-it-costs)
 - [Scan Modes](#scan-modes) · [Scan Depth](#scan-depth)
 - [What It Scans](#what-it-scans) — [DAST](#dast-scanners--tests-your-live-app) · [Special DAST](#special-dast-scanners-8) · [SAST](#sast-scanners-18--analyzes-your-code) · [LLM](#llm-powered-analysis-requires-api-key) · [Cross-Referencing](#cross-referencing--guided-dast)
-- [Language Support](#language-support) · [Output Formats](#output-formats)
+- [Language Support](#language-support) · [Output Formats](#output-formats) · [Suppressing False Positives](#suppressing-false-positives)
 - [Auto-Fix](#auto-fix-one-command-to-fix-your-app) · [Security Badge](#security-badge)
 - [How We Compare](#how-we-compare) · [What It Does NOT Cover](#what-it-does-not-cover)
 - [Configuration](#configuration) — [API Keys](#api-keys) · [OOB Callbacks](#oob-callbacks-blind-vulnerability-detection) · [Authenticated Scanning](#authenticated-scanning)
@@ -287,6 +287,32 @@ isitsecure scan URL --output sarif   # SARIF 2.1.0 for GitHub Code Scanning
 isitsecure scan URL --output fixes   # AI-generated fix plan (Markdown with diffs)
 ```
 
+## Suppressing False Positives
+
+A finding you've reviewed and accepted (a false positive, or an accepted risk) shouldn't nag you on every scan. Each finding has a **stable fingerprint** — the same across runs, environments (localhost vs. prod), and code edits — shown under each row in the table output (`fp <hash>`) and in the JSON/SARIF output.
+
+Suppress one by adding its fingerprint to a repo-local **`.isitsecureignore`** file, which is committed and reviewable in pull requests:
+
+```bash
+# See the fingerprints (in table or JSON output)
+isitsecure scan https://your-app.com --output json | jq '.findings[] | {fingerprint, title, endpoint_url}'
+
+# Suppress a finding (appends to ./.isitsecureignore with context + reason)
+isitsecure scan https://your-app.com --suppress de0e57aeb5f61708 --suppress-reason "benign: /createdb re-populate, not injection"
+
+# Future scans hide it automatically; review what's hidden anytime:
+isitsecure scan https://your-app.com --show-suppressed
+```
+
+The `.isitsecureignore` file is plain text — one fingerprint per line, `#` comments for context — so suppressions live with your code and are reviewed like any other change. Delete a line to un-suppress.
+
+```
+# .isitsecureignore
+de0e57aeb5f61708   # [injection_risk] GET /createdb — SQL injection (benign: not injection)
+```
+
+Suppressed findings are dropped from the findings list, counts, and themes in every output format. (The AI *owner summary* narrative is written during the scan, so it may still mention a finding you suppressed afterward.)
+
 ## Auto-Fix: One Command to Fix Your App
 
 `fix` works two ways depending on what you point it at:
@@ -496,6 +522,10 @@ Options:
   --auth-password-b TEXT Second user's password (paired with --auth-email-b)
   --login-url TEXT       Explicit login endpoint (else auto-discovered)
   --github-token TEXT    GitHub token for cloning private repos
+  --suppress TEXT        Fingerprint to add to .isitsecureignore (repeatable)
+  --suppress-reason TEXT Reason recorded next to --suppress entries
+  --suppress-file TEXT   Ignore file path [default: ./.isitsecureignore]
+  --show-suppressed      List suppressed findings instead of hiding them
   -v, --verbose          Enable debug logging
 
 isitsecure fix [OPTIONS]

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -317,6 +317,8 @@ isitsecure/
 │   ├── models.py               # DeepFinding, DeepScanReport, etc.
 │   ├── enums.py                # All enumerations
 │   ├── constants.py            # All configuration constants
+│   ├── identity.py             # Stable cross-scan finding fingerprint (#38 trust)
+│   ├── suppression.py          # .isitsecureignore parsing + filter (#51)
 │   ├── cross_referencer.py     # DAST ↔ SAST finding matcher
 │   ├── scan_config.py          # User-configurable scan settings
 │   ├── scanners/               # 16 DAST scanners (quick) + special scanners

--- a/isitsecure/cli.py
+++ b/isitsecure/cli.py
@@ -201,6 +201,10 @@ def scan(
     llm_provider: str = typer.Option("anthropic", "--llm", help="LLM provider: anthropic|google|none"),
     output: str = typer.Option("table", "--output", "-o", help="Output format: table|json|html|sarif|fixes"),
     output_file: Optional[str] = typer.Option(None, "--output-file", "-f", help="Write report to file"),
+    suppress: Optional[list[str]] = typer.Option(None, "--suppress", help="Fingerprint to add to .isitsecureignore (repeatable)"),
+    suppress_reason: str = typer.Option("", "--suppress-reason", help="Reason recorded next to --suppress entries"),
+    suppress_file: Optional[str] = typer.Option(None, "--suppress-file", help="Ignore file path (default ./.isitsecureignore)"),
+    show_suppressed: bool = typer.Option(False, "--show-suppressed", help="List suppressed findings instead of hiding them"),
     verbose: bool = typer.Option(False, "--verbose", "-v"),
 ) -> None:
     """Run a security scan against a web application."""
@@ -309,6 +313,54 @@ def scan(
         credentials_b=credentials_b,
         scan_mode=resolved_mode,
     ))
+
+    # --- Suppression (#51): drop findings the user has accepted as FPs -------
+    # Applied once here so every output format (table/json/html/sarif/fixes)
+    # sees the same filtered set. The .isitsecureignore file is the source of
+    # truth and is reviewable in code review.
+    from isitsecure.engine import suppression as _suppression
+    _ignore_path = Path(suppress_file) if suppress_file else _suppression.default_ignore_path()
+    if suppress:
+        newly = _suppression.add_suppressions(
+            _ignore_path, report.findings, suppress, suppress_reason
+        )
+        if newly:
+            err_console.print(
+                f"[green]Suppressed {len(newly)} finding(s)[/green] in "
+                f"[dim]{_ignore_path}[/dim]"
+            )
+        unmatched = set(suppress) - {f.fingerprint for f in report.findings}
+        if unmatched:
+            err_console.print(
+                f"[yellow]No finding in this scan matched: {', '.join(sorted(unmatched))}[/yellow]"
+            )
+    _suppressed_fps = _suppression.load_suppressed_fingerprints(_ignore_path)
+    _active, _hidden = _suppression.partition(report.findings, _suppressed_fps)
+    if show_suppressed:
+        report.findings = _hidden
+        if output not in ("json", "sarif"):
+            err_console.print(
+                f"[dim]Showing {len(_hidden)} suppressed finding(s) from {_ignore_path.name}[/dim]"
+            )
+    else:
+        report.findings = _active
+        # Keep the thematic grouping honest: drop suppressed findings from themes
+        # (they reference findings by id). The owner_summary is an LLM narrative
+        # generated pre-suppression and may still mention a suppressed finding.
+        _hidden_ids = {f.id for f in _hidden}
+        if _hidden_ids and report.themes:
+            _kept = []
+            for _th in report.themes:
+                _th.finding_ids = [i for i in _th.finding_ids if i not in _hidden_ids]
+                _th.finding_count = len(_th.finding_ids)
+                if _th.finding_ids:
+                    _kept.append(_th)
+            report.themes = _kept
+        if _hidden and output not in ("json", "sarif"):
+            err_console.print(
+                f"[dim]{len(_hidden)} finding(s) suppressed via {_ignore_path.name} "
+                f"(use --show-suppressed to view)[/dim]"
+            )
 
     # Output results
     if output == "json":
@@ -603,6 +655,9 @@ def _print_report_table(report) -> None:
                 detail = f"{detail}\n[dim]{term.upper()}: {definition}[/dim]"
                 seen_glossary.add(term)
                 break
+
+        # Stable fingerprint so the user can `--suppress` this finding (#38/#51).
+        detail = f"{detail}\n[dim]fp {finding.fingerprint}[/dim]"
 
         table.add_row(
             str(i),

--- a/isitsecure/engine/constants.py
+++ b/isitsecure/engine/constants.py
@@ -2214,7 +2214,10 @@ class RaceConditionConfig:
     CONFIDENCE_RACE = 0.80
 
     TITLE_RACE_CONDITION = (
-        "Race condition — {method} '{path}' succeeds {count} times concurrently"
+        # No {count} here — it varies run-to-run (timing), which would
+        # destabilise the finding fingerprint. The count lives in the
+        # description instead (#38).
+        "Race condition — {method} '{path}' succeeds concurrently"
     )
     DESC_RACE_CONDITION = (
         "Sending {total} concurrent {method} requests to '{path}' resulted in "

--- a/isitsecure/engine/identity.py
+++ b/isitsecure/engine/identity.py
@@ -1,0 +1,78 @@
+"""Stable, cross-scan finding identity (#38 trust & false-positive epic).
+
+The per-scan ``DeepFinding.id`` is a random ``uuid4`` — it cannot match a finding
+across two separate scans. Suppression (#51) and baseline mode (#52) both need a
+signature that is the SAME every time the same underlying issue is found, so a
+user can say "ignore this one" once and have it stick.
+
+The fingerprint is derived only from stable, deterministic content — never from
+the random id or from LLM-enriched, non-deterministic fields (priority, theme,
+remediation). It is deliberately line-agnostic for SAST (edits above a finding
+don't change it) and host/query-agnostic for DAST (the same endpoint on
+localhost vs. prod, with different query values, keeps one identity).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from typing import TYPE_CHECKING
+from urllib.parse import urlparse
+
+if TYPE_CHECKING:
+    from isitsecure.engine.models import DeepFinding
+
+# Length of the hex digest exposed to users. 16 hex chars = 64 bits — plenty to
+# avoid collisions across a single project's findings while staying short enough
+# to paste into a `.isitsecureignore` line.
+_FINGERPRINT_LEN = 16
+_SEP = "\x1f"  # unit separator — cannot appear in the hashed fields
+
+# Some finding titles interpolate the full target URL (host:port + query). That
+# would make the fingerprint environment-dependent, so before hashing we replace
+# any embedded URL with just its path — matching how the DAST locus is built.
+_URL_IN_TEXT = re.compile(r"https?://\S+")
+
+
+def _normalize_title(title: str) -> str:
+    """Neutralise environment-specific data embedded in a title (full URLs →
+    path) so the same issue fingerprints identically across hosts/queries."""
+    return _URL_IN_TEXT.sub(lambda m: urlparse(m.group(0)).path or "/", title or "")
+
+
+def compute_fingerprint(
+    *,
+    scanner_name: str,
+    category: object,
+    title: str,
+    file_path: str | None = None,
+    endpoint_url: str | None = None,
+    http_method: str | None = None,
+) -> str:
+    """Compute a stable fingerprint from a finding's identifying content.
+
+    Locus is the source file (SAST) or the ``METHOD /path`` (DAST) — host, port
+    and query string are dropped so the identity survives environment changes.
+    """
+    cat = category.value if hasattr(category, "value") else str(category)
+    if file_path:
+        locus = file_path.replace("\\", "/")
+    elif endpoint_url:
+        path = urlparse(endpoint_url).path or "/"
+        locus = f"{(http_method or 'GET').upper()} {path}"
+    else:
+        locus = ""
+    raw = _SEP.join([scanner_name or "", cat, locus, _normalize_title(title)])
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()[:_FINGERPRINT_LEN]
+
+
+def finding_fingerprint(finding: DeepFinding) -> str:
+    """Stable fingerprint for a ``DeepFinding`` (SAST or DAST)."""
+    return compute_fingerprint(
+        scanner_name=finding.scanner_name,
+        category=finding.category,
+        title=finding.title,
+        file_path=finding.code_location.file_path if finding.code_location else None,
+        endpoint_url=finding.endpoint_url,
+        http_method=finding.http_method,
+    )

--- a/isitsecure/engine/models.py
+++ b/isitsecure/engine/models.py
@@ -4,7 +4,7 @@ from enum import Enum
 from typing import Optional
 from uuid import uuid4
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, computed_field
 
 from isitsecure.engine.enums import (
     EndpointCategory,
@@ -194,6 +194,14 @@ class DeepFinding(BaseModel):
 
     # Cross-reference
     related_finding_ids: list[str] = Field(default_factory=list)
+
+    @computed_field  # serialized so users can copy it into `.isitsecureignore`
+    @property
+    def fingerprint(self) -> str:
+        """Stable cross-scan identity (#38). Derived, never stored, so it can't
+        drift from the finding's content. See ``engine/identity.py``."""
+        from isitsecure.engine.identity import finding_fingerprint
+        return finding_fingerprint(self)
 
     def to_customer_dict(self) -> dict:
         """Serialize for customer-facing report (excludes fix_code)."""

--- a/isitsecure/engine/reporting/sarif_renderer.py
+++ b/isitsecure/engine/reporting/sarif_renderer.py
@@ -141,9 +141,10 @@ class SARIFRenderer:
         if locations:
             result["locations"] = locations
 
-        # Fingerprint for dedup across runs
+        # Stable fingerprint for dedup across runs (#38). Must NOT be finding.id
+        # (a per-scan random uuid) — that defeats cross-run dedup.
         result["fingerprints"] = {
-            "isitsecure/v1": finding.id,
+            "isitsecure/v1": finding.fingerprint,
         }
 
         # Properties

--- a/isitsecure/engine/scanners/race_condition_scanner.py
+++ b/isitsecure/engine/scanners/race_condition_scanner.py
@@ -128,7 +128,7 @@ class RaceConditionScanner:
                 category=FindingCategory.AUTH_WEAKNESS,
                 severity=SeverityLevel.HIGH,
                 title=RaceConditionConfig.TITLE_RACE_CONDITION.format(
-                    method=method, path=path, count=success_count,
+                    method=method, path=path,
                 ),
                 description=RaceConditionConfig.DESC_RACE_CONDITION.format(
                     total=RaceConditionConfig.CONCURRENT_REQUESTS,

--- a/isitsecure/engine/suppression.py
+++ b/isitsecure/engine/suppression.py
@@ -1,0 +1,113 @@
+"""Persisted finding suppression — the ``.isitsecureignore`` file (#51).
+
+A finding a user has judged not-applicable / accepted-risk should not reappear on
+every future scan. Suppressions live in a repo-local ``.isitsecureignore`` file so
+they travel with the code and are reviewable in pull requests (the acceptance
+criterion). Each line names a finding by its stable :func:`fingerprint`; anything
+after ``#`` is human context and is ignored by the parser.
+
+Format (line-based, git-friendly, no external deps)::
+
+    # isitsecure suppressions — findings listed here are hidden on future scans.
+    de0e57aeb5f61708   # [injection_risk] GET /createdb — benign IntegrityError
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from isitsecure.engine.models import DeepFinding
+
+IGNORE_FILENAME = ".isitsecureignore"
+
+_HEADER = (
+    "# isitsecure suppressions — findings listed here are hidden on future scans.\n"
+    "# Format: <fingerprint>   # <context>   (only the first token is read).\n"
+    "# Remove a line to un-suppress. Reviewable in code review.\n"
+)
+
+
+def default_ignore_path(base: Path | None = None) -> Path:
+    """The ``.isitsecureignore`` path for the given directory (default: CWD)."""
+    return (base or Path.cwd()) / IGNORE_FILENAME
+
+
+def load_suppressed_fingerprints(path: Path) -> set[str]:
+    """Read the fingerprints suppressed by an ignore file (empty set if absent)."""
+    if not path.exists():
+        return set()
+    out: set[str] = set()
+    for line in path.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        before_comment = stripped.split("#", 1)[0].split()
+        if before_comment:
+            out.add(before_comment[0])
+    return out
+
+
+def partition(
+    findings: list[DeepFinding], suppressed: set[str]
+) -> tuple[list[DeepFinding], list[DeepFinding]]:
+    """Split findings into (active, suppressed) by fingerprint."""
+    active: list[DeepFinding] = []
+    hidden: list[DeepFinding] = []
+    for f in findings:
+        (hidden if f.fingerprint in suppressed else active).append(f)
+    return active, hidden
+
+
+def _entry_line(finding: DeepFinding, reason: str = "") -> str:
+    cat = finding.category.value if hasattr(finding.category, "value") else str(finding.category)
+    if finding.code_location and finding.code_location.file_path:
+        locus = finding.code_location.file_path
+    elif finding.endpoint_url:
+        from urllib.parse import urlparse
+        locus = f"{finding.http_method or 'GET'} {urlparse(finding.endpoint_url).path or '/'}"
+    else:
+        locus = ""
+    context = f"[{cat}] {locus} — {finding.title}".strip()
+    if reason:
+        context += f" ({reason})"
+    return f"{finding.fingerprint}   # {context}\n"
+
+
+def add_suppressions(
+    path: Path,
+    findings: list[DeepFinding],
+    fingerprints: list[str],
+    reason: str = "",
+) -> list[DeepFinding]:
+    """Append ignore entries for the given fingerprints, using ``findings`` for
+    human-readable context. Skips fingerprints already suppressed or not present
+    in this scan. Returns the findings that were newly suppressed.
+
+    Creates the file (with a header) if it does not exist.
+    """
+    already = load_suppressed_fingerprints(path)
+    by_fp: dict[str, DeepFinding] = {}
+    for f in findings:
+        by_fp.setdefault(f.fingerprint, f)
+
+    newly: list[DeepFinding] = []
+    lines: list[str] = []
+    for fp in fingerprints:
+        if fp in already or fp in {f.fingerprint for f in newly}:
+            continue
+        finding = by_fp.get(fp)
+        if finding is None:
+            continue  # not in this scan — nothing to give context; skip
+        newly.append(finding)
+        lines.append(_entry_line(finding, reason))
+
+    if not lines:
+        return []
+
+    existing = path.read_text(encoding="utf-8") if path.exists() else _HEADER
+    if existing and not existing.endswith("\n"):
+        existing += "\n"
+    path.write_text(existing + "".join(lines), encoding="utf-8")
+    return newly

--- a/isitsecure/mcp_server.py
+++ b/isitsecure/mcp_server.py
@@ -392,6 +392,7 @@ def _trim_report(report, min_severity: str, scan_id: str) -> ScanResult:
         findings_out.append(
             {
                 "id": finding.id,
+                "fingerprint": finding.fingerprint,  # stable id for suppression (#38)
                 "severity": sev,
                 "category": finding.category.value,
                 "title": finding.title,

--- a/tests/engine/test_identity.py
+++ b/tests/engine/test_identity.py
@@ -1,0 +1,129 @@
+"""Tests for stable cross-scan finding identity (#38)."""
+
+from __future__ import annotations
+
+from isitsecure.engine.enums import FindingCategory, SeverityLevel
+from isitsecure.engine.identity import compute_fingerprint, finding_fingerprint
+from isitsecure.engine.models import CodeLocation, DeepFinding, FindingSource
+
+
+def _dast(title="SQL injection", url="http://localhost:3000/createdb", method="GET",
+          scanner="active_injection_scanner", category=FindingCategory.INJECTION_RISK):
+    return DeepFinding(
+        source=FindingSource.DAST_URL, category=category, severity=SeverityLevel.HIGH,
+        title=title, description="d", confidence=0.8, scanner_name=scanner,
+        endpoint_url=url, http_method=method,
+    )
+
+
+def _sast(file_path="app/db.py", line=42, title="SQLi", scanner="semgrep_taint",
+          category=FindingCategory.INJECTION_RISK):
+    return DeepFinding(
+        source=FindingSource.SAST_CODE, category=category, severity=SeverityLevel.HIGH,
+        title=title, description="d", confidence=0.9, scanner_name=scanner,
+        code_location=CodeLocation(file_path=file_path, line_number=line),
+    )
+
+
+class TestDASTFingerprint:
+    def test_stable_across_host_port_and_query(self):
+        a = _dast(url="http://localhost:3000/createdb")
+        b = _dast(url="https://prod.example.com:8443/createdb?x=1&y=2")
+        assert a.fingerprint == b.fingerprint
+
+    def test_different_path_differs(self):
+        assert _dast(url="http://x/createdb").fingerprint != _dast(url="http://x/login").fingerprint
+
+    def test_different_method_differs(self):
+        assert _dast(method="GET").fingerprint != _dast(method="POST").fingerprint
+
+    def test_different_category_differs(self):
+        a = _dast(category=FindingCategory.INJECTION_RISK)
+        b = _dast(category=FindingCategory.AUTH_WEAKNESS)
+        assert a.fingerprint != b.fingerprint
+
+
+class TestSASTFingerprint:
+    def test_line_agnostic(self):
+        assert _sast(line=42).fingerprint == _sast(line=999).fingerprint
+
+    def test_different_file_differs(self):
+        assert _sast(file_path="a.py").fingerprint != _sast(file_path="b.py").fingerprint
+
+    def test_sast_and_dast_never_collide(self):
+        assert _sast().fingerprint != _dast().fingerprint
+
+
+class TestProperties:
+    def test_stable_across_instances_despite_random_id(self):
+        a, b = _dast(), _dast()
+        assert a.id != b.id  # per-scan random
+        assert a.fingerprint == b.fingerprint  # but stable identity
+
+    def test_serialized_in_model_dump(self):
+        d = _dast().model_dump(mode="json")
+        assert d.get("fingerprint") == _dast().fingerprint
+        assert len(d["fingerprint"]) == 16
+
+    def test_finding_without_locus_is_deterministic(self):
+        f = DeepFinding(
+            source=FindingSource.DAST_URL, category=FindingCategory.MISSING_HEADERS,
+            severity=SeverityLevel.LOW, title="Missing header", description="d",
+            confidence=0.5, scanner_name="security_headers_scanner",
+        )
+        assert f.fingerprint == f.fingerprint
+        assert len(f.fingerprint) == 16
+
+
+def test_compute_fingerprint_matches_finding_helper():
+    f = _dast()
+    assert finding_fingerprint(f) == compute_fingerprint(
+        scanner_name=f.scanner_name, category=f.category, title=f.title,
+        endpoint_url=f.endpoint_url, http_method=f.http_method,
+    )
+
+
+class TestVolatileTitleStability:
+    """Regression for #38-C1: titles that interpolate the full URL or a run-to-run
+    count must NOT destabilise the fingerprint across environments/runs."""
+
+    def test_title_with_full_url_is_environment_stable(self):
+        from isitsecure.engine.constants import TemplateInjectionConfig as SSTI
+        t_local = SSTI.TITLE_SSTI.format(engine="jinja2", param="name",
+                                         url="http://localhost:3000/render?x=1")
+        t_prod = SSTI.TITLE_SSTI.format(engine="jinja2", param="name",
+                                        url="https://prod.example.com:8443/render?x=99")
+        fp = lambda title, url: compute_fingerprint(  # noqa: E731
+            scanner_name="active_injection_scanner", category=FindingCategory.INJECTION_RISK,
+            title=title, endpoint_url=url, http_method="POST")
+        assert fp(t_local, "http://localhost:3000/render?x=1") == \
+               fp(t_prod, "https://prod.example.com:8443/render?x=99")
+
+    def test_verbose_error_title_is_environment_stable(self):
+        from isitsecure.engine.constants import HTTPProbeConfig
+        a = HTTPProbeConfig.TITLE_VERBOSE_ERROR.format(url="http://localhost:3000/api")
+        b = HTTPProbeConfig.TITLE_VERBOSE_ERROR.format(url="http://prod:80/api")
+        assert compute_fingerprint(scanner_name="http_probe_scanner",
+                                   category=FindingCategory.INFO_DISCLOSURE, title=a,
+                                   endpoint_url="http://localhost:3000/api", http_method="GET") == \
+               compute_fingerprint(scanner_name="http_probe_scanner",
+                                   category=FindingCategory.INFO_DISCLOSURE, title=b,
+                                   endpoint_url="http://prod:80/api", http_method="GET")
+
+    def test_race_title_has_no_volatile_count(self):
+        from isitsecure.engine.constants import RaceConditionConfig
+        title = RaceConditionConfig.TITLE_RACE_CONDITION.format(method="POST", path="/buy")
+        assert "{count}" not in title and "succeeds concurrently" in title
+
+    def test_different_paths_still_distinct_after_normalization(self):
+        a = compute_fingerprint(scanner_name="s", category="c", title="Verbose error page at http://x/a")
+        b = compute_fingerprint(scanner_name="s", category="c", title="Verbose error page at http://x/b")
+        assert a != b
+
+
+def test_fingerprint_survives_model_dump_roundtrip():
+    """The server layers reload findings via model_validate; the extra computed
+    field must be ignored and the fingerprint recompute unchanged."""
+    f = _dast()
+    reloaded = DeepFinding.model_validate(f.model_dump(mode="json"))
+    assert reloaded.fingerprint == f.fingerprint

--- a/tests/engine/test_suppression.py
+++ b/tests/engine/test_suppression.py
@@ -1,0 +1,100 @@
+"""Tests for persisted finding suppression — .isitsecureignore (#51)."""
+
+from __future__ import annotations
+
+from isitsecure.engine import suppression as S
+from isitsecure.engine.enums import FindingCategory, SeverityLevel
+from isitsecure.engine.models import DeepFinding, FindingSource
+
+
+def _f(title, url):
+    return DeepFinding(
+        source=FindingSource.DAST_URL, category=FindingCategory.INJECTION_RISK,
+        severity=SeverityLevel.HIGH, title=title, description="d", confidence=0.8,
+        scanner_name="active_injection_scanner", endpoint_url=url, http_method="GET",
+    )
+
+
+class TestLoad:
+    def test_missing_file_is_empty(self, tmp_path):
+        assert S.load_suppressed_fingerprints(tmp_path / ".isitsecureignore") == set()
+
+    def test_parses_fingerprints_and_ignores_comments(self, tmp_path):
+        p = tmp_path / ".isitsecureignore"
+        p.write_text(
+            "# a comment\n"
+            "\n"
+            "abc123def4567890   # [injection_risk] GET /x — reason\n"
+            "   deadbeefcafebabe\n"  # leading whitespace, no comment
+            "# another comment\n"
+        )
+        assert S.load_suppressed_fingerprints(p) == {"abc123def4567890", "deadbeefcafebabe"}
+
+    def test_only_first_token_is_read(self, tmp_path):
+        p = tmp_path / ".isitsecureignore"
+        p.write_text("abc123 extra words here\n")
+        assert S.load_suppressed_fingerprints(p) == {"abc123"}
+
+
+class TestPartition:
+    def test_splits_by_fingerprint(self):
+        f1, f2 = _f("SQLi", "http://x/a"), _f("SQLi", "http://x/b")
+        active, hidden = S.partition([f1, f2], {f1.fingerprint})
+        assert [f.fingerprint for f in active] == [f2.fingerprint]
+        assert [f.fingerprint for f in hidden] == [f1.fingerprint]
+
+    def test_empty_suppression_keeps_all(self):
+        fs = [_f("SQLi", "http://x/a"), _f("SQLi", "http://x/b")]
+        active, hidden = S.partition(fs, set())
+        assert len(active) == 2 and hidden == []
+
+
+class TestAddSuppressions:
+    def test_creates_file_with_header_and_entry(self, tmp_path):
+        p = tmp_path / ".isitsecureignore"
+        f = _f("SQL injection", "http://x/createdb")
+        newly = S.add_suppressions(p, [f], [f.fingerprint], reason="benign")
+        assert [x.fingerprint for x in newly] == [f.fingerprint]
+        text = p.read_text()
+        assert text.startswith("# isitsecure suppressions")
+        assert f.fingerprint in text
+        assert "benign" in text and "createdb" in text
+        # round-trips
+        assert S.load_suppressed_fingerprints(p) == {f.fingerprint}
+
+    def test_idempotent(self, tmp_path):
+        p = tmp_path / ".isitsecureignore"
+        f = _f("SQLi", "http://x/a")
+        S.add_suppressions(p, [f], [f.fingerprint])
+        before = p.read_text()
+        assert S.add_suppressions(p, [f], [f.fingerprint]) == []
+        assert p.read_text() == before  # nothing appended
+
+    def test_unknown_fingerprint_skipped(self, tmp_path):
+        p = tmp_path / ".isitsecureignore"
+        f = _f("SQLi", "http://x/a")
+        assert S.add_suppressions(p, [f], ["notinthisscan00"]) == []
+        assert not p.exists()  # nothing to write
+
+    def test_appends_to_existing_file(self, tmp_path):
+        p = tmp_path / ".isitsecureignore"
+        f1, f2 = _f("SQLi", "http://x/a"), _f("SQLi", "http://x/b")
+        S.add_suppressions(p, [f1, f2], [f1.fingerprint])
+        S.add_suppressions(p, [f1, f2], [f2.fingerprint])
+        assert S.load_suppressed_fingerprints(p) == {f1.fingerprint, f2.fingerprint}
+
+    def test_appends_cleanly_to_hand_edited_file_without_header_or_newline(self, tmp_path):
+        """A user may hand-write the file with no header and no trailing newline —
+        appending must not merge two entries onto one line."""
+        p = tmp_path / ".isitsecureignore"
+        existing_fp = "aaaabbbbccccdddd"
+        p.write_text(f"{existing_fp}   # hand-written, no trailing newline")  # no \n
+        f = _f("SQLi", "http://x/new")
+        S.add_suppressions(p, [f], [f.fingerprint])
+        fps = S.load_suppressed_fingerprints(p)
+        assert fps == {existing_fp, f.fingerprint}  # both parsed = not merged
+
+
+def test_default_ignore_path_uses_cwd_by_default(tmp_path):
+    assert S.default_ignore_path().name == ".isitsecureignore"
+    assert S.default_ignore_path(tmp_path) == tmp_path / ".isitsecureignore"

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -103,9 +103,10 @@ def test_trim_report_shape_and_plain_english():
     # Each finding carries the trimmed + plain-English fields, no raw bloat.
     f = out["findings"][0]
     assert set(f) == {
-        "id", "severity", "category", "title", "file", "line",
+        "id", "fingerprint", "severity", "category", "title", "file", "line",
         "priority", "what_it_is", "attacker_could", "fix",
     }
+    assert len(f["fingerprint"]) == 16  # stable id for suppression (#38)
     assert f["severity"] == "critical"
     assert f["category"] == "injection_risk"
     assert f["file"] == "app/api/x.ts" and f["line"] == 10


### PR DESCRIPTION
Phase 0 + **#51** of the Trust & false-positive epic (**#38**). Keeps the epic open for #52 (baseline) and #53 (re-verify).

## Phase 0 — stable cross-scan finding identity
The per-scan `DeepFinding.id` is a random uuid — useless for matching a finding across scans. New `engine/identity.py` computes a **deterministic fingerprint** from `(scanner_name, category, locus, normalized-title)`:
- **Locus** = source file (SAST, **line-agnostic**) or `METHOD /path` (DAST, **host/port/query-agnostic**) → same issue, same fingerprint across runs/environments/edits.
- **Title normalization:** titles that interpolate the full URL are normalized (URL → path) before hashing, and the race-condition title drops its run-to-run `{count}`, so those findings are stable too. *(This was the CRITICAL bug the adversarial review caught — with a regression test.)*
- Exposed as a serialized **`DeepFinding.fingerprint`** (JSON, SARIF, table, MCP). Also fixes a latent SARIF bug that used the random `finding.id` for cross-run dedup.

## #51 — persisted suppression
- Repo-local **`.isitsecureignore`** (committed → reviewable in PRs, the acceptance criterion). Line-based, first token = fingerprint, `#` comments for context.
- New `scan` flags: `--suppress` (repeatable), `--suppress-reason`, `--suppress-file`, `--show-suppressed`.
- Filter applied **once** (feeds every output format); `report.findings`, computed counts, and **themes** all stay consistent. The AI owner-summary narrative is scan-time prose and may still mention a suppressed finding (documented).

```
# .isitsecureignore
de0e57aeb5f61708   # [injection_risk] GET /createdb — SQL injection (benign: not injection)
```

## Not detection logic — verified no-op
- **Regression benchmark (`--llm none`) byte-identical:** juiceshop **20/45 (sqli 7/7)**, vampi-vulnerable **3/3**, vampi-secure **2 FP (0 SQLi)**.
- **Full engine suite: 2012 passed, 1 xfailed.** New identity/suppression tests incl. volatile-title stability regressions, a `model_validate` round-trip, and hand-edited-file handling. New modules ruff-clean (cli.py's new flags follow its existing `typer.Option` style).

## Adversarial reviews — all findings addressed
- **CRITICAL:** volatile-title fingerprint instability (SSTI/verbose/dangerous-method/race) → fixed + regression test.
- **MAJOR:** themes re-filtered after suppression; MCP now exposes `fingerprint`. Deferred (noted): unifying the old `verifier.sig_obj` with the new fingerprint (a later epic step).
- **Doc review:** table/JSON claim made true (added `fp <hash>` to the table), TOC + owner-summary caveat.

## Docs
README "Suppressing False Positives" section + CLI flags + TOC; `docs/architecture.md` module tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)