### PR TITLE
feat(trust): baseline mode — surface only new findings (#52)

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,28 @@ de0e57aeb5f61708   # [injection_risk] GET /createdb — SQL injection (benign: n
 
 Suppressed findings are dropped from the findings list, counts, and themes in every output format. (The AI *owner summary* narrative is written during the scan, so it may still mention a finding you suppressed afterward.)
 
+### Baseline mode — only show what's new
+
+For an app that already has a backlog of known findings, **baseline mode** lets you accept the current set once and then, on later scans, see only what's *new* — ideal for a CI gate that should fail on regressions but not on pre-existing debt.
+
+```bash
+# Accept the current findings as the baseline for this project (once)
+isitsecure scan https://your-app.com --baseline-accept
+
+# Later scans: show only findings new since the baseline
+isitsecure scan https://your-app.com --baseline
+```
+
+Baselines are keyed per project (repo or target URL) and stored under `~/.isitsecure/baselines/` — machine-local state, unlike the committed `.isitsecureignore`. Baseline and suppression compose: `--baseline` shows new, not-suppressed findings. Findings match by the same stable fingerprint, so a baseline survives host/port/query changes and code edits.
+
+**In CI:** the default `~/.isitsecure/` path is per-machine, so a fresh runner has no baseline and `--baseline` would show the whole backlog. Point `--baseline-file` at a path you commit to the repo (or cache between runs) so the gate compares against a shared, version-controlled baseline:
+
+```bash
+isitsecure scan "$URL" --baseline-file .isitsecure-baseline.json --baseline --output sarif
+# establish/refresh it deliberately (e.g. on main):
+isitsecure scan "$URL" --baseline-file .isitsecure-baseline.json --baseline-accept
+```
+
 ## Auto-Fix: One Command to Fix Your App
 
 `fix` works two ways depending on what you point it at:
@@ -526,6 +548,9 @@ Options:
   --suppress-reason TEXT Reason recorded next to --suppress entries
   --suppress-file TEXT   Ignore file path [default: ./.isitsecureignore]
   --show-suppressed      List suppressed findings instead of hiding them
+  --baseline             Show only findings new since the accepted baseline
+  --baseline-accept      Record the current findings as the baseline
+  --baseline-file TEXT   Baseline path [default: ~/.isitsecure/baselines/<project>.json]
   -v, --verbose          Enable debug logging
 
 isitsecure fix [OPTIONS]

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -319,6 +319,7 @@ isitsecure/
 │   ├── constants.py            # All configuration constants
 │   ├── identity.py             # Stable cross-scan finding fingerprint (#38 trust)
 │   ├── suppression.py          # .isitsecureignore parsing + filter (#51)
+│   ├── baseline.py             # Baseline accept/diff — show only new findings (#52)
 │   ├── cross_referencer.py     # DAST ↔ SAST finding matcher
 │   ├── scan_config.py          # User-configurable scan settings
 │   ├── scanners/               # 16 DAST scanners (quick) + special scanners

--- a/isitsecure/cli.py
+++ b/isitsecure/cli.py
@@ -175,6 +175,108 @@ def _ensure_config_dir() -> Path:
     return CONFIG_DIR
 
 
+def _drop_findings_from_themes(report, hidden_ids: set) -> None:
+    """Remove hidden findings from the report's thematic grouping so suppressed
+    or baseline-known findings don't resurface there (#51/#52)."""
+    if not hidden_ids or not report.themes:
+        return
+    kept = []
+    for theme in report.themes:
+        theme.finding_ids = [i for i in theme.finding_ids if i not in hidden_ids]
+        theme.finding_count = len(theme.finding_ids)
+        if theme.finding_ids:
+            kept.append(theme)
+    report.themes = kept
+
+
+def _apply_trust_filters(
+    report, *, output: str, target_url, repo,
+    suppress, suppress_reason: str, suppress_file, show_suppressed: bool,
+    baseline: bool, baseline_accept: bool, baseline_file,
+) -> None:
+    """Apply suppression (#51) then baseline (#52) to ``report.findings`` in place.
+
+    Suppression runs first, so the baseline never records or diffs a suppressed
+    finding. Mutates ``report.findings`` (and themes) so every output format sees
+    the same filtered set; emits progress to stderr. Extracted from ``scan`` so
+    the composition can be unit-tested directly.
+    """
+    from isitsecure.engine import baseline as _baseline
+    from isitsecure.engine import suppression as _suppression
+
+    # --- Suppression -----------------------------------------------------
+    ignore_path = Path(suppress_file) if suppress_file else _suppression.default_ignore_path()
+    if suppress:
+        newly = _suppression.add_suppressions(
+            ignore_path, report.findings, suppress, suppress_reason
+        )
+        if newly:
+            err_console.print(
+                f"[green]Suppressed {len(newly)} finding(s)[/green] in [dim]{ignore_path}[/dim]"
+            )
+        unmatched = set(suppress) - {f.fingerprint for f in report.findings}
+        if unmatched:
+            err_console.print(
+                f"[yellow]No finding in this scan matched: {', '.join(sorted(unmatched))}[/yellow]"
+            )
+    active, hidden = _suppression.partition(
+        report.findings, _suppression.load_suppressed_fingerprints(ignore_path)
+    )
+    if show_suppressed:
+        report.findings = hidden
+        if output not in ("json", "sarif"):
+            err_console.print(
+                f"[dim]Showing {len(hidden)} suppressed finding(s) from {ignore_path.name}[/dim]"
+            )
+    else:
+        report.findings = active
+        _drop_findings_from_themes(report, {f.id for f in hidden})
+        if hidden and output not in ("json", "sarif"):
+            err_console.print(
+                f"[dim]{len(hidden)} finding(s) suppressed via {ignore_path.name} "
+                f"(use --show-suppressed to view)[/dim]"
+            )
+
+    # --- Baseline --------------------------------------------------------
+    if baseline_accept and show_suppressed:
+        err_console.print(
+            "[yellow]--baseline-accept is ignored with --show-suppressed "
+            "(refusing to baseline the suppressed set).[/yellow]"
+        )
+    if not (baseline or baseline_accept) or show_suppressed:
+        return
+    bl_path = Path(baseline_file) if baseline_file else _baseline.baseline_path(target_url, repo)
+    if baseline_accept:
+        n = _baseline.save_baseline(
+            bl_path, report.findings, target_url=target_url, repo_url=repo,
+            commit=report.repo_commit_hash,
+        )
+        err_console.print(
+            f"[green]Baseline accepted[/green] — {n} finding(s) recorded in [dim]{bl_path}[/dim]"
+        )
+    if not baseline:
+        return
+    known_baseline = _baseline.load_baseline(bl_path)
+    if known_baseline is None:  # missing OR corrupt — distinguish for an honest message
+        if bl_path.exists():
+            err_console.print(
+                f"[yellow]Baseline at {bl_path} is unreadable/corrupt — showing all findings.[/yellow]"
+            )
+        elif not baseline_accept:
+            err_console.print(
+                "[yellow]No baseline accepted yet for this project — showing all findings. "
+                "Run once with --baseline-accept first.[/yellow]"
+            )
+        return
+    new, known = _baseline.partition_new(report.findings, known_baseline)
+    report.findings = new
+    _drop_findings_from_themes(report, {f.id for f in known})
+    if known and output not in ("json", "sarif"):
+        err_console.print(
+            f"[dim]{len(known)} known finding(s) hidden by baseline; showing {len(new)} new.[/dim]"
+        )
+
+
 def _load_api_key(provider: str) -> str | None:
     """Load API key from env, .env file, or config (see isitsecure.config)."""
     return load_api_key(provider)
@@ -205,6 +307,9 @@ def scan(
     suppress_reason: str = typer.Option("", "--suppress-reason", help="Reason recorded next to --suppress entries"),
     suppress_file: Optional[str] = typer.Option(None, "--suppress-file", help="Ignore file path (default ./.isitsecureignore)"),
     show_suppressed: bool = typer.Option(False, "--show-suppressed", help="List suppressed findings instead of hiding them"),
+    baseline: bool = typer.Option(False, "--baseline", help="Show only findings new since the accepted baseline"),
+    baseline_accept: bool = typer.Option(False, "--baseline-accept", help="Record the current findings as the baseline"),
+    baseline_file: Optional[str] = typer.Option(None, "--baseline-file", help="Baseline path (default ~/.isitsecure/baselines/<project>.json)"),
     verbose: bool = typer.Option(False, "--verbose", "-v"),
 ) -> None:
     """Run a security scan against a web application."""
@@ -314,53 +419,14 @@ def scan(
         scan_mode=resolved_mode,
     ))
 
