### PR TITLE
feat(trust): per-finding re-verify — verify command (#53)

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,6 +335,22 @@ isitsecure scan "$URL" --baseline-file .isitsecure-baseline.json --baseline --ou
 isitsecure scan "$URL" --baseline-file .isitsecure-baseline.json --baseline-accept
 ```
 
+### Re-verifying a fix — is it fixed now?
+
+After you fix something, `isitsecure verify` re-checks *specific* findings from a previous scan and tells you fixed vs. still-present — without re-scanning everything:
+
+```bash
+isitsecure scan https://your-app.com --output json -f before.json   # capture findings + fingerprints
+# ...apply your fix...
+isitsecure verify https://your-app.com --report before.json --fingerprint de0e57aeb5f61708
+```
+
+- **DAST** findings are re-probed against the target — the exact endpoint is re-run through the scanner that raised it. To avoid ever *falsely* claiming a fix, a `fixed`/`still-present` verdict is only given when a single-endpoint re-probe can faithfully reproduce the finding (endpoint-level checks like security headers / CORS / CSRF, and parameter-level injection where the tested parameter is recoverable). Findings that depend on crawl-derived state or multi-request flows (e.g. stored XSS) are reported `unverifiable` — re-verify those with a full scan.
+- **SAST** findings are re-checked against a local `--repo` via a code-only re-scan.
+- Omit `--fingerprint` to re-verify every finding in the report. Exit codes make it a CI gate: **`0`** all clear (everything fixed), **`1`** at least one finding still present, **`2`** inconclusive — something couldn't be verified (`unverifiable`/error) or a requested fingerprint wasn't in the report. LLM-review findings (which need a model to reproduce) are always `unverifiable`.
+
+(This is the per-finding CLI counterpart to the MCP `verify(scan_id)` tool, which instead re-scans everything and reports grade movement.)
+
 ## Auto-Fix: One Command to Fix Your App
 
 `fix` works two ways depending on what you point it at:
@@ -564,6 +580,12 @@ isitsecure fix [OPTIONS]
   --pr-strategy TEXT     Group PRs by: per-category|per-file|per-finding|single [default: per-category]
   --max-prs INT          Cap on PRs; excess low-severity categories batch into one [default: 8]
   -v, --verbose          Enable debug logging
+
+isitsecure verify [TARGET_URL] [OPTIONS]   # exit 0 all-fixed · 1 still-present · 2 inconclusive
+  --report TEXT          Previous scan JSON (from scan --output json) [required]
+  --fingerprint TEXT     Only verify these fingerprints (repeatable; default: all)
+  -r, --repo TEXT        Local repo path for re-checking SAST findings
+  -o, --output TEXT      Output format: table|json [default: table]
 
 isitsecure badge [OPTIONS]
   -r, --repo TEXT        Path to local repo to scan [required]

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -320,6 +320,7 @@ isitsecure/
 │   ├── identity.py             # Stable cross-scan finding fingerprint (#38 trust)
 │   ├── suppression.py          # .isitsecureignore parsing + filter (#51)
 │   ├── baseline.py             # Baseline accept/diff — show only new findings (#52)
+│   ├── reverify.py             # Per-finding re-verification (SAST + DAST) (#53)
 │   ├── cross_referencer.py     # DAST ↔ SAST finding matcher
 │   ├── scan_config.py          # User-configurable scan settings
 │   ├── scanners/               # 16 DAST scanners (quick) + special scanners

--- a/isitsecure/cli.py
+++ b/isitsecure/cli.py
@@ -769,6 +769,100 @@ def _print_report_table(report) -> None:
 
 
 # ---------------------------------------------------------------------------
+# verify command (#53 — re-check specific findings: fixed or still present)
+# ---------------------------------------------------------------------------
+
+@app.command()
+def verify(
+    target_url: Optional[str] = typer.Argument(None, help="Target URL to re-probe DAST findings against"),
+    report: str = typer.Option(..., "--report", help="Previous scan JSON (from scan --output json)"),
+    fingerprint: Optional[list[str]] = typer.Option(None, "--fingerprint", help="Only verify these fingerprints (repeatable; default: all)"),
+    repo: Optional[str] = typer.Option(None, "--repo", "-r", help="Local repo path for re-checking SAST findings"),
+    output: str = typer.Option("table", "--output", "-o", help="Output format: table|json"),
+) -> None:
+    """Re-check whether findings from a previous scan are fixed now.
+
+    SAST findings are re-checked against a local --repo; DAST findings are
+    re-probed against the target URL. Exits non-zero if any finding is still
+    present (CI-friendly).
+    """
+    import asyncio as _asyncio
+
+    from isitsecure.engine.models import DeepFinding
+    from isitsecure.engine.reverify import VerifyStatus, reverify_findings
+
+    report_path = Path(report)
+    if not report_path.exists():
+        err_console.print(f"[red]Report not found: {report}[/red]")
+        raise typer.Exit(2)
+    try:
+        data = json.loads(report_path.read_text())
+    except (json.JSONDecodeError, OSError) as exc:
+        err_console.print(f"[red]Could not read report {report}: {exc}[/red]")
+        raise typer.Exit(2) from exc
+
+    findings = [DeepFinding.model_validate(d) for d in data.get("findings", [])]
+    unknown: set[str] = set()
+    if fingerprint:
+        wanted = set(fingerprint)
+        findings = [f for f in findings if f.fingerprint in wanted]
+        unknown = wanted - {f.fingerprint for f in findings}
+        if unknown:
+            err_console.print(
+                f"[yellow]Not in report: {', '.join(sorted(unknown))}[/yellow]"
+            )
+    if not findings:
+        # Nothing verified — an inconclusive gate must not read as "green".
+        err_console.print("[yellow]No matching findings to verify.[/yellow]")
+        raise typer.Exit(2 if unknown else 0)
+
+    verdicts = _asyncio.run(reverify_findings(findings, target_url=target_url, repo_path=repo))
+
+    still = [v for v in verdicts if v.status == VerifyStatus.STILL_PRESENT]
+    fixed = [v for v in verdicts if v.status == VerifyStatus.FIXED]
+    inconclusive = [v for v in verdicts
+                    if v.status in (VerifyStatus.UNVERIFIABLE, VerifyStatus.ERROR)]
+
+    if output == "json":
+        sys.stdout.write(json.dumps({
+            "verdicts": [
+                {"fingerprint": v.finding.fingerprint, "status": v.status.value,
+                 "title": v.finding.title, "detail": v.detail}
+                for v in verdicts
+            ],
+            "fixed": len(fixed), "still_present": len(still),
+        }, indent=2) + "\n")
+    else:
+        _status_style = {
+            VerifyStatus.FIXED: "[green]FIXED[/green]",
+            VerifyStatus.STILL_PRESENT: "[red]STILL PRESENT[/red]",
+            VerifyStatus.UNVERIFIABLE: "[dim]unverifiable[/dim]",
+            VerifyStatus.ERROR: "[yellow]error[/yellow]",
+        }
+        table = Table(title="Re-verification", show_lines=False)
+        table.add_column("Status", width=16)
+        table.add_column("Finding", width=52)
+        table.add_column("Fingerprint", style="dim", width=16)
+        for v in verdicts:
+            table.add_row(_status_style[v.status], v.finding.title[:52], v.finding.fingerprint)
+        console.print(table)
+        console.print(
+            f"\n[green]{len(fixed)} fixed[/green] · "
+            f"[red]{len(still)} still present[/red] · "
+            f"[dim]{len(inconclusive)} unverifiable/error[/dim]"
+        )
+
+    # Exit codes for CI: 1 = a regression is still present; 2 = inconclusive
+    # (something couldn't be verified, or a requested fingerprint wasn't found) —
+    # so a typo or a missing target never reads as a green gate; 0 = all fixed.
+    if still:
+        raise typer.Exit(1)
+    if inconclusive or unknown:
+        raise typer.Exit(2)
+    raise typer.Exit(0)
+
+
+# ---------------------------------------------------------------------------
 # launch command (web UI)
 # ---------------------------------------------------------------------------
 

--- a/isitsecure/engine/reverify.py
+++ b/isitsecure/engine/reverify.py
@@ -1,0 +1,217 @@
+"""Per-finding re-verification (#53) — is this one finding fixed now?
+
+The fix-flow verifier (``fixes/verifier.py``) re-scans a whole repo and only
+handles SAST findings. This module re-checks *specific* findings — SAST **and**
+DAST — and returns a definitive fixed / still-present verdict per finding:
+
+- **SAST** (has ``code_location``): one code-only re-scan of the repo; a finding
+  is fixed when its fingerprint no longer appears.
+- **DAST** (has ``endpoint_url``): reconstruct the endpoint against the target and
+  re-run *the scanner that raised it*; fixed when it no longer raises the same
+  fingerprint. Host/port/query are re-based onto the given target, which is
+  exactly why the fingerprint is host-agnostic.
+- Everything else (LLM-review findings, special scanners not in the standard DAST
+  set) is reported ``unverifiable`` rather than falsely claimed fixed.
+
+Identity is the shared :func:`isitsecure.engine.identity.finding_fingerprint`.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from dataclasses import dataclass
+from enum import StrEnum
+from urllib.parse import urlparse
+
+from isitsecure.engine.fixes.verifier import LLM_SCANNERS
+from isitsecure.engine.identity import finding_fingerprint
+from isitsecure.engine.models import DeepFinding
+
+logger = logging.getLogger(__name__)
+
+# A re-verify tool must NEVER falsely claim "fixed". A single-endpoint re-probe
+# can only faithfully reproduce a finding when the finding doesn't depend on
+# crawl-derived state (multi-request flows like stored XSS) or on a tested
+# parameter we can't recover. So FIXED/STILL_PRESENT is claimed only for a
+# conservative allowlist; everything else degrades to UNVERIFIABLE.
+#
+# Endpoint-level: reproducible from URL + method alone (checks the endpoint or
+# its response, not an injected parameter).
+_ENDPOINT_REVERIFIABLE = {
+    "security_headers_scanner",
+    "cors_scanner",
+    "source_map_scanner",
+    "http_probe_scanner",
+    "csrf_scanner",
+}
+# Parameter-level: reproducible only when the tested parameter is recovered from
+# ``request_payload`` (a clean ``param=value``). SSTI/XSS store a raw payload or
+# put the param in the title, so param recovery fails and they fall through to
+# UNVERIFIABLE rather than a false FIXED.
+_PARAM_REVERIFIABLE = {
+    "active_injection_scanner",
+}
+# A recovered token only counts as a real parameter name if it looks like one
+# (not a raw ``' OR 1=1`` / XML / canary payload).
+_PARAM_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_.\[\]-]{0,39}$")
+
+
+class VerifyStatus(StrEnum):
+    FIXED = "fixed"
+    STILL_PRESENT = "still_present"
+    UNVERIFIABLE = "unverifiable"
+    ERROR = "error"
+
+
+@dataclass
+class Verdict:
+    finding: DeepFinding
+    status: VerifyStatus
+    detail: str = ""
+
+
+def _is_sast(f: DeepFinding) -> bool:
+    return bool(
+        f.code_location and f.code_location.file_path
+        and f.scanner_name not in LLM_SCANNERS
+    )
+
+
+def _is_dast(f: DeepFinding) -> bool:
+    return bool(f.endpoint_url and f.scanner_name not in LLM_SCANNERS)
+
+
+def _param_names_from_payload(payload: str | None) -> list[str]:
+    """Best-effort recover the tested parameter name(s) from a finding's
+    ``request_payload`` (``param=value`` for query/body, or a JSON object).
+
+    Only tokens that actually look like parameter names are returned — a raw
+    injection payload (``' OR 1=1``, XML, an XSS canary) yields ``[]`` so the
+    caller can treat it as unrecoverable rather than fabricate a bogus param.
+    """
+    if not payload:
+        return []
+    text = payload.strip()
+    if text.startswith("{"):
+        try:
+            obj = json.loads(text)
+        except (json.JSONDecodeError, ValueError):
+            return []
+        candidates = [str(k) for k in obj] if isinstance(obj, dict) else []
+    else:
+        candidates = [text.split("=", 1)[0].strip()]
+    return [c for c in candidates if _PARAM_NAME_RE.match(c)]
+
+
+def _endpoint_for(finding: DeepFinding, target_url: str, params: list[str]):
+    """Reconstruct a DiscoveredEndpoint pointing at ``target_url`` with the
+    finding's path/query (and the recovered tested params), so the scanner
+    re-probes the same place in the app."""
+    from isitsecure.engine.enums import EndpointMethod
+    from isitsecure.engine.models import DiscoveredEndpoint
+
+    orig = urlparse(finding.endpoint_url or "")
+    base = urlparse(target_url)
+    url = f"{base.scheme}://{base.netloc}{orig.path or '/'}"
+    if orig.query:
+        url += f"?{orig.query}"
+    method_str = (finding.http_method or "GET").upper()
+    try:
+        method = EndpointMethod(method_str)
+    except ValueError:
+        method = EndpointMethod.GET
+    return DiscoveredEndpoint(url=url, method=method, query_param_names=params)
+
+
+async def _sast_present_fingerprints(repo_path: str) -> set[str]:
+    """Fingerprints still raised by a code-only re-scan of ``repo_path``."""
+    from isitsecure.engine.fixes.verifier import _rescan_sast_findings
+    rescan = await _rescan_sast_findings(repo_path)
+    return {d["fingerprint"] for d in rescan if d.get("fingerprint")}
+
+
+def _dast_scanners_by_name() -> dict:
+    """Map scanner_name -> a standalone DAST scanner instance (deep depth so the
+    full scanner set is available). No LLM — re-verification is deterministic."""
+    from isitsecure.engine.enums import ScanDepth
+    from isitsecure.engine.factory import create_deep_security_scan_agent
+    agent = create_deep_security_scan_agent(depth=ScanDepth.DEEP)
+    return {s.scanner_name: s for s in agent._dast_scanners}
+
+
+async def _reverify_dast(finding: DeepFinding, target_url: str, scanners: dict) -> Verdict:
+    name = finding.scanner_name
+    scanner = scanners.get(name)
+    # Only re-probe when a single-endpoint re-run can FAITHFULLY reproduce the
+    # finding — otherwise a non-reproduction is not evidence of a fix.
+    if scanner is None or name not in _ENDPOINT_REVERIFIABLE | _PARAM_REVERIFIABLE:
+        return Verdict(finding, VerifyStatus.UNVERIFIABLE,
+                       "can't be reproduced by a single-endpoint re-probe — re-verify manually")
+    params = _param_names_from_payload(finding.request_payload)
+    if name in _PARAM_REVERIFIABLE and not params:
+        return Verdict(finding, VerifyStatus.UNVERIFIABLE,
+                       "couldn't recover the tested parameter — re-verify manually")
+    try:
+        endpoint = _endpoint_for(finding, target_url, params)
+        results = await scanner.scan([endpoint], snapshot=None)
+    except Exception as exc:  # noqa: BLE001 — a probe failure is a verdict, not a crash
+        logger.warning("Re-verify probe failed for %s: %s", finding.fingerprint, exc)
+        return Verdict(finding, VerifyStatus.ERROR, str(exc))
+    target_fp = finding_fingerprint(finding)
+    if any(finding_fingerprint(r) == target_fp for r in results):
+        return Verdict(finding, VerifyStatus.STILL_PRESENT)
+    return Verdict(finding, VerifyStatus.FIXED)
+
+
+async def reverify_findings(
+    findings: list[DeepFinding],
+    *,
+    target_url: str | None = None,
+    repo_path: str | None = None,
+) -> list[Verdict]:
+    """Re-check each finding and return a verdict, preserving input order."""
+    sast = [f for f in findings if _is_sast(f)]
+    dast = [f for f in findings if not _is_sast(f) and _is_dast(f)]
+
+    verdict_by_id: dict[str, Verdict] = {}
+
+    # SAST — one shared re-scan for all of them.
+    if sast:
+        if not repo_path:
+            for f in sast:
+                verdict_by_id[f.id] = Verdict(
+                    f, VerifyStatus.UNVERIFIABLE, "no repo path given (--repo)"
+                )
+        else:
+            try:
+                present = await _sast_present_fingerprints(repo_path)
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("SAST re-verify re-scan failed: %s", exc)
+                for f in sast:
+                    verdict_by_id[f.id] = Verdict(f, VerifyStatus.ERROR, str(exc))
+            else:
+                for f in sast:
+                    status = (VerifyStatus.STILL_PRESENT
+                              if finding_fingerprint(f) in present else VerifyStatus.FIXED)
+                    verdict_by_id[f.id] = Verdict(f, status)
+
+    # DAST — re-probe each finding's endpoint.
+    if dast:
+        if not target_url:
+            for f in dast:
+                verdict_by_id[f.id] = Verdict(f, VerifyStatus.UNVERIFIABLE, "no target URL given")
+        else:
+            scanners = _dast_scanners_by_name()
+            for f in dast:
+                verdict_by_id[f.id] = await _reverify_dast(f, target_url, scanners)
+
+    verdicts: list[Verdict] = []
+    for f in findings:
+        verdicts.append(
+            verdict_by_id.get(f.id)
+            or Verdict(f, VerifyStatus.UNVERIFIABLE,
+                       "LLM-review or non-locatable finding — cannot re-check deterministically")
+        )
+    return verdicts

--- a/tests/engine/test_reverify.py
+++ b/tests/engine/test_reverify.py
@@ -1,0 +1,165 @@
+"""Tests for per-finding re-verification (#53)."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from isitsecure.engine import reverify as R
+from isitsecure.engine.enums import EndpointMethod, FindingCategory, SeverityLevel
+from isitsecure.engine.models import CodeLocation, DeepFinding, FindingSource
+
+
+def _dast(url="http://x/login", method="GET", payload="q='",
+          scanner="active_injection_scanner", title="SQL injection vulnerability (error-based)"):
+    return DeepFinding(
+        source=FindingSource.DAST_URL, category=FindingCategory.INJECTION_RISK,
+        severity=SeverityLevel.CRITICAL, title=title, description="d", confidence=0.9,
+        scanner_name=scanner, endpoint_url=url, http_method=method, request_payload=payload,
+    )
+
+
+def _sast(file_path="app/db.py", scanner="semgrep_taint", title="SQLi"):
+    return DeepFinding(
+        source=FindingSource.SAST_CODE, category=FindingCategory.INJECTION_RISK,
+        severity=SeverityLevel.HIGH, title=title, description="d", confidence=0.9,
+        scanner_name=scanner, code_location=CodeLocation(file_path=file_path, line_number=10),
+    )
+
+
+def _llm():
+    return DeepFinding(
+        source=FindingSource.SAST_CODE, category=FindingCategory.BUSINESS_LOGIC,
+        severity=SeverityLevel.HIGH, title="Logic flaw", description="d", confidence=0.7,
+        scanner_name="llm_code_reviewer", code_location=CodeLocation(file_path="a.py"),
+    )
+
+
+class TestHelpers:
+    def test_param_names_from_form_payload(self):
+        assert R._param_names_from_payload("username=' OR 1=1") == ["username"]
+
+    def test_param_names_from_json_payload(self):
+        assert R._param_names_from_payload('{"user": "x", "pw": "y"}') == ["user", "pw"]
+
+    def test_param_names_from_empty_or_bad(self):
+        assert R._param_names_from_payload(None) == []
+        assert R._param_names_from_payload("{not json") == []
+
+    def test_endpoint_rebased_onto_target(self):
+        ep = R._endpoint_for(_dast(url="http://old:9999/login?x=1"),
+                             "https://prod.example.com", ["q"])
+        assert ep.url == "https://prod.example.com/login?x=1"
+        assert ep.method == EndpointMethod.GET
+        assert ep.query_param_names == ["q"]
+
+    def test_param_recovery_rejects_raw_injection_payload(self):
+        # A raw injection value is NOT a parameter name.
+        assert R._param_names_from_payload("' OR 1=1") == []
+        assert R._param_names_from_payload("<canary_xss_abc>") == []
+        assert R._param_names_from_payload("<?xml version='1.0'?>") == []
+
+
+class TestDASTReverify:
+    @pytest.mark.asyncio
+    async def test_still_present_when_scanner_reraises(self):
+        f = _dast()
+        scanner = type("S", (), {
+            "scanner_name": "active_injection_scanner",
+            "scan": AsyncMock(return_value=[_dast(url="http://prod/login")]),  # same fp
+        })()
+        v = await R._reverify_dast(f, "http://prod", {"active_injection_scanner": scanner})
+        assert v.status == R.VerifyStatus.STILL_PRESENT
+
+    @pytest.mark.asyncio
+    async def test_fixed_when_scanner_finds_nothing(self):
+        f = _dast()
+        scanner = type("S", (), {"scanner_name": "active_injection_scanner",
+                                 "scan": AsyncMock(return_value=[])})()
+        v = await R._reverify_dast(f, "http://prod", {"active_injection_scanner": scanner})
+        assert v.status == R.VerifyStatus.FIXED
+
+    @pytest.mark.asyncio
+    async def test_scanner_error_is_a_verdict_not_a_crash(self):
+        f = _dast()
+        scanner = type("S", (), {"scanner_name": "active_injection_scanner",
+                                 "scan": AsyncMock(side_effect=RuntimeError("boom"))})()
+        v = await R._reverify_dast(f, "http://prod", {"active_injection_scanner": scanner})
+        assert v.status == R.VerifyStatus.ERROR
+
+    @pytest.mark.asyncio
+    async def test_unknown_scanner_is_unverifiable(self):
+        f = _dast(scanner="idor_scanner")
+        v = await R._reverify_dast(f, "http://prod", {})
+        assert v.status == R.VerifyStatus.UNVERIFIABLE
+
+    @pytest.mark.asyncio
+    async def test_lossy_param_recovery_is_unverifiable_not_false_fixed(self):
+        """SSTI-style: a param-level scanner whose payload doesn't encode the
+        param must NOT be reported FIXED just because a lossy re-probe found
+        nothing — it's UNVERIFIABLE. (The core safety property.)"""
+        f = _dast(scanner="active_injection_scanner", payload=None)  # no param
+        scanner = type("S", (), {"scanner_name": "active_injection_scanner",
+                                 "scan": AsyncMock(return_value=[])})()
+        v = await R._reverify_dast(f, "http://prod", {"active_injection_scanner": scanner})
+        assert v.status == R.VerifyStatus.UNVERIFIABLE
+        scanner.scan.assert_not_called()  # never even ran a lossy probe
+
+    @pytest.mark.asyncio
+    async def test_xss_finding_is_unverifiable_not_false_fixed(self):
+        """XSS (raw canary / multi-request stored flow) is not single-endpoint
+        reproducible → UNVERIFIABLE, never a false FIXED."""
+        f = _dast(scanner="xss_scanner", payload="<canary>", title="Reflected XSS")
+        scanner = type("S", (), {"scanner_name": "xss_scanner",
+                                 "scan": AsyncMock(return_value=[])})()
+        v = await R._reverify_dast(f, "http://prod", {"xss_scanner": scanner})
+        assert v.status == R.VerifyStatus.UNVERIFIABLE
+        scanner.scan.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_endpoint_level_scanner_needs_no_param(self):
+        """An endpoint-level finding (e.g. missing security headers) is
+        reproducible from URL+method alone — no param required."""
+        f = _dast(scanner="security_headers_scanner", payload=None,
+                  title="Missing security headers")
+        scanner = type("S", (), {"scanner_name": "security_headers_scanner",
+                                 "scan": AsyncMock(return_value=[f])})()
+        v = await R._reverify_dast(f, "http://prod", {"security_headers_scanner": scanner})
+        assert v.status == R.VerifyStatus.STILL_PRESENT
+
+
+class TestReverifyFindings:
+    @pytest.mark.asyncio
+    async def test_llm_finding_is_unverifiable(self):
+        (v,) = await R.reverify_findings([_llm()], target_url="http://x", repo_path="repo")
+        assert v.status == R.VerifyStatus.UNVERIFIABLE
+
+    @pytest.mark.asyncio
+    async def test_dast_without_target_is_unverifiable(self):
+        (v,) = await R.reverify_findings([_dast()], target_url=None)
+        assert v.status == R.VerifyStatus.UNVERIFIABLE
+
+    @pytest.mark.asyncio
+    async def test_sast_without_repo_is_unverifiable(self):
+        (v,) = await R.reverify_findings([_sast()], repo_path=None)
+        assert v.status == R.VerifyStatus.UNVERIFIABLE
+
+    @pytest.mark.asyncio
+    async def test_sast_fixed_and_still_present(self, monkeypatch):
+        present, gone = _sast(file_path="present.py"), _sast(file_path="gone.py")
+
+        async def fake_present(_repo):
+            return {present.fingerprint}  # only 'present' still detected
+        monkeypatch.setattr(R, "_sast_present_fingerprints", fake_present)
+
+        verdicts = await R.reverify_findings([present, gone], repo_path="repo")
+        by_fp = {v.finding.fingerprint: v.status for v in verdicts}
+        assert by_fp[present.fingerprint] == R.VerifyStatus.STILL_PRESENT
+        assert by_fp[gone.fingerprint] == R.VerifyStatus.FIXED
+
+    @pytest.mark.asyncio
+    async def test_preserves_input_order(self):
+        a, b, c = _dast(url="http://x/a"), _llm(), _dast(url="http://x/c")
+        verdicts = await R.reverify_findings([a, b, c])  # no target → all unverifiable
+        assert [v.finding.id for v in verdicts] == [a.id, b.id, c.id]

--- a/tests/test_cli_verify.py
+++ b/tests/test_cli_verify.py
@@ -1,0 +1,100 @@
+"""CLI-level tests for the `verify` command (#53)."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+import typer
+
+from isitsecure import cli
+from isitsecure.engine import reverify as R
+from isitsecure.engine.enums import FindingCategory, SeverityLevel
+from isitsecure.engine.models import DeepFinding, DeepScanReport, FindingSource
+
+
+def _dast(url, title="SQL injection vulnerability (error-based)"):
+    return DeepFinding(
+        source=FindingSource.DAST_URL, category=FindingCategory.INJECTION_RISK,
+        severity=SeverityLevel.CRITICAL, title=title, description="d", confidence=0.9,
+        scanner_name="active_injection_scanner", endpoint_url=url, http_method="GET",
+        request_payload="q='",
+    )
+
+
+def _write_report(tmp_path, findings):
+    report = DeepScanReport(target_url="http://app", findings=findings)
+    p = tmp_path / "before.json"
+    p.write_text(report.model_dump_json())
+    return p
+
+
+def _run_verify(monkeypatch, report_path, verdicts, **kw):
+    async def fake(findings, *, target_url=None, repo_path=None):
+        return verdicts(findings)
+    monkeypatch.setattr(R, "reverify_findings", fake)
+    opts = dict(target_url="http://app", report=str(report_path),
+                fingerprint=None, repo=None, output="json")
+    opts.update(kw)
+    with pytest.raises(typer.Exit) as exc:
+        cli.verify(**opts)
+    return exc.value.exit_code
+
+
+def test_exit_zero_when_all_fixed(tmp_path, monkeypatch, capsys):
+    f = _dast("http://app/login")
+    p = _write_report(tmp_path, [f])
+    code = _run_verify(monkeypatch, p,
+                       lambda fs: [R.Verdict(fs[0], R.VerifyStatus.FIXED)])
+    assert code == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["fixed"] == 1 and out["still_present"] == 0
+
+
+def test_exit_one_when_any_still_present(tmp_path, monkeypatch):
+    f = _dast("http://app/login")
+    p = _write_report(tmp_path, [f])
+    code = _run_verify(monkeypatch, p,
+                       lambda fs: [R.Verdict(fs[0], R.VerifyStatus.STILL_PRESENT)])
+    assert code == 1
+
+
+def test_fingerprint_filter_selects_subset(tmp_path, monkeypatch):
+    a, b = _dast("http://app/a"), _dast("http://app/b")
+    p = _write_report(tmp_path, [a, b])
+    captured = {}
+
+    async def fake(findings, *, target_url=None, repo_path=None):
+        captured["ids"] = [f.endpoint_url for f in findings]
+        return [R.Verdict(f, R.VerifyStatus.FIXED) for f in findings]
+    monkeypatch.setattr(R, "reverify_findings", fake)
+    with pytest.raises(typer.Exit):
+        cli.verify(target_url="http://app", report=str(p),
+                   fingerprint=[a.fingerprint], repo=None, output="json")
+    assert captured["ids"] == ["http://app/a"]  # only the requested finding verified
+
+
+def test_missing_report_exits_two(tmp_path):
+    with pytest.raises(typer.Exit) as exc:
+        cli.verify(target_url="http://app", report=str(tmp_path / "nope.json"),
+                   fingerprint=None, repo=None, output="json")
+    assert exc.value.exit_code == 2
+
+
+def test_unknown_fingerprint_exits_two(tmp_path, monkeypatch):
+    # A typo'd fingerprint must NOT read as a green gate (inconclusive → exit 2).
+    p = _write_report(tmp_path, [_dast("http://app/a")])
+    monkeypatch.setattr(R, "reverify_findings", None)  # must not be called
+    with pytest.raises(typer.Exit) as exc:
+        cli.verify(target_url="http://app", report=str(p),
+                   fingerprint=["deadbeefdeadbeef"], repo=None, output="json")
+    assert exc.value.exit_code == 2
+
+
+def test_unverifiable_exits_two_not_green(tmp_path, monkeypatch):
+    # If nothing could be definitively verified, the gate must not pass.
+    f = _dast("http://app/login")
+    p = _write_report(tmp_path, [f])
+    code = _run_verify(monkeypatch, p,
+                       lambda fs: [R.Verdict(fs[0], R.VerifyStatus.UNVERIFIABLE)])
+    assert code == 2


### PR DESCRIPTION
Closes #53 — and completes the Trust & false-positive epic (#38): suppression (#51), baseline (#52), re-verify (#53).

## What

A new `isitsecure verify` command re-checks *specific* findings from a previous scan and reports **fixed / still-present / unverifiable** — without re-scanning everything.

```bash
isitsecure scan https://your-app.com --output json -f before.json
# ...apply your fix...
isitsecure verify https://your-app.com --report before.json --fingerprint de0e57aeb5f61708
```

- **SAST** findings: one code-only re-scan of `--repo`; fixed when the fingerprint no longer appears.
- **DAST** findings: reconstruct the endpoint against the target and re-run the scanner that raised it; fixed when the same fingerprint no longer fires.
- Omit `--fingerprint` to re-verify the whole report. Exit codes make it a CI gate: **0** all-fixed · **1** still-present · **2** inconclusive.

## Safety: never a false "fixed"

A re-verify tool must never falsely claim a fix. A single-endpoint re-probe can only faithfully reproduce a finding that doesn't depend on crawl-derived state (stored / multi-request flows) or a tested parameter we can't recover. So `fixed`/`still-present` is claimed **only** for a conservative allowlist:

- **Endpoint-level** (`security_headers`, `cors`, `source_map`, `http_probe`, `csrf`) — reproducible from URL + method alone.
- **Param-level** (`active_injection`) — only when the tested parameter is cleanly recoverable (validated against a param-name regex, so raw payloads / canaries / XML are rejected).
- **Everything else** → `unverifiable`; unknown fingerprints and probe errors → exit 2.

## Verification

- Unit: 23 tests across the two new files, incl. safety tests asserting SSTI-no-payload, XSS, and lossy param recovery degrade to `unverifiable` rather than false-FIXED. **Full suite: 2161 passed, 1 xfailed.**
- Benchmark: byte-identical to baseline (juiceshop 20/45, vampi-vuln 3/3, vampi-secure 2 IDOR FPs) — verify is a separate command; the scan path is untouched.
- Docs: README "Re-verifying a fix" + CLI reference; architecture module tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)