### PR TITLE
fix(lsp): give the TypeScript language server a runtime so repo scans initialize (#145)

### DIFF
--- a/README.md
+++ b/README.md
@@ -731,6 +731,8 @@ isitsecure setup --check    # report what's installed (API key, DAST browser, LS
 
 `setup --lsp` installs what it can cleanly (Python via pip always; TypeScript via npm if Node is present; Java via Homebrew if available) and prints guidance for anything it can't. It's also offered as a step in the full `isitsecure setup`. This is optional — scans still work without it using regex-based detection. For manual setup and per-language detail, see [docs/lsp-setup.md](docs/lsp-setup.md).
 
+For TypeScript it also provisions a private TypeScript 5.x runtime under `~/.isitsecure/lsp` — `typescript-language-server` carries none of its own and won't start without one, and a scan runs against a copy of your project with `node_modules` stripped, so it can't borrow yours. Your global `typescript` is never installed or changed. To use a specific one instead, set `ISITSECURE_TSSERVER_PATH` to its `lib/tsserver.js`. `isitsecure setup --check` prints the runtime a scan will use.
+
 ## Contributing
 
 isitsecure is built on protocols and the strategy pattern. Adding a new scanner is straightforward:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -107,7 +107,11 @@ The repository is cloned (shallow, to temp dir) and indexed:
 
 ### Phase 7.5: LSP Validation
 
-If TypeScript and Node.js are available, the **TypeScript Language Server** is used to trace auth flows:
+If TypeScript and Node.js are available, the **TypeScript Language Server** is used to trace auth flows.
+
+The server carries no TypeScript of its own and resolves one from the workspace — but ingestion strips `node_modules`, so there is never one there. Phase 6.5 therefore locates a TypeScript 5.x `tsserver.js` (`lsp/tsserver_locator.py`: `$ISITSECURE_TSSERVER_PATH` → the scanned project → `~/.isitsecure/lsp` → the global npm root) and passes it as `tsserver.path` in the handshake. Without it the server refuses to start and this phase is skipped entirely.
+
+
 
 ```
 Route file: app/api/tasks/[id]/route.ts
@@ -274,6 +278,7 @@ The scanner works at any completeness level:
 | No LLM API key | Rule-based scanners only. No business logic review, no semantic verification, no triage enrichment |
 | No Playwright | URL ingestion falls back to httpx. No authenticated crawl, no DOM XSS |
 | No TypeScript/Node.js | LSP validation skipped. Auth flow tracing unavailable, more false positives |
+| No TypeScript 5.x runtime | Same — `typescript-language-server` won't start without a `tsserver.js`. `isitsecure setup --lsp` provisions one; see [lsp-setup.md](lsp-setup.md) |
 | No repo URL | SAST skipped entirely. DAST-only scan |
 | No target URL | SAST-only scan against code |
 | No credentials | Authenticated scanners skipped. No IDOR cross-user, no privilege escalation |

--- a/docs/lsp-setup.md
+++ b/docs/lsp-setup.md
@@ -24,7 +24,7 @@ Route file: app/api/tasks/[id]/route.ts
 
 | Language | LSP Server | Install Command | Auth Tracing |
 |---|---|---|---|
-| **TypeScript/JavaScript** | typescript-language-server | `npm install -g typescript-language-server typescript` | Full trace via go-to-definition |
+| **TypeScript/JavaScript** | typescript-language-server | `isitsecure setup --lsp` (server + a private TypeScript 5.x runtime) | Full trace via go-to-definition |
 | **Python** | pylsp or pyright | `pip install python-lsp-server` or `pip install pyright` | Traces Depends(), decorators |
 | **Java/Kotlin** | jdtls | See [jdtls install guide](https://github.com/eclipse-jdtls/eclipse.jdt.ls#installation) | Traces @PreAuthorize, SecurityConfig |
 
@@ -51,22 +51,61 @@ sudo apt-get install -y nodejs
 2. **TypeScript Language Server** — the actual LSP server
 
 ```bash
-# Option A: Install globally (recommended)
-npm install -g typescript-language-server typescript
+# Recommended: installs the server AND the TypeScript runtime it needs
+isitsecure setup --lsp
 
-# Option B: npx (no install needed, slower startup)
-# isitsecure will automatically use npx if typescript-language-server is not found
+# Manual equivalent
+npm install -g typescript-language-server
+npm install --prefix ~/.isitsecure/lsp typescript@5
+```
+
+`npx` also works as a fallback — isitsecure uses it automatically when
+`typescript-language-server` isn't on PATH — but it's slower to start.
+
+3. **A TypeScript 5.x runtime** — the `tsserver.js` the server actually runs
+
+This is a separate requirement, and the one that most often bites:
+
+- `typescript-language-server` ships **no TypeScript of its own**. It resolves
+  `typescript` from the *workspace* and refuses to start when it can't find
+  one (`Could not find a valid TypeScript installation…`).
+- isitsecure scans a **copy** of your project with `node_modules` stripped, so
+  the workspace never has one — meaning a scan can't rely on your project's
+  install even when your editor can.
+- It must be TypeScript **5.x**. `typescript@latest` is now 7.x — the
+  Go-native rewrite — which ships no `lib/tsserver.js` at all and cannot drive
+  the language server.
+
+So `isitsecure setup --lsp` provisions a private TypeScript 5.x under
+`~/.isitsecure/lsp` and passes it to the server as `tsserver.path`. It never
+installs or changes a global `typescript`, so your projects keep whatever
+version they use.
+
+### Where isitsecure looks for the runtime
+
+First match wins:
+
+1. `$ISITSECURE_TSSERVER_PATH` — an explicit path to a `tsserver.js`
+2. The scanned project, then its immediate subdirectories (monorepo packages)
+3. `~/.isitsecure/lsp/node_modules/typescript/lib/tsserver.js` (provisioned)
+4. Next to the `typescript-language-server` binary (a global install that also
+   has a global `typescript` 5.x)
+5. `npm root -g` — the global node_modules root
+
+To pin a specific TypeScript:
+
+```bash
+export ISITSECURE_TSSERVER_PATH=/path/to/node_modules/typescript/lib/tsserver.js
 ```
 
 ### Verification
 
 ```bash
-# Check if everything is set up
-typescript-language-server --version
-# Should output a version number
+# Reports the server AND the TypeScript runtime it will use
+isitsecure setup --check
 
-# Or check via npx
-npx typescript-language-server --version
+# Or check the server by hand
+typescript-language-server --version
 ```
 
 ### How isitsecure Detects LSP
@@ -127,8 +166,24 @@ LSP adds ~2-5 seconds to the scan for initialization and ~0.5s per route traced.
 **"LSP DISABLED: Node.js found but typescript-language-server is not installed"**
 
 ```bash
-npm install -g typescript-language-server typescript
+isitsecure setup --lsp
 ```
+
+**"LSP initialize failed: … Could not find a valid TypeScript installation"**
+
+The language server is installed and healthy, but has no TypeScript 5.x
+`tsserver.js` to run. Install one:
+
+```bash
+isitsecure setup --lsp
+```
+
+Confirm with `isitsecure setup --check`, which prints the exact `tsserver.js`
+that scans will use. If you keep your own TypeScript somewhere unusual, point
+at it with `ISITSECURE_TSSERVER_PATH` instead.
+
+Note that a global `npm install -g typescript` no longer helps on its own:
+that installs 7.x, which has no `lib/tsserver.js`.
 
 **"LSP initialization timed out"**
 
@@ -242,6 +297,7 @@ public SecurityFilterChain filterChain(HttpSecurity http) {
 isitsecure tries LSP servers in this order:
 
 1. **TypeScript** — if `typescript-language-server` or `npx` is available
+   (it also needs a TypeScript 5.x runtime to start — see above)
 2. **Python** — if `pylsp` or `pyright-langserver` is available
 3. **Java** — if `java` runtime + `jdtls` is available
 4. **NoOp** — fallback, regex-only analysis

--- a/isitsecure/cli.py
+++ b/isitsecure/cli.py
@@ -1422,7 +1422,11 @@ _LSP_SPECS = [
         "bins": ("typescript-language-server",),
         "runtime": ("node",),
         "needs": "npm",
-        "cmd": ["npm", "install", "-g", "typescript-language-server", "typescript"],
+        # No `typescript` here on purpose: `typescript@latest` is now 7.x (the
+        # Go rewrite), which ships no lib/tsserver.js and can't drive the
+        # language server. `_ensure_tsserver_runtime` provisions a private 5.x
+        # runtime instead of touching the user's global install (issue #145).
+        "cmd": ["npm", "install", "-g", "typescript-language-server"],
         "hint": {
             "macos": "install Node.js (`brew install node`), then re-run `isitsecure setup --lsp`",
             "windows": "install Node.js (`winget install OpenJS.NodeJS` or nodejs.org), then re-run `isitsecure setup --lsp`",
@@ -1578,6 +1582,21 @@ def _preflight_checks(
                 "flag more false alarms.[/dim]\n"
                 "    [bold]Fix:[/bold] isitsecure setup --lsp"
             )
+        elif shutil.which("typescript-language-server"):
+            # The server being installed isn't enough: it needs a TypeScript
+            # 5.x runtime to start at all, and scans never provide one from
+            # the scanned tree itself (issue #145).
+            from isitsecure.engine.code_analysis.lsp.tsserver_locator import (
+                find_tsserver_js,
+            )
+            if not find_tsserver_js():
+                warnings.append(
+                    "The TypeScript language server has no TypeScript runtime "
+                    "to run, so it can't start.\n"
+                    "    [dim]→ Auth-flow tracing is skipped; code scanning "
+                    "falls back to regex-only analysis.[/dim]\n"
+                    "    [bold]Fix:[/bold] isitsecure setup --lsp"
+                )
 
     # (c) LLM API key — only if the user asked for an LLM provider.
     if llm_provider != "none" and not has_api_key:
@@ -1624,6 +1643,19 @@ def _print_status_report() -> None:
                           f"[dim]{', '.join(missing_rt)}[/dim] not on PATH to run it")
         else:
             console.print(f"  [yellow]•[/yellow] {spec['lang']}: [dim]not installed[/dim]")
+
+    if _first_which(("typescript-language-server",)):
+        from isitsecure.engine.code_analysis.lsp.tsserver_locator import (
+            find_tsserver_js,
+        )
+        tsserver = find_tsserver_js()
+        if tsserver:
+            console.print("  [green]✓[/green] TypeScript runtime (tsserver.js): "
+                          f"[dim]{tsserver}[/dim]")
+        else:
+            console.print("  [yellow]•[/yellow] TypeScript runtime (tsserver.js): "
+                          "[dim]missing — the TS language server can't start; "
+                          "run `isitsecure setup --lsp`[/dim]")
     console.print("\n[dim]Install missing language servers with:[/dim] isitsecure setup --lsp")
 
 
@@ -1661,6 +1693,66 @@ def _setup_lsps() -> None:
         missing_rt = [r for r in spec["runtime"] if not shutil.which(r)]
         if missing_rt:
             console.print(f"      [dim](also needs {', '.join(missing_rt)} on PATH to run)[/dim]")
+
+    _ensure_tsserver_runtime()
+
+
+def _ensure_tsserver_runtime() -> None:
+    """Make sure the TypeScript language server has a TypeScript to run.
+
+    typescript-language-server ships no TypeScript of its own and resolves it
+    from the workspace — but scans run against an ingested copy with no
+    ``node_modules``, so there is never one to find and the server refuses to
+    start. We install a private TypeScript 5.x under ``~/.isitsecure/lsp`` and
+    pass it as ``tsserver.path``; 5.x specifically, because ``typescript@latest``
+    is now the Go rewrite with no ``lib/tsserver.js`` (issue #145).
+    """
+    import shutil
+    import subprocess
+
+    from isitsecure.engine.code_analysis.lsp.tsserver_locator import (
+        PROVISIONED_ROOT,
+        TYPESCRIPT_PACKAGE_SPEC,
+        find_tsserver_js,
+    )
+
+    if not _first_which(("typescript-language-server",)):
+        return  # nothing to feed — the server itself isn't installed
+
+    found = find_tsserver_js()
+    if found:
+        console.print(f"  [green]✓[/green] TypeScript runtime: [dim]{found}[/dim]")
+        return
+
+    if not shutil.which("npm"):
+        console.print("  [yellow]![/yellow] TypeScript runtime: [dim]npm not on PATH — "
+                      f"install {TYPESCRIPT_PACKAGE_SPEC} and set "
+                      "ISITSECURE_TSSERVER_PATH to its lib/tsserver.js[/dim]")
+        return
+
+    console.print(f"  [cyan]→[/cyan] TypeScript runtime: installing {TYPESCRIPT_PACKAGE_SPEC}…")
+    try:
+        PROVISIONED_ROOT.mkdir(parents=True, exist_ok=True)
+        res = subprocess.run(
+            _resolve_install_cmd([
+                "npm", "install", "--prefix", str(PROVISIONED_ROOT),
+                TYPESCRIPT_PACKAGE_SPEC, "--no-audit", "--no-fund",
+            ]),
+            capture_output=True, text=True, timeout=600,
+        )
+    except Exception as exc:
+        console.print(f"  [red]✗[/red] TypeScript runtime: {exc}")
+        return
+
+    found = find_tsserver_js()
+    if res.returncode == 0 and found:
+        console.print("  [green]✓[/green] TypeScript runtime: installed "
+                      f"[dim]({found})[/dim]")
+    else:
+        tail = (res.stderr or res.stdout or "install did not complete").strip().splitlines()
+        console.print("  [yellow]![/yellow] TypeScript runtime: "
+                      f"{(tail[-1] if tail else '')[:120]}")
+        console.print("      [dim]Auth-flow tracing will fall back to regex-only analysis.[/dim]")
 
 
 def _lsp_offer() -> None:

--- a/isitsecure/engine/agent.py
+++ b/isitsecure/engine/agent.py
@@ -692,10 +692,17 @@ class DeepSecurityScanAgent:
                             )
                         )
                     else:
+                        # The client logs the server's own words; repeat the
+                        # cause here so one line explains the fallback (#145).
+                        reason = (
+                            self._lsp_client.last_error
+                            or "the language server did not initialize"
+                        )
                         logger.warning(
-                            "LSP initialization returned False — "
-                            "typescript-language-server may not be installed. "
-                            "Falling back to regex-only analysis."
+                            "LSP initialization failed (%s) — falling back to "
+                            "regex-only analysis. Run `isitsecure setup --lsp` "
+                            "to check the language-server setup.",
+                            reason,
                         )
                 except asyncio.TimeoutError:
                     logger.warning(

--- a/isitsecure/engine/code_analysis/lsp/base_client.py
+++ b/isitsecure/engine/code_analysis/lsp/base_client.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from typing import Any
 
 from isitsecure.engine.code_analysis.lsp.protocols import LSPLocation
+from isitsecure.engine.code_analysis.lsp.rpc_errors import format_rpc_error
 from isitsecure.engine.constants import LSPConfig
 
 logger = logging.getLogger(__name__)
@@ -43,14 +44,25 @@ class BaseLSPClient:
         self._project_path: str = ""
         self._lock = asyncio.Lock()
         self._opened_files: set[str] = set()
+        self._last_error: str | None = None
 
     @property
     def is_available(self) -> bool:
         return self._initialized and self._process is not None
 
+    @property
+    def last_error(self) -> str | None:
+        """The most recent server-reported failure, for diagnostics.
+
+        A language server explains its own refusals better than we can guess
+        at them, so callers surface this rather than speculating (issue #145).
+        """
+        return self._last_error
+
     async def initialize(self, project_path: str) -> bool:
         """Spawn LSP server and initialize the session."""
         self._project_path = project_path
+        self._last_error = None
 
         try:
             self._pre_initialize(project_path)
@@ -98,6 +110,10 @@ class BaseLSPClient:
             )
 
             if result is None:
+                logger.warning(
+                    "LSP initialize failed: %s",
+                    self._last_error or "no response from the server",
+                )
                 await self.shutdown()
                 return False
 
@@ -242,10 +258,16 @@ class BaseLSPClient:
                 body = await self._process.stdout.readexactly(content_length)
                 data = json.loads(body.decode())
                 req_id = data.get("id")
+                rpc_error = format_rpc_error(data)
+                if rpc_error:
+                    # Keep the server's own explanation — dropping it is what
+                    # made #145 look like a missing install.
+                    self._last_error = rpc_error
+                    logger.debug("LSP request returned an error: %s", rpc_error)
                 if req_id is not None and req_id in self._pending:
                     future = self._pending[req_id]
                     if not future.done():
-                        future.set_result(data.get("result") if "error" not in data else None)
+                        future.set_result(None if rpc_error else data.get("result"))
         except (asyncio.CancelledError, asyncio.IncompleteReadError):
             pass
         except Exception as e:

--- a/isitsecure/engine/code_analysis/lsp/noop_client.py
+++ b/isitsecure/engine/code_analysis/lsp/noop_client.py
@@ -29,6 +29,11 @@ class NoOpLSPClient:
     def is_available(self) -> bool:
         return False
 
+    @property
+    def last_error(self) -> str | None:
+        # Nothing was ever attempted, so there is nothing to explain.
+        return None
+
     async def initialize(self, project_path: str) -> bool:
         return False
 

--- a/isitsecure/engine/code_analysis/lsp/protocols.py
+++ b/isitsecure/engine/code_analysis/lsp/protocols.py
@@ -67,6 +67,15 @@ class LSPClientProtocol(Protocol):
         """Whether the LSP server is available and initialized."""
         ...
 
+    @property
+    def last_error(self) -> str | None:
+        """The most recent server-reported failure, or None.
+
+        Lets callers report *why* LSP is unavailable in the server's own
+        words instead of guessing at a cause (issue #145).
+        """
+        ...
+
     async def initialize(self, project_path: str) -> bool:
         """Initialize the LSP server for a project.
 

--- a/isitsecure/engine/code_analysis/lsp/rpc_errors.py
+++ b/isitsecure/engine/code_analysis/lsp/rpc_errors.py
@@ -1,0 +1,38 @@
+"""Formatting for JSON-RPC error responses from language servers.
+
+DRY: every LSP client reads the same wire format, so the one place that turns
+an ``{"error": {...}}`` payload into a human sentence lives here.
+
+Why it matters (issue #145): the clients used to collapse an error response to
+``None``, which made a precise, actionable server message ("Could not find a
+valid TypeScript installation…") surface as "initialize returned None.
+Stderr: (empty)" — pointing the user at the wrong problem entirely.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def format_rpc_error(message: Any) -> str | None:
+    """Render the ``error`` member of a JSON-RPC message, if it has one.
+
+    Returns ``None`` for successful responses and for anything that isn't a
+    JSON-RPC message, so callers can use it as the "did this fail?" test.
+    """
+    if not isinstance(message, dict):
+        return None
+    error = message.get("error")
+    if error is None:
+        return None
+    if not isinstance(error, dict):
+        return str(error)
+
+    text = str(error.get("message", "")).strip() or "unknown error"
+    code = error.get("code")
+    rendered = f"[{code}] {text}" if code is not None else text
+
+    data = error.get("data")
+    if data not in (None, "", {}, []):
+        rendered = f"{rendered} ({data})"
+    return rendered

--- a/isitsecure/engine/code_analysis/lsp/tsserver_client.py
+++ b/isitsecure/engine/code_analysis/lsp/tsserver_client.py
@@ -26,6 +26,10 @@ from typing import Any
 from isitsecure.engine.code_analysis.lsp.protocols import (
     LSPLocation,
 )
+from isitsecure.engine.code_analysis.lsp.rpc_errors import format_rpc_error
+from isitsecure.engine.code_analysis.lsp.tsserver_locator import (
+    find_tsserver_js,
+)
 from isitsecure.engine.constants import LSPConfig
 
 logger = logging.getLogger(__name__)
@@ -48,6 +52,9 @@ class TypeScriptLSPClient:
         self._temp_tsconfig: Path | None = None
         self._lock = asyncio.Lock()
         self._opened_files: set[str] = set()  # instance variable, not class
+        self._last_error: str | None = None
+        self._pending_methods: dict[int, str] = {}
+        self._tsserver_js: Path | None = None
 
     # ------------------------------------------------------------------
     # Static availability check (called by factory)
@@ -66,9 +73,20 @@ class TypeScriptLSPClient:
     def is_available(self) -> bool:
         return self._initialized and self._process is not None
 
+    @property
+    def last_error(self) -> str | None:
+        """The most recent server-reported failure, for diagnostics.
+
+        The server explains its own refusals far better than we can guess at
+        them, so callers surface this instead of speculating (issue #145).
+        """
+        return self._last_error
+
     async def initialize(self, project_path: str) -> bool:
         """Spawn tsserver and initialize the LSP session."""
         self._project_path = project_path
+        self._last_error = None
+        self._tsserver_js = None
 
         if not self.is_node_available():
             logger.info(LSPConfig.MSG_UNAVAILABLE)
@@ -118,37 +136,12 @@ class TypeScriptLSPClient:
             # Send LSP initialize request
             result = await self._send_request(
                 "initialize",
-                {
-                    "processId": None,
-                    "rootUri": f"file://{project_path}",
-                    "rootPath": project_path,
-                    "capabilities": {
-                        "textDocument": {
-                            "definition": {"dynamicRegistration": False},
-                            "references": {"dynamicRegistration": False},
-                            "hover": {"dynamicRegistration": False},
-                        }
-                    },
-                },
+                self._initialize_params(project_path),
                 timeout=LSPConfig.INIT_TIMEOUT_SECONDS,
             )
 
             if result is None:
-                # Try to get stderr for diagnostics
-                stderr_out = ""
-                if self._process and self._process.stderr:
-                    try:
-                        stderr_data = await asyncio.wait_for(
-                            self._process.stderr.read(2000), timeout=1
-                        )
-                        stderr_out = stderr_data.decode(errors="replace")
-                    except (asyncio.TimeoutError, Exception):
-                        pass
-                logger.warning(
-                    "LSP initialize returned None. "
-                    "Stderr: %s",
-                    stderr_out[:300] if stderr_out else "(empty)",
-                )
+                await self._report_initialize_failure()
                 await self.shutdown()
                 return False
 
@@ -164,6 +157,69 @@ class TypeScriptLSPClient:
             )
             await self.shutdown()
             return False
+
+    def _initialize_params(self, project_path: str) -> dict[str, Any]:
+        """Build the ``initialize`` params, including ``tsserver.path``.
+
+        typescript-language-server resolves TypeScript from the workspace and
+        refuses to start when it can't find one.  Scans always run against a
+        freshly-ingested copy with no ``node_modules``, so we hand it an
+        explicit ``tsserver.path`` — the server's own supported escape hatch
+        (issue #145).
+        """
+        params: dict[str, Any] = {
+            "processId": None,
+            "rootUri": f"file://{project_path}",
+            "rootPath": project_path,
+            "capabilities": {
+                "textDocument": {
+                    "definition": {"dynamicRegistration": False},
+                    "references": {"dynamicRegistration": False},
+                    "hover": {"dynamicRegistration": False},
+                }
+            },
+        }
+
+        self._tsserver_js = find_tsserver_js(project_path)
+        if self._tsserver_js:
+            logger.info("Using TypeScript runtime: %s", self._tsserver_js)
+            params["initializationOptions"] = {
+                "tsserver": {"path": str(self._tsserver_js)}
+            }
+        else:
+            # Not fatal on its own — the workspace may still resolve one. If
+            # it doesn't, the failure report below names this as the cause.
+            logger.debug(LSPConfig.MSG_NO_TYPESCRIPT_RUNTIME)
+        return params
+
+    async def _report_initialize_failure(self) -> None:
+        """Log why initialization failed, using the server's own words."""
+        if self._last_error:
+            logger.warning(
+                "LSP initialize failed: %s%s",
+                self._last_error,
+                (
+                    ""
+                    if self._tsserver_js
+                    else f" — {LSPConfig.MSG_NO_TYPESCRIPT_RUNTIME}"
+                ),
+            )
+            return
+
+        stderr_out = ""
+        if self._process and self._process.stderr:
+            try:
+                stderr_data = await asyncio.wait_for(
+                    self._process.stderr.read(2000), timeout=1
+                )
+                stderr_out = stderr_data.decode(errors="replace")
+            except Exception:
+                pass
+        logger.warning(
+            "LSP initialize got no response (timed out or the server died). "
+            "Stderr: %s",
+            stderr_out[:300] if stderr_out else "(empty)",
+        )
 
     async def get_definition(
         self, file_path: str, line: int, character: int
@@ -284,6 +340,7 @@ class TypeScriptLSPClient:
             if not future.done():
                 future.cancel()
         self._pending.clear()
+        self._pending_methods.clear()
 
     # ------------------------------------------------------------------
     # JSON-RPC communication
@@ -313,6 +370,7 @@ class TypeScriptLSPClient:
 
         future: asyncio.Future[Any] = asyncio.get_event_loop().create_future()
         self._pending[req_id] = future
+        self._pending_methods[req_id] = method
 
         try:
             self._write_message(message)
@@ -329,6 +387,7 @@ class TypeScriptLSPClient:
             return None
         finally:
             self._pending.pop(req_id, None)
+            self._pending_methods.pop(req_id, None)
 
     async def _send_notification(
         self, method: str, params: Any
@@ -384,13 +443,22 @@ class TypeScriptLSPClient:
 
                 # Dispatch response to pending future
                 req_id = data.get("id")
+                rpc_error = format_rpc_error(data)
+                if rpc_error:
+                    # Keep the server's own explanation — collapsing it to
+                    # None is what made #145 invisible.
+                    self._last_error = rpc_error
+                    logger.debug(
+                        "LSP %s returned an error: %s",
+                        self._pending_methods.get(req_id, "request"),
+                        rpc_error,
+                    )
                 if req_id is not None and req_id in self._pending:
                     future = self._pending[req_id]
                     if not future.done():
-                        if "error" in data:
-                            future.set_result(None)
-                        else:
-                            future.set_result(data.get("result"))
+                        future.set_result(
+                            None if rpc_error else data.get("result")
+                        )
 
         except (asyncio.CancelledError, asyncio.IncompleteReadError):
             pass

--- a/isitsecure/engine/code_analysis/lsp/tsserver_locator.py
+++ b/isitsecure/engine/code_analysis/lsp/tsserver_locator.py
@@ -1,0 +1,179 @@
+"""Locate a TypeScript 5.x ``tsserver.js`` for the TypeScript language server.
+
+Why this exists (issue #145):
+
+``typescript-language-server`` ships no TypeScript of its own (v6 dropped the
+bundled dependency).  It resolves ``typescript`` from the *workspace* and
+refuses to start when it can't find one::
+
+    Could not find a valid TypeScript installation. Please ensure that the
+    "typescript" dependency is installed in the workspace or that a valid
+    `tsserver.path` is specified. Exiting.
+
+Repo scans always ingest into a fresh temp directory and drop ``node_modules``
+(see ``repo_ingestion``), so the workspace *never* has a TypeScript install.
+That made LSP initialization fail on every repo-mode scan of a TS project, on
+every machine.  Passing an explicit ``tsserver.path`` through
+``initializationOptions`` is the server's supported escape hatch.
+
+The path must point at a TypeScript **5.x** install: ``typescript@latest`` is
+now 7.x — the Go-native rewrite — which ships no ``lib/tsserver.js`` at all.
+The presence of that file is therefore both the existence *and* the version
+check; a 7.x install simply doesn't match and we keep looking.
+
+SRP: this module only *finds* a runtime.  Installing one is
+``isitsecure setup --lsp`` (see ``cli._ensure_tsserver_runtime``); using one is
+``TypeScriptLSPClient``.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+from isitsecure.config import CONFIG_DIR
+
+logger = logging.getLogger(__name__)
+
+# Escape hatch: point isitsecure at a specific tsserver.js.
+ENV_OVERRIDE = "ISITSECURE_TSSERVER_PATH"
+
+# Where `isitsecure setup --lsp` provisions its own private TypeScript, so we
+# never depend on — or disturb — whatever the user has installed globally.
+PROVISIONED_ROOT = CONFIG_DIR / "lsp"
+
+# npm spec for that private install. Pinned to 5.x on purpose: 6.x was never
+# released as `latest` and 7.x is the Go rewrite with no tsserver.js.
+TYPESCRIPT_PACKAGE_SPEC = "typescript@5"
+
+# Path of tsserver.js inside a package root that has installed TypeScript.
+_TSSERVER_REL = Path("node_modules") / "typescript" / "lib" / "tsserver.js"
+
+# How far up from the language-server binary to look for a node_modules tree.
+_MAX_ANCESTORS = 6
+
+_NPM_ROOT_TIMEOUT_SECONDS = 15
+
+
+def tsserver_js_in(package_root: str | Path) -> Path | None:
+    """Return ``<package_root>/node_modules/typescript/lib/tsserver.js``.
+
+    ``None`` when it isn't there — which is also how a TypeScript 7.x install
+    is rejected, since it ships no ``lib/tsserver.js``.
+    """
+    try:
+        candidate = Path(package_root) / _TSSERVER_REL
+        return candidate if candidate.is_file() else None
+    except OSError:
+        return None
+
+
+def find_tsserver_js(project_path: str | Path | None = None) -> Path | None:
+    """Find a usable TypeScript 5.x ``tsserver.js``, or ``None``.
+
+    Search order (first hit wins):
+
+    1. ``$ISITSECURE_TSSERVER_PATH`` — explicit operator override.
+    2. The scanned project itself, then its immediate subdirectories (a
+       monorepo package may carry the only install).
+    3. ``~/.isitsecure/lsp`` — provisioned by ``isitsecure setup --lsp``.
+    4. Next to the ``typescript-language-server`` binary (a global
+       ``npm i -g typescript-language-server typescript`` puts them as
+       siblings in the same ``node_modules``).
+    5. ``npm root -g`` — the global root, when the binary isn't on PATH or
+       lives somewhere unrelated.
+
+    Never raises; a broken environment just yields ``None``.
+    """
+    for finder in (
+        _from_env,
+        lambda: _from_project(project_path),
+        _from_provisioned,
+        _from_language_server_binary,
+        _from_npm_global_root,
+    ):
+        try:
+            found = finder()
+        except Exception as exc:  # a hostile FS/PATH must not break the scan
+            logger.debug("tsserver lookup step failed: %s", exc)
+            continue
+        if found:
+            return found
+    return None
+
+
+def _from_env() -> Path | None:
+    raw = os.environ.get(ENV_OVERRIDE, "").strip()
+    if not raw:
+        return None
+    path = Path(raw).expanduser()
+    if path.is_file():
+        return path
+    logger.warning(
+        "%s is set to %s, which is not a file — ignoring it.", ENV_OVERRIDE, raw
+    )
+    return None
+
+
+def _from_project(project_path: str | Path | None) -> Path | None:
+    if not project_path:
+        return None
+    root = Path(project_path)
+    found = tsserver_js_in(root)
+    if found:
+        return found
+    # Monorepos: the install often lives in a package, not at the root.
+    try:
+        children = sorted(c for c in root.iterdir() if c.is_dir())
+    except OSError:
+        return None
+    for child in children:
+        found = tsserver_js_in(child)
+        if found:
+            return found
+    return None
+
+
+def _from_provisioned() -> Path | None:
+    return tsserver_js_in(PROVISIONED_ROOT)
+
+
+def _from_language_server_binary() -> Path | None:
+    binary = shutil.which("typescript-language-server")
+    if not binary:
+        return None
+    # The PATH entry is usually a symlink into the real package directory.
+    real = Path(binary).resolve()
+    for ancestor in list(real.parents)[:_MAX_ANCESTORS]:
+        # …/node_modules/typescript/lib/tsserver.js (installed as a sibling)
+        if ancestor.name == "node_modules":
+            candidate = ancestor / "typescript" / "lib" / "tsserver.js"
+            if candidate.is_file():
+                return candidate
+        # …/<pkg>/node_modules/typescript/lib/tsserver.js (nested install)
+        found = tsserver_js_in(ancestor)
+        if found:
+            return found
+    return None
+
+
+def _from_npm_global_root() -> Path | None:
+    npm = shutil.which("npm")
+    if not npm:
+        return None
+    result = subprocess.run(
+        [npm, "root", "-g"],
+        capture_output=True,
+        text=True,
+        timeout=_NPM_ROOT_TIMEOUT_SECONDS,
+    )
+    if result.returncode != 0:
+        return None
+    root = result.stdout.strip()
+    if not root:
+        return None
+    candidate = Path(root) / "typescript" / "lib" / "tsserver.js"
+    return candidate if candidate.is_file() else None

--- a/isitsecure/engine/constants.py
+++ b/isitsecure/engine/constants.py
@@ -4920,6 +4920,14 @@ class LSPConfig:
     MSG_UNAVAILABLE = "TypeScript LSP unavailable — using regex-only analysis"
     MSG_INIT_FAILED = "LSP initialization failed: {error}"
     MSG_INIT_SUCCESS = "LSP initialized in {duration:.1f}s"
+    # typescript-language-server carries no TypeScript of its own, and scans
+    # run against an ingested copy with no node_modules — without a runtime it
+    # refuses to start at all (issue #145).
+    MSG_NO_TYPESCRIPT_RUNTIME = (
+        "No TypeScript 5.x runtime (tsserver.js) found for the language "
+        "server. Run `isitsecure setup --lsp` to install one, or set "
+        "ISITSECURE_TSSERVER_PATH to a typescript/lib/tsserver.js."
+    )
     MSG_VALIDATION_COMPLETE = (
         "LSP validation: {confirmed} findings confirmed, "
         "{suppressed} findings suppressed"

--- a/tests/engine/test_code_analysis/test_lsp_protocols.py
+++ b/tests/engine/test_code_analysis/test_lsp_protocols.py
@@ -1,14 +1,24 @@
-"""Tests for LSP protocol data models.
+"""Tests for LSP protocol data models and the client contract.
 
 Verifies default values, field assignment, and Pydantic behavior for
-``LSPLocation`` and ``AuthFlowResult``.
+``LSPLocation`` and ``AuthFlowResult``, plus the parts of
+``LSPClientProtocol`` every concrete client must honour.
 """
 
 from __future__ import annotations
 
+import pytest
+
+from isitsecure.engine.code_analysis.lsp.java_client import JavaLSPClient
+from isitsecure.engine.code_analysis.lsp.noop_client import NoOpLSPClient
 from isitsecure.engine.code_analysis.lsp.protocols import (
     AuthFlowResult,
+    LSPClientProtocol,
     LSPLocation,
+)
+from isitsecure.engine.code_analysis.lsp.python_client import PythonLSPClient
+from isitsecure.engine.code_analysis.lsp.tsserver_client import (
+    TypeScriptLSPClient,
 )
 
 
@@ -102,3 +112,29 @@ class TestAuthFlowResult:
         assert result.has_verified_auth is True
         assert result.trace_depth == 2
         assert result.has_ownership_check is True
+
+
+# ---------------------------------------------------------------------------
+# last_error — part of the client contract since #145
+# ---------------------------------------------------------------------------
+
+
+class TestLastErrorContract:
+    """Every client must be able to say why it isn't working.
+
+    Callers report the reason LSP is unavailable in the server's own words, so
+    a client that can't answer would send them back to guessing.
+    """
+
+    @pytest.mark.parametrize(
+        "client_factory",
+        [NoOpLSPClient, TypeScriptLSPClient, PythonLSPClient, JavaLSPClient],
+    )
+    def test_clients_expose_last_error(self, client_factory) -> None:
+        client = client_factory()
+        assert isinstance(client, LSPClientProtocol)
+        assert client.last_error is None
+
+    def test_noop_client_never_reports_an_error(self) -> None:
+        # It never attempts anything, so it has nothing to explain.
+        assert NoOpLSPClient().last_error is None

--- a/tests/engine/test_code_analysis/test_rpc_errors.py
+++ b/tests/engine/test_code_analysis/test_rpc_errors.py
@@ -1,0 +1,67 @@
+"""Tests for JSON-RPC error rendering (issue #145).
+
+Collapsing an error response to ``None`` is what hid the language server's own
+explanation of why it wouldn't start, so these pin the "did this fail, and
+what did the server say?" contract.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from isitsecure.engine.code_analysis.lsp.rpc_errors import format_rpc_error
+
+
+class TestSuccessfulMessages:
+    @pytest.mark.parametrize(
+        "message",
+        [
+            {"jsonrpc": "2.0", "id": 1, "result": {"capabilities": {}}},
+            {"jsonrpc": "2.0", "id": 1, "result": None},
+            {"jsonrpc": "2.0", "method": "window/logMessage", "params": {}},
+            {},
+        ],
+    )
+    def test_returns_none(self, message: dict) -> None:
+        assert format_rpc_error(message) is None
+
+    @pytest.mark.parametrize("message", [None, "not a message", 42, []])
+    def test_non_message_returns_none(self, message: object) -> None:
+        assert format_rpc_error(message) is None
+
+
+class TestErrorMessages:
+    def test_renders_code_and_message(self) -> None:
+        rendered = format_rpc_error(
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "error": {"code": -32603, "message": "Could not find a valid "
+                                                     "TypeScript installation."},
+            }
+        )
+        assert rendered == (
+            "[-32603] Could not find a valid TypeScript installation."
+        )
+
+    def test_includes_data_when_present(self) -> None:
+        rendered = format_rpc_error(
+            {"error": {"code": -1, "message": "boom", "data": "stack trace"}}
+        )
+        assert rendered == "[-1] boom (stack trace)"
+
+    def test_omits_empty_data(self) -> None:
+        rendered = format_rpc_error(
+            {"error": {"code": -1, "message": "boom", "data": None}}
+        )
+        assert rendered == "[-1] boom"
+
+    def test_message_without_code(self) -> None:
+        assert format_rpc_error({"error": {"message": "boom"}}) == "boom"
+
+    def test_error_without_message_still_reports_a_failure(self) -> None:
+        """An empty message must not read as success."""
+        assert format_rpc_error({"error": {"code": -5}}) == "[-5] unknown error"
+
+    def test_non_dict_error_is_stringified(self) -> None:
+        assert format_rpc_error({"error": "server exploded"}) == "server exploded"

--- a/tests/engine/test_code_analysis/test_tsserver_client.py
+++ b/tests/engine/test_code_analysis/test_tsserver_client.py
@@ -6,11 +6,14 @@ parsing without spawning a real tsserver subprocess.
 
 from __future__ import annotations
 
+import asyncio
 import json
+import logging
 from pathlib import Path
 
 import pytest
 
+from isitsecure.engine.code_analysis.lsp import tsserver_client
 from isitsecure.engine.code_analysis.lsp.tsserver_client import (
     TypeScriptLSPClient,
 )
@@ -226,3 +229,198 @@ class TestTsconfigManagement:
         assert client._temp_tsconfig is None
         content = json.loads(tsconfig_path.read_text())
         assert content == original
+
+
+# ------------------------------------------------------------------
+# TestInitializeParams (issue #145)
+# ------------------------------------------------------------------
+
+
+class TestInitializeParams:
+    """Tests for the ``initialize`` params, especially ``tsserver.path``.
+
+    typescript-language-server refuses to start when it can't resolve a
+    TypeScript, and a scanned tree never has ``node_modules`` — so the
+    explicit path is the whole reason repo-mode scans work at all.
+    """
+
+    def test_includes_tsserver_path_when_a_runtime_is_found(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        runtime = tmp_path / "typescript" / "lib" / "tsserver.js"
+        runtime.parent.mkdir(parents=True)
+        runtime.write_text("// tsserver")
+        monkeypatch.setattr(
+            tsserver_client, "find_tsserver_js", lambda _p: runtime
+        )
+
+        params = TypeScriptLSPClient()._initialize_params(str(tmp_path))
+
+        assert params["initializationOptions"] == {
+            "tsserver": {"path": str(runtime)}
+        }
+
+    def test_omits_tsserver_path_when_no_runtime_is_found(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Without a runtime we still try — a workspace may resolve one."""
+        monkeypatch.setattr(
+            tsserver_client, "find_tsserver_js", lambda _p: None
+        )
+
+        params = TypeScriptLSPClient()._initialize_params(str(tmp_path))
+
+        assert "initializationOptions" not in params
+
+    def test_keeps_the_standard_handshake_fields(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            tsserver_client, "find_tsserver_js", lambda _p: None
+        )
+
+        params = TypeScriptLSPClient()._initialize_params(str(tmp_path))
+
+        assert params["processId"] is None
+        assert params["rootPath"] == str(tmp_path)
+        assert params["rootUri"] == f"file://{tmp_path}"
+        assert "definition" in params["capabilities"]["textDocument"]
+
+
+# ------------------------------------------------------------------
+# TestErrorReporting (issue #145)
+# ------------------------------------------------------------------
+
+
+class _FakeStdout:
+    """Minimal stdout stub that replays framed LSP messages."""
+
+    def __init__(self, messages: list[dict]) -> None:
+        payload = b""
+        for message in messages:
+            body = json.dumps(message).encode()
+            payload += b"Content-Length: %d\r\n\r\n" % len(body) + body
+        self._buffer = payload
+
+    async def readline(self) -> bytes:
+        index = self._buffer.find(b"\r\n")
+        if index == -1:
+            return b""
+        line, self._buffer = self._buffer[: index + 2], self._buffer[index + 2:]
+        return line
+
+    async def readexactly(self, count: int) -> bytes:
+        chunk, self._buffer = self._buffer[:count], self._buffer[count:]
+        return chunk
+
+
+class _FakeProcess:
+    def __init__(self, messages: list[dict]) -> None:
+        self.stdout = _FakeStdout(messages)
+        self.stdin = None
+        self.stderr = None
+        self.returncode = None
+
+
+class TestErrorReporting:
+    """The server's own explanation must survive the reader loop."""
+
+    def test_last_error_is_none_before_anything_happens(self) -> None:
+        assert TypeScriptLSPClient().last_error is None
+
+    @pytest.mark.asyncio
+    async def test_reader_keeps_the_server_error(self) -> None:
+        client = TypeScriptLSPClient()
+        client._process = _FakeProcess([  # type: ignore[assignment]
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "error": {
+                    "code": -32603,
+                    "message": (
+                        "Request initialize failed with message: Could not "
+                        "find a valid TypeScript installation."
+                    ),
+                },
+            }
+        ])
+        client._pending_methods[1] = "initialize"
+
+        await client._read_responses()
+
+        assert client.last_error is not None
+        assert "-32603" in client.last_error
+        assert "valid TypeScript installation" in client.last_error
+
+    @pytest.mark.asyncio
+    async def test_error_response_still_resolves_the_request_to_none(
+        self,
+    ) -> None:
+        """Callers keep their result-or-None contract."""
+        client = TypeScriptLSPClient()
+        client._process = _FakeProcess([  # type: ignore[assignment]
+            {"jsonrpc": "2.0", "id": 7, "error": {"code": -1, "message": "no"}}
+        ])
+        future: asyncio.Future = asyncio.get_running_loop().create_future()
+        client._pending[7] = future
+
+        await client._read_responses()
+
+        assert future.result() is None
+
+    @pytest.mark.asyncio
+    async def test_successful_response_leaves_last_error_unset(self) -> None:
+        client = TypeScriptLSPClient()
+        client._process = _FakeProcess([  # type: ignore[assignment]
+            {"jsonrpc": "2.0", "id": 1, "result": {"capabilities": {}}}
+        ])
+        future: asyncio.Future = asyncio.get_running_loop().create_future()
+        client._pending[1] = future
+
+        await client._read_responses()
+
+        assert client.last_error is None
+        assert future.result() == {"capabilities": {}}
+
+    @pytest.mark.asyncio
+    async def test_failure_report_uses_the_server_error(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        client = TypeScriptLSPClient()
+        client._last_error = (
+            "[-32603] Could not find a valid TypeScript installation."
+        )
+
+        with caplog.at_level(logging.WARNING):
+            await client._report_initialize_failure()
+
+        assert "valid TypeScript installation" in caplog.text
+        # …and it points at the fix rather than at a missing install.
+        assert "setup --lsp" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_failure_report_without_a_server_error(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A dead/silent server must not be reported as an RPC error."""
+        client = TypeScriptLSPClient()
+
+        with caplog.at_level(logging.WARNING):
+            await client._report_initialize_failure()
+
+        assert "no response" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_failure_report_omits_the_runtime_hint_when_one_was_used(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A runtime we already supplied isn't the thing to go install."""
+        client = TypeScriptLSPClient()
+        client._tsserver_js = tmp_path / "tsserver.js"
+        client._last_error = "[-1] something else went wrong"
+
+        with caplog.at_level(logging.WARNING):
+            await client._report_initialize_failure()
+
+        assert "something else went wrong" in caplog.text
+        assert "setup --lsp" not in caplog.text

--- a/tests/engine/test_code_analysis/test_tsserver_locator.py
+++ b/tests/engine/test_code_analysis/test_tsserver_locator.py
@@ -1,0 +1,251 @@
+"""Tests for the TypeScript runtime locator (issue #145).
+
+The language server refuses to start without a TypeScript 5.x
+``lib/tsserver.js``, and scans always run against a tree with no
+``node_modules`` — so these tests pin down where we look for one, in what
+order, and that a 7.x install is never mistaken for a usable runtime.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from isitsecure.engine.code_analysis.lsp import tsserver_locator
+from isitsecure.engine.code_analysis.lsp.tsserver_locator import (
+    ENV_OVERRIDE,
+    find_tsserver_js,
+    tsserver_js_in,
+)
+
+
+def _make_typescript(root: Path, *, version_5: bool = True) -> Path:
+    """Create a fake ``node_modules/typescript`` under ``root``.
+
+    A TypeScript 7.x package (``version_5=False``) is the Go rewrite: it has
+    the package directory but no ``lib/tsserver.js``.
+    """
+    lib = root / "node_modules" / "typescript" / "lib"
+    lib.mkdir(parents=True, exist_ok=True)
+    tsserver = lib / "tsserver.js"
+    if version_5:
+        tsserver.write_text("// tsserver")
+    return tsserver
+
+
+@pytest.fixture
+def isolated(monkeypatch, tmp_path: Path):
+    """Neutralise every ambient source so each test controls exactly one."""
+    monkeypatch.delenv(ENV_OVERRIDE, raising=False)
+    monkeypatch.setattr(
+        tsserver_locator, "PROVISIONED_ROOT", tmp_path / "unused-config"
+    )
+    monkeypatch.setattr(tsserver_locator.shutil, "which", lambda _name: None)
+    return tmp_path
+
+
+# ------------------------------------------------------------------
+# tsserver_js_in
+# ------------------------------------------------------------------
+
+
+class TestTsserverJsIn:
+    def test_finds_installed_typescript(self, tmp_path: Path) -> None:
+        expected = _make_typescript(tmp_path)
+        assert tsserver_js_in(tmp_path) == expected
+
+    def test_returns_none_without_node_modules(self, tmp_path: Path) -> None:
+        assert tsserver_js_in(tmp_path) is None
+
+    def test_rejects_typescript_7_without_tsserver_js(self, tmp_path: Path) -> None:
+        """TS 7.x ships no lib/tsserver.js — the package alone isn't enough."""
+        _make_typescript(tmp_path, version_5=False)
+        assert (tmp_path / "node_modules" / "typescript").is_dir()
+        assert tsserver_js_in(tmp_path) is None
+
+    def test_accepts_str_path(self, tmp_path: Path) -> None:
+        expected = _make_typescript(tmp_path)
+        assert tsserver_js_in(str(tmp_path)) == expected
+
+
+# ------------------------------------------------------------------
+# find_tsserver_js — sources
+# ------------------------------------------------------------------
+
+
+class TestFindTsserverJsSources:
+    def test_env_override_wins(self, isolated: Path, monkeypatch) -> None:
+        override = isolated / "custom-tsserver.js"
+        override.write_text("// tsserver")
+        project = isolated / "project"
+        project.mkdir()
+        _make_typescript(project)
+        monkeypatch.setenv(ENV_OVERRIDE, str(override))
+
+        assert find_tsserver_js(project) == override
+
+    def test_env_override_ignored_when_not_a_file(
+        self, isolated: Path, monkeypatch
+    ) -> None:
+        monkeypatch.setenv(ENV_OVERRIDE, str(isolated / "does-not-exist.js"))
+        project = isolated / "project"
+        project.mkdir()
+        expected = _make_typescript(project)
+
+        assert find_tsserver_js(project) == expected
+
+    def test_project_install(self, isolated: Path) -> None:
+        project = isolated / "project"
+        project.mkdir()
+        expected = _make_typescript(project)
+        assert find_tsserver_js(project) == expected
+
+    def test_monorepo_package_install(self, isolated: Path) -> None:
+        """The only install may live in a workspace package, not the root."""
+        project = isolated / "project"
+        (project / "packages").mkdir(parents=True)
+        expected = _make_typescript(project / "packages")
+        assert find_tsserver_js(project) == expected
+
+    def test_provisioned_root(self, isolated: Path, monkeypatch) -> None:
+        provisioned = isolated / "config" / "lsp"
+        provisioned.mkdir(parents=True)
+        expected = _make_typescript(provisioned)
+        monkeypatch.setattr(
+            tsserver_locator, "PROVISIONED_ROOT", provisioned
+        )
+
+        project = isolated / "project"
+        project.mkdir()  # no node_modules — the repo-clone case
+
+        assert find_tsserver_js(project) == expected
+
+    def test_project_preferred_over_provisioned(
+        self, isolated: Path, monkeypatch
+    ) -> None:
+        provisioned = isolated / "config" / "lsp"
+        provisioned.mkdir(parents=True)
+        _make_typescript(provisioned)
+        monkeypatch.setattr(tsserver_locator, "PROVISIONED_ROOT", provisioned)
+
+        project = isolated / "project"
+        project.mkdir()
+        expected = _make_typescript(project)
+
+        assert find_tsserver_js(project) == expected
+
+    def test_sibling_of_language_server_binary(
+        self, isolated: Path, monkeypatch
+    ) -> None:
+        """`npm i -g typescript-language-server typescript` puts them as
+        siblings in the same global node_modules."""
+        node_modules = isolated / "lib" / "node_modules"
+        server_bin = node_modules / "typescript-language-server" / "lib" / "cli.mjs"
+        server_bin.parent.mkdir(parents=True)
+        server_bin.write_text("// server")
+        expected = node_modules / "typescript" / "lib" / "tsserver.js"
+        expected.parent.mkdir(parents=True)
+        expected.write_text("// tsserver")
+
+        monkeypatch.setattr(
+            tsserver_locator.shutil, "which", lambda _name: str(server_bin)
+        )
+
+        assert find_tsserver_js(isolated / "project") == expected
+
+    def test_nested_install_under_language_server(
+        self, isolated: Path, monkeypatch
+    ) -> None:
+        server_pkg = isolated / "node_modules" / "typescript-language-server"
+        server_bin = server_pkg / "lib" / "cli.mjs"
+        server_bin.parent.mkdir(parents=True)
+        server_bin.write_text("// server")
+        expected = _make_typescript(server_pkg)
+
+        monkeypatch.setattr(
+            tsserver_locator.shutil, "which", lambda _name: str(server_bin)
+        )
+
+        assert find_tsserver_js(isolated / "project") == expected
+
+    def test_npm_global_root_fallback(
+        self, isolated: Path, monkeypatch
+    ) -> None:
+        global_root = isolated / "global" / "node_modules"
+        expected = global_root / "typescript" / "lib" / "tsserver.js"
+        expected.parent.mkdir(parents=True)
+        expected.write_text("// tsserver")
+
+        monkeypatch.setattr(
+            tsserver_locator.shutil,
+            "which",
+            lambda name: "/usr/bin/npm" if name == "npm" else None,
+        )
+        monkeypatch.setattr(
+            tsserver_locator.subprocess,
+            "run",
+            lambda *a, **k: subprocess.CompletedProcess(
+                a[0], 0, stdout=f"{global_root}\n", stderr=""
+            ),
+        )
+
+        assert find_tsserver_js(isolated / "project") == expected
+
+    def test_returns_none_when_nothing_is_installed(
+        self, isolated: Path
+    ) -> None:
+        assert find_tsserver_js(isolated / "project") is None
+
+    def test_no_project_path_still_searches_other_sources(
+        self, isolated: Path, monkeypatch
+    ) -> None:
+        provisioned = isolated / "config" / "lsp"
+        provisioned.mkdir(parents=True)
+        expected = _make_typescript(provisioned)
+        monkeypatch.setattr(tsserver_locator, "PROVISIONED_ROOT", provisioned)
+
+        assert find_tsserver_js() == expected
+
+
+# ------------------------------------------------------------------
+# find_tsserver_js — robustness
+# ------------------------------------------------------------------
+
+
+class TestFindTsserverJsRobustness:
+    def test_a_failing_source_does_not_break_the_search(
+        self, isolated: Path, monkeypatch
+    ) -> None:
+        """One broken lookup must not cost us the runtime a later one finds."""
+        provisioned = isolated / "config" / "lsp"
+        provisioned.mkdir(parents=True)
+        expected = _make_typescript(provisioned)
+        monkeypatch.setattr(tsserver_locator, "PROVISIONED_ROOT", provisioned)
+
+        def explode(_project_path):
+            raise OSError("permission denied")
+
+        monkeypatch.setattr(tsserver_locator, "_from_project", explode)
+
+        assert find_tsserver_js(isolated / "project") == expected
+
+    def test_npm_failure_is_survivable(self, isolated: Path, monkeypatch) -> None:
+        monkeypatch.setattr(
+            tsserver_locator.shutil,
+            "which",
+            lambda name: "/usr/bin/npm" if name == "npm" else None,
+        )
+
+        def timeout(*_a, **_k):
+            raise subprocess.TimeoutExpired("npm", 15)
+
+        monkeypatch.setattr(tsserver_locator.subprocess, "run", timeout)
+
+        assert find_tsserver_js(isolated / "project") is None
+
+    def test_missing_project_directory_is_survivable(
+        self, isolated: Path
+    ) -> None:
+        assert find_tsserver_js(isolated / "nope" / "gone") is None

--- a/tests/test_cli_onboarding.py
+++ b/tests/test_cli_onboarding.py
@@ -42,7 +42,10 @@ def test_every_selectable_mode_has_an_explanation():
 # #54 — pre-flight checks (which warnings fire, per mode / prerequisites)
 # ---------------------------------------------------------------------------
 
-def _run_preflight(monkeypatch, *, mode, chromium, missing_lsp, provider, has_key):
+def _run_preflight(
+    monkeypatch, *, mode, chromium, missing_lsp, provider, has_key,
+    ts_runtime="/fake/typescript/lib/tsserver.js",
+):
     """Run _preflight_checks with fully stubbed detection, return captured text."""
     monkeypatch.setattr(cli, "_chromium_installed", lambda: chromium)
     # Force LSP detection: _first_which returns None (missing) or a fake path.
@@ -51,6 +54,12 @@ def _run_preflight(monkeypatch, *, mode, chromium, missing_lsp, provider, has_ke
     # only variable is _first_which above.
     import shutil
     monkeypatch.setattr(shutil, "which", lambda *_: "found")
+    # The TypeScript runtime lookup hits the real filesystem otherwise, which
+    # would make these tests depend on the host's npm install (#145).
+    from isitsecure.engine.code_analysis.lsp import tsserver_locator
+    monkeypatch.setattr(
+        tsserver_locator, "find_tsserver_js", lambda *_a, **_k: ts_runtime
+    )
 
     printed: list[str] = []
     monkeypatch.setattr(
@@ -94,6 +103,28 @@ def test_code_only_warns_about_missing_lsp(monkeypatch):
         missing_lsp=True, provider="none", has_key=False,
     )
     assert "isitsecure setup --lsp" in out
+
+
+def test_code_only_warns_when_ts_server_has_no_typescript_runtime(monkeypatch):
+    # The language server being installed isn't enough — without a TypeScript
+    # 5.x runtime it refuses to start, and the scan silently degrades (#145).
+    out = _run_preflight(
+        monkeypatch, mode="code-only", chromium=True,
+        missing_lsp=False, provider="none", has_key=False,
+        ts_runtime=None,
+    )
+    assert "TypeScript runtime" in out
+    assert "isitsecure setup --lsp" in out
+
+
+def test_no_runtime_warning_when_the_ts_server_itself_is_missing(monkeypatch):
+    # One warning, not two: "install the language server" already covers it.
+    out = _run_preflight(
+        monkeypatch, mode="code-only", chromium=True,
+        missing_lsp=True, provider="none", has_key=False,
+        ts_runtime=None,
+    )
+    assert "TypeScript runtime" not in out
 
 
 def test_llm_key_warning_only_when_provider_selected_and_missing(monkeypatch):
@@ -162,3 +193,105 @@ def test_scan_with_no_target_shows_human_error(monkeypatch):
     # Plain-language, not the old terse "provide a target URL, a --repo".
     assert "I need either your website" in out
     assert "isitsecure scan https://" in out
+
+
+# ---------------------------------------------------------------------------
+# #145 — `setup --lsp` provisions a TypeScript runtime for the TS language server
+# ---------------------------------------------------------------------------
+
+def _run_ensure_runtime(
+    monkeypatch, tmp_path, *, server_installed=True, runtime=None,
+    npm=True, install_result=(0, ""), installs_runtime=True,
+):
+    """Run _ensure_tsserver_runtime with npm and the locator stubbed out."""
+    import shutil
+    import subprocess
+
+    from isitsecure.engine.code_analysis.lsp import tsserver_locator
+
+    monkeypatch.setattr(
+        cli, "_first_which", lambda bins: "found" if server_installed else None
+    )
+    monkeypatch.setattr(
+        shutil, "which", lambda name: "/usr/bin/npm" if (npm and name == "npm") else None
+    )
+    monkeypatch.setattr(tsserver_locator, "PROVISIONED_ROOT", tmp_path / "lsp")
+
+    calls: list[list[str]] = []
+    found = {"path": runtime}
+
+    def fake_run(cmd, **_kwargs):
+        calls.append(list(cmd))
+        code, output = install_result
+        if code == 0 and installs_runtime:
+            found["path"] = tmp_path / "lsp/node_modules/typescript/lib/tsserver.js"
+        return subprocess.CompletedProcess(cmd, code, stdout=output, stderr=output)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    monkeypatch.setattr(
+        tsserver_locator, "find_tsserver_js", lambda *_a, **_k: found["path"]
+    )
+
+    printed: list[str] = []
+    monkeypatch.setattr(
+        cli.console, "print", lambda *a, **k: printed.append(" ".join(str(x) for x in a))
+    )
+    cli._ensure_tsserver_runtime()
+    return "\n".join(printed), calls
+
+
+def test_runtime_provisioning_skipped_without_the_language_server(monkeypatch, tmp_path):
+    # Nothing to feed a runtime to — stay quiet rather than install for nobody.
+    out, calls = _run_ensure_runtime(monkeypatch, tmp_path, server_installed=False)
+    assert out == ""
+    assert calls == []
+
+
+def test_existing_runtime_is_reported_and_not_reinstalled(monkeypatch, tmp_path):
+    out, calls = _run_ensure_runtime(
+        monkeypatch, tmp_path, runtime="/usr/lib/typescript/lib/tsserver.js"
+    )
+    assert "/usr/lib/typescript/lib/tsserver.js" in out
+    assert calls == []
+
+
+def test_missing_runtime_is_installed_privately_and_pinned_to_5(monkeypatch, tmp_path):
+    from isitsecure.engine.code_analysis.lsp.tsserver_locator import (
+        TYPESCRIPT_PACKAGE_SPEC,
+    )
+
+    out, calls = _run_ensure_runtime(monkeypatch, tmp_path, runtime=None)
+
+    assert len(calls) == 1
+    cmd = calls[0]
+    assert "install" in cmd and TYPESCRIPT_PACKAGE_SPEC in cmd
+    # Private prefix: never touch the user's global TypeScript.
+    assert "--prefix" in cmd
+    assert str(tmp_path / "lsp") in cmd
+    assert "-g" not in cmd
+    assert "installed" in out
+
+
+def test_install_failure_is_reported_not_claimed_as_success(monkeypatch, tmp_path):
+    out, _calls = _run_ensure_runtime(
+        monkeypatch, tmp_path, runtime=None,
+        install_result=(1, "npm ERR! network timeout"), installs_runtime=False,
+    )
+    assert "installed" not in out
+    assert "network timeout" in out
+
+
+def test_install_that_exits_clean_but_provisions_nothing_is_not_success(
+    monkeypatch, tmp_path
+):
+    out, _calls = _run_ensure_runtime(
+        monkeypatch, tmp_path, runtime=None,
+        install_result=(0, "up to date"), installs_runtime=False,
+    )
+    assert "installed" not in out
+
+
+def test_missing_npm_gives_guidance_instead_of_installing(monkeypatch, tmp_path):
+    out, calls = _run_ensure_runtime(monkeypatch, tmp_path, runtime=None, npm=False)
+    assert calls == []
+    assert "ISITSECURE_TSSERVER_PATH" in out


### PR DESCRIPTION
Fixes #145.

## Root cause

LSP validation never ran on `--repo` scans of TypeScript projects, and the scan blamed the wrong thing for it. Three facts had to line up, and all three are true on any machine today:

1. **`typescript-language-server` >= 6 ships no TypeScript of its own.** It resolves `typescript` from the workspace and exits if it can't find one. (Verified against a clean 6.0.0 install: zero dependencies.)
2. **Scans never have a workspace TypeScript.** Ingestion copies into a fresh temp dir and strips `node_modules` — for local paths as well as remote clones, via `_LOCAL_COPY_IGNORE`.
3. **`typescript@latest` is now 7.x** — the Go-native rewrite, which ships no `lib/tsserver.js` at all. So the old `npm i -g typescript-language-server typescript` in `setup --lsp` installed a TypeScript that cannot drive the server.

The server explained all of this in a JSON-RPC error, which the reader collapsed to `None`. The user saw:

```
LSP initialize returned None. Stderr: (empty)
LSP initialization returned False — typescript-language-server may not be installed.
```

…while the binary was present and healthy. Guaranteed, and invisible.

## What changed

**Pass the server a runtime.** New `lsp/tsserver_locator.py` finds a TypeScript 5.x `tsserver.js` and the client hands it over as `tsserver.path` in `initializationOptions` — the server's own supported escape hatch. Search order, first match wins:

1. `$ISITSECURE_TSSERVER_PATH`
2. the scanned project, then its immediate subdirectories (monorepo packages)
3. `~/.isitsecure/lsp` (provisioned by `setup --lsp`)
4. next to the `typescript-language-server` binary
5. `npm root -g`

Absence of `lib/tsserver.js` is what rejects a 7.x install — no version parsing needed.

**Provision a runtime, privately.** `setup --lsp` installs `typescript@5` under `~/.isitsecure/lsp` instead of installing a global one, so a user's own TypeScript is never installed, changed, or downgraded. `setup --check` and the scan pre-flight now both report the runtime, because having the server *without* one is a setup that looks fine and isn't.

**Stop dropping JSON-RPC errors.** Both clients keep the server's own words via a shared `lsp/rpc_errors.py` and expose them as `last_error`, now part of `LSPClientProtocol`, so `agent.py` reports the actual cause instead of guessing at a missing install.

## Verification

Reproduced against a real `typescript-language-server` 6.0.0 with no resolvable TypeScript — the exact reported configuration. Pre-fix code emits both misleading warnings verbatim; post-fix initializes and runs `lsp_validator`.

| Check | Result |
|---|---|
| Unit tests | 2216 passed, 1 xfailed (+43 new) |
| sast-injection benchmark | 46/46 taint recall, **0 false positives** |
| VAmPI benchmark | 3/3 recall |
| `test-app/` repo scan, broken env | pre-fix: no `lsp_validator` → post-fix: initializes, 15 routes traced |
| juice-shop repo scan (104 routes) | `lsp_validator` runs; **198 findings LSP-on == 198 LSP-off** — no recall change, no new FPs |
| juice-shop DAST (`localhost:3000`) | 26 findings incl. 5 injection_risk + 4 idor — path untouched |
| Full journey in a broken env | fresh HOME + tls 6.0.0 + empty global root → `setup --lsp` → scan traces auth flows |

## Docs

`docs/lsp-setup.md` (install commands, a "TypeScript runtime" section, lookup order, the real troubleshooting entry), `README.md` (LSP setup), `docs/architecture.md` (Phase 7.5 + the degradation table).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EZ4QoTqRoYWE25CNoV2Wfy