-    # --- Suppression (#51): drop findings the user has accepted as FPs -------
-    # Applied once here so every output format (table/json/html/sarif/fixes)
-    # sees the same filtered set. The .isitsecureignore file is the source of
-    # truth and is reviewable in code review.
-    from isitsecure.engine import suppression as _suppression
-    _ignore_path = Path(suppress_file) if suppress_file else _suppression.default_ignore_path()
-    if suppress:
-        newly = _suppression.add_suppressions(
-            _ignore_path, report.findings, suppress, suppress_reason
-        )
-        if newly:
-            err_console.print(
-                f"[green]Suppressed {len(newly)} finding(s)[/green] in "
-                f"[dim]{_ignore_path}[/dim]"
-            )
-        unmatched = set(suppress) - {f.fingerprint for f in report.findings}
-        if unmatched:
-            err_console.print(
-                f"[yellow]No finding in this scan matched: {', '.join(sorted(unmatched))}[/yellow]"
-            )
-    _suppressed_fps = _suppression.load_suppressed_fingerprints(_ignore_path)
-    _active, _hidden = _suppression.partition(report.findings, _suppressed_fps)
-    if show_suppressed:
-        report.findings = _hidden
-        if output not in ("json", "sarif"):
-            err_console.print(
-                f"[dim]Showing {len(_hidden)} suppressed finding(s) from {_ignore_path.name}[/dim]"
-            )
-    else:
-        report.findings = _active
-        # Keep the thematic grouping honest: drop suppressed findings from themes
-        # (they reference findings by id). The owner_summary is an LLM narrative
-        # generated pre-suppression and may still mention a suppressed finding.
-        _hidden_ids = {f.id for f in _hidden}
-        if _hidden_ids and report.themes:
-            _kept = []
-            for _th in report.themes:
-                _th.finding_ids = [i for i in _th.finding_ids if i not in _hidden_ids]
-                _th.finding_count = len(_th.finding_ids)
-                if _th.finding_ids:
-                    _kept.append(_th)
-            report.themes = _kept
-        if _hidden and output not in ("json", "sarif"):
-            err_console.print(
-                f"[dim]{len(_hidden)} finding(s) suppressed via {_ignore_path.name} "
-                f"(use --show-suppressed to view)[/dim]"
-            )
+    # Suppression (#51) + baseline (#52): filter the findings once, so every
+    # output format sees the same set. Extracted for direct testing.
+    _apply_trust_filters(
+        report, output=output, target_url=target_url, repo=repo,
+        suppress=suppress, suppress_reason=suppress_reason,
+        suppress_file=suppress_file, show_suppressed=show_suppressed,
+        baseline=baseline, baseline_accept=baseline_accept, baseline_file=baseline_file,
+    )
 
     # Output results
     if output == "json":

--- a/isitsecure/engine/baseline.py
+++ b/isitsecure/engine/baseline.py
@@ -1,0 +1,115 @@
+"""Baseline mode — surface only findings that are new since an accepted baseline (#52).
+
+A team that has triaged its current findings wants later scans to show only what
+is *new*, not re-litigate the whole backlog every run. ``--baseline-accept``
+records the fingerprints of the current findings; a later ``--baseline`` scan
+hides those and shows only findings whose fingerprint is not in the baseline.
+
+Baselines are keyed per project (repo URL or target URL) and stored under
+``~/.isitsecure/baselines/`` — machine-local state, unlike the repo-committed
+``.isitsecureignore`` used for suppression (#51). Identity is the shared
+:func:`isitsecure.engine.identity.finding_fingerprint`.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import TYPE_CHECKING
+from urllib.parse import urlparse
+
+from isitsecure.config import CONFIG_DIR
+
+if TYPE_CHECKING:
+    from isitsecure.engine.models import DeepFinding
+
+BASELINES_DIRNAME = "baselines"
+_SLUG_MAX = 40
+
+
+def baselines_dir() -> Path:
+    return CONFIG_DIR / BASELINES_DIRNAME
+
+
+def project_key(target_url: str | None, repo_url: str | None) -> str:
+    """A stable, filesystem-safe key identifying the scanned project.
+
+    Prefers the repo URL (a repo is the same project across environments); falls
+    back to the target URL's host+path. The hash is over the NORMALIZED host+path
+    (lower-cased, scheme dropped) so `https://x/a`, `x/a` and `X/a` share a key;
+    a slug prefix keeps the filename readable. (Deeper git-URL normalization —
+    `.git`, `git@` SSH form — is out of scope; those still key separately.)
+    """
+    identifier = (repo_url or target_url or "unknown").strip()
+    parsed = urlparse(identifier if "://" in identifier else f"//{identifier}")
+    readable = (f"{parsed.netloc}{parsed.path}" or identifier).lower()
+    slug = re.sub(r"[^a-zA-Z0-9]+", "-", readable).strip("-")[:_SLUG_MAX] or "project"
+    digest = hashlib.sha256(readable.encode("utf-8")).hexdigest()[:8]
+    return f"{slug}-{digest}"
+
+
+def baseline_path(target_url: str | None, repo_url: str | None) -> Path:
+    return baselines_dir() / f"{project_key(target_url, repo_url)}.json"
+
+
+def load_baseline(path: Path) -> set[str] | None:
+    """Fingerprints in the baseline, or ``None`` if the file is absent OR
+    unreadable/corrupt (the caller uses ``path.exists()`` to tell those apart).
+    A validly-empty baseline returns an empty set, not ``None``."""
+    if not path.exists():
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError, ValueError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    fps = data.get("fingerprints", [])
+    if not isinstance(fps, list):
+        return None
+    return {str(x) for x in fps}
+
+
+def save_baseline(
+    path: Path,
+    findings: list[DeepFinding],
+    *,
+    target_url: str | None = None,
+    repo_url: str | None = None,
+    commit: str = "",
+) -> int:
+    """Write the current findings' fingerprints as the accepted baseline.
+
+    Returns the number of unique fingerprints recorded.
+    """
+    fingerprints = sorted({f.fingerprint for f in findings})
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "version": 1,  # informational; not yet used for migration
+        "created": datetime.now(UTC).isoformat(),
+        "target_url": target_url,
+        "repo_url": repo_url,
+        "commit": commit,
+        "fingerprints": fingerprints,
+    }
+    # Atomic write: a crash or concurrent scan must never leave a truncated file
+    # (which load_baseline would treat as corrupt).
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    os.replace(tmp, path)
+    return len(fingerprints)
+
+
+def partition_new(
+    findings: list[DeepFinding], baseline: set[str]
+) -> tuple[list[DeepFinding], list[DeepFinding]]:
+    """Split findings into (new, known) relative to the baseline fingerprints."""
+    new: list[DeepFinding] = []
+    known: list[DeepFinding] = []
+    for f in findings:
+        (known if f.fingerprint in baseline else new).append(f)
+    return new, known

--- a/tests/engine/test_baseline.py
+++ b/tests/engine/test_baseline.py
@@ -1,0 +1,129 @@
+"""Tests for baseline mode — surface only new findings (#52)."""
+
+from __future__ import annotations
+
+from isitsecure.engine import baseline as B
+from isitsecure.engine.enums import FindingCategory, SeverityLevel
+from isitsecure.engine.models import DeepFinding, FindingSource
+
+
+def _f(title, url):
+    return DeepFinding(
+        source=FindingSource.DAST_URL, category=FindingCategory.INJECTION_RISK,
+        severity=SeverityLevel.HIGH, title=title, description="d", confidence=0.8,
+        scanner_name="active_injection_scanner", endpoint_url=url, http_method="GET",
+    )
+
+
+class TestProjectKey:
+    def test_repo_key_stable_across_target_environments(self):
+        a = B.project_key("http://localhost:3000", "github.com/me/app")
+        b = B.project_key("https://prod.example.com:8443", "github.com/me/app")
+        assert a == b
+
+    def test_distinct_repos_get_distinct_keys(self):
+        assert B.project_key(None, "github.com/me/a") != B.project_key(None, "github.com/me/b")
+
+    def test_key_is_filesystem_safe_and_readable(self):
+        k = B.project_key("http://localhost:3000/app", None)
+        assert "/" not in k and k.startswith("localhost-3000")
+
+    def test_slug_collision_disambiguated_by_hash(self):
+        # Two identifiers that slugify identically must still differ (hash suffix).
+        a = B.project_key(None, "github.com/me/app")
+        b = B.project_key(None, "github.com/me/app/")  # trailing slash → same slug
+        assert a != b
+
+
+class TestSaveLoad:
+    def test_missing_baseline_returns_none(self, tmp_path):
+        # None (absent) is distinct from an empty set (a validly-empty baseline).
+        assert B.load_baseline(tmp_path / "none.json") is None
+
+    def test_save_then_load_roundtrips_fingerprints(self, tmp_path):
+        p = tmp_path / "proj.json"
+        fs = [_f("SQLi", "http://x/a"), _f("SQLi", "http://x/b")]
+        n = B.save_baseline(p, fs, target_url="http://x", repo_url=None)
+        assert n == 2
+        assert B.load_baseline(p) == {fs[0].fingerprint, fs[1].fingerprint}
+
+    def test_validly_empty_baseline_is_empty_set_not_none(self, tmp_path):
+        p = tmp_path / "clean.json"
+        B.save_baseline(p, [])  # a clean app: 0 findings baselined
+        assert B.load_baseline(p) == set()
+
+    def test_save_dedups_fingerprints(self, tmp_path):
+        p = tmp_path / "proj.json"
+        dupe = _f("SQLi", "http://x/a")
+        same = _f("SQLi", "http://x/a")  # identical → same fingerprint
+        assert dupe.fingerprint == same.fingerprint
+        assert B.save_baseline(p, [dupe, same]) == 1
+
+    def test_corrupt_baseline_returns_none(self, tmp_path):
+        p = tmp_path / "proj.json"
+        p.write_text("not valid json {{{")
+        assert B.load_baseline(p) is None
+
+    def test_valid_json_wrong_shape_returns_none_not_crash(self, tmp_path):
+        # A JSON array, or a non-list `fingerprints`, must degrade to None — never
+        # crash (M1) and never mis-read a string as a set of chars.
+        for bad in ('[1, 2, 3]', '{"fingerprints": "abcd"}', '"just a string"', '42'):
+            p = tmp_path / "bad.json"
+            p.write_text(bad)
+            assert B.load_baseline(p) is None
+
+    def test_creates_parent_directory(self, tmp_path):
+        p = tmp_path / "nested" / "dir" / "proj.json"
+        B.save_baseline(p, [_f("SQLi", "http://x/a")])
+        assert p.exists()
+
+
+class TestPartitionNew:
+    def test_splits_new_vs_known(self):
+        old = [_f("SQLi", "http://x/a"), _f("SQLi", "http://x/b")]
+        baseline = {old[0].fingerprint, old[1].fingerprint}
+        current = [_f("SQLi", "http://x/a"), _f("SQLi", "http://x/c")]  # b fixed, c new
+        new, known = B.partition_new(current, baseline)
+        assert [f.endpoint_url for f in new] == ["http://x/c"]
+        assert [f.endpoint_url for f in known] == ["http://x/a"]
+
+    def test_empty_baseline_makes_everything_new(self):
+        fs = [_f("SQLi", "http://x/a"), _f("SQLi", "http://x/b")]
+        new, known = B.partition_new(fs, set())
+        assert len(new) == 2 and known == []
+
+
+def test_baseline_path_uses_baselines_dir(tmp_path, monkeypatch):
+    monkeypatch.setattr(B, "CONFIG_DIR", tmp_path)
+    p = B.baseline_path("http://x", None)
+    assert p.parent == tmp_path / "baselines"
+    assert p.suffix == ".json"
+
+
+class TestIntegration:
+    """Mirror the CLI flow: accept a baseline, then a later scan surfaces only new."""
+
+    def test_accept_then_diff_surfaces_only_new(self, tmp_path):
+        p = tmp_path / "proj.json"
+        scan1 = [_f("SQLi", "http://x/a"), _f("SQLi", "http://x/b")]
+        B.save_baseline(p, scan1)
+        scan2 = [_f("SQLi", "http://x/a"), _f("SQLi", "http://x/d")]  # b fixed, d new
+        new, known = B.partition_new(scan2, B.load_baseline(p))
+        assert [f.endpoint_url for f in new] == ["http://x/d"]
+        assert [f.endpoint_url for f in known] == ["http://x/a"]
+
+    def test_composes_with_suppression(self, tmp_path):
+        """The CLI baselines the post-suppression set, so a suppressed finding is
+        neither recorded nor surfaced as new later."""
+        from isitsecure.engine import suppression as Sup
+        ignore = tmp_path / ".isitsecureignore"
+        p = tmp_path / "proj.json"
+        scan1 = [_f("SQLi", "http://x/a"), _f("SQLi", "http://x/b"), _f("SQLi", "http://x/c")]
+        Sup.add_suppressions(ignore, scan1, [scan1[1].fingerprint], "fp")  # suppress b
+        active1, _ = Sup.partition(scan1, Sup.load_suppressed_fingerprints(ignore))
+        B.save_baseline(p, active1)  # baseline = {a, c}
+
+        scan2 = [_f("SQLi", "http://x/a"), _f("SQLi", "http://x/c"), _f("SQLi", "http://x/d")]
+        active2, _ = Sup.partition(scan2, Sup.load_suppressed_fingerprints(ignore))
+        new, _ = B.partition_new(active2, B.load_baseline(p))
+        assert [f.endpoint_url for f in new] == ["http://x/d"]  # only the genuinely new one

--- a/tests/test_cli_trust_filters.py
+++ b/tests/test_cli_trust_filters.py
@@ -1,0 +1,96 @@
+"""CLI-level tests for the suppression + baseline composition hook (#51/#52).
+
+Exercises `cli._apply_trust_filters` directly — the seam that wires the
+suppression and baseline modules together and mutates the report — without
+running a full scan.
+"""
+
+from __future__ import annotations
+
+from isitsecure import cli
+from isitsecure.engine import baseline as B
+from isitsecure.engine.enums import FindingCategory, SeverityLevel
+from isitsecure.engine.models import DeepFinding, DeepScanReport, FindingSource
+
+
+def _f(title, url):
+    return DeepFinding(
+        source=FindingSource.DAST_URL, category=FindingCategory.INJECTION_RISK,
+        severity=SeverityLevel.CRITICAL, title=title, description="d", confidence=0.8,
+        scanner_name="active_injection_scanner", endpoint_url=url, http_method="GET",
+    )
+
+
+def _report(findings):
+    return DeepScanReport(target_url="http://app", findings=list(findings))
+
+
+def _apply(report, tmp_path, **kw):
+    opts = dict(
+        output="table", target_url="http://app", repo=None,
+        suppress=None, suppress_reason="", suppress_file=str(tmp_path / ".isitsecureignore"),
+        show_suppressed=False, baseline=False, baseline_accept=False,
+        baseline_file=str(tmp_path / "bl.json"),
+    )
+    opts.update(kw)
+    cli._apply_trust_filters(report, **opts)
+
+
+def test_suppress_adds_and_hides(tmp_path):
+    fp = _f("SQLi", "http://app/createdb").fingerprint
+    r = _report([_f("SQLi", "http://app/createdb"), _f("SQLi", "http://app/login")])
+    _apply(r, tmp_path, suppress=[fp], suppress_reason="benign")
+    assert [f.endpoint_url for f in r.findings] == ["http://app/login"]
+    assert (tmp_path / ".isitsecureignore").exists()
+
+
+def test_baseline_accept_records_post_suppression_set(tmp_path):
+    """The baseline must exclude a finding suppressed in the same run."""
+    supp = _f("SQLi", "http://app/createdb").fingerprint
+    r = _report([_f("SQLi", "http://app/createdb"), _f("SQLi", "http://app/login")])
+    _apply(r, tmp_path, suppress=[supp], baseline_accept=True)
+    saved = B.load_baseline(tmp_path / "bl.json")
+    assert supp not in saved  # suppressed finding not baselined
+    assert _f("SQLi", "http://app/login").fingerprint in saved
+
+
+def test_accept_then_baseline_shows_only_new(tmp_path):
+    # Run 1: accept a,b.
+    r1 = _report([_f("SQLi", "http://app/a"), _f("SQLi", "http://app/b")])
+    _apply(r1, tmp_path, baseline_accept=True)
+    # Run 2: a,c — only c is new.
+    r2 = _report([_f("SQLi", "http://app/a"), _f("SQLi", "http://app/c")])
+    _apply(r2, tmp_path, baseline=True)
+    assert [f.endpoint_url for f in r2.findings] == ["http://app/c"]
+    assert r2.critical_count == 1  # counts follow the filtered set
+
+
+def test_suppression_and_baseline_compose(tmp_path):
+    # Accept baseline of the active (post-suppression) set: suppress b.
+    supp = _f("SQLi", "http://app/b").fingerprint
+    r1 = _report([_f("SQLi", "http://app/a"), _f("SQLi", "http://app/b"), _f("SQLi", "http://app/c")])
+    _apply(r1, tmp_path, suppress=[supp], baseline_accept=True)
+    # Run 2: a,c,d with b still suppressed → only d is new.
+    r2 = _report([_f("SQLi", "http://app/a"), _f("SQLi", "http://app/c"), _f("SQLi", "http://app/d")])
+    _apply(r2, tmp_path, baseline=True)
+    assert [f.endpoint_url for f in r2.findings] == ["http://app/d"]
+
+
+def test_show_suppressed_disables_baseline(tmp_path):
+    # With --show-suppressed, baseline_accept must NOT write a baseline.
+    r = _report([_f("SQLi", "http://app/a")])
+    _apply(r, tmp_path, show_suppressed=True, baseline_accept=True)
+    assert not (tmp_path / "bl.json").exists()
+
+
+def test_baseline_missing_shows_all(tmp_path):
+    r = _report([_f("SQLi", "http://app/a"), _f("SQLi", "http://app/b")])
+    _apply(r, tmp_path, baseline=True)  # no baseline accepted yet
+    assert len(r.findings) == 2  # falls open, not closed
+
+
+def test_corrupt_baseline_shows_all_without_crashing(tmp_path):
+    (tmp_path / "bl.json").write_text("}{ not json")
+    r = _report([_f("SQLi", "http://app/a")])
+    _apply(r, tmp_path, baseline=True)
+    assert len(r.findings) == 1  # corrupt → show all, no crash


### PR DESCRIPTION
**#52** of the Trust & false-positive epic (**#38**), built on the v0.20.0 fingerprint. Epic stays open for #53 (per-finding re-verify).

## What it does
- **`--baseline-accept`** records the current findings' fingerprints as the baseline; **`--baseline`** shows only findings new since it. Ideal for a CI gate that fails on regressions but not on pre-existing debt.
- Keyed per project (repo preferred → environment-stable) under `~/.isitsecure/baselines/<project>.json`. `--baseline-file` overrides the path.
- **Composes with #51 suppression:** `--baseline` shows new, *not-suppressed* findings.

```bash
isitsecure scan "$URL" --baseline-accept   # once
isitsecure scan "$URL" --baseline          # later: only new
```

## Robustness (from adversarial review)
- `load_baseline` is **crash-proof** — validates JSON shape, never raises on a wrong-shape file (M1); **missing vs. corrupt** are distinct (returns `None`) so the user gets an honest message (M2).
- `save_baseline` is **atomic** (temp + `os.replace`).
- `project_key` hashes the **normalized** host+path (scheme/case-stable).
- The post-report suppression+baseline hook is extracted into a testable **`_apply_trust_filters`** helper (M4).

## CI-gate caveat (documented)
Baselines default to `~/.isitsecure/` (machine-local), so a fresh CI runner has none. The README shows the recipe: point `--baseline-file` at a committed/cached path.

## Verification
- **Regression benchmark (`--llm none`) byte-identical:** juiceshop **20/45 (sqli 7/7)**, vampi-vulnerable **3/3**, vampi-secure **2 FP (0 SQLi)** — the refactored hook (now on every scan path) is a no-op on detection.
- **Full `tests/` suite: 2138 passed, 1 xfailed** (ran the complete tree, not just `tests/engine/`). 23 new baseline + CLI-composition tests incl. accept-records-post-suppression-set, corrupt-baseline-no-crash, and suppression∘baseline compose. New files ruff-clean.
- Adversarial code + doc review run; all findings addressed.

## Docs
README "Baseline mode" subsection + CI recipe + CLI flags; `docs/architecture.md` module tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)