### PR TITLE
fix(scan): honour --branch, default to the repo's own branch, and stop reporting unread code as clean (#147)

### DIFF
--- a/README.md
+++ b/README.md
@@ -546,7 +546,7 @@ Arguments:
 
 Options:
   -r, --repo TEXT        GitHub repo URL (SAST)
-  -b, --branch TEXT      Git branch [default: main]
+  -b, --branch TEXT      Git branch [default: the repo's own default branch]
   -m, --mode TEXT        Scan mode: auto|url-only|code-only|authenticated|full
   --depth TEXT           Scan depth: quick|deep [default: quick]
   --llm TEXT             LLM provider: anthropic|google|none [default: anthropic]
@@ -568,6 +568,9 @@ Options:
   --baseline-accept      Record the current findings as the baseline
   --baseline-file TEXT   Baseline path [default: ~/.isitsecure/baselines/<project>.json]
   -v, --verbose          Enable debug logging
+
+  # exit 1 if something you asked to scan couldn't be read (e.g. the repo
+  # failed to clone) — a report that never saw your code isn't a clean scan
 
 isitsecure fix [OPTIONS]
   -r, --repo TEXT        Local repo path, OR a remote GitHub URL to open PRs against [required]

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -280,6 +280,7 @@ The scanner works at any completeness level:
 | No TypeScript/Node.js | LSP validation skipped. Auth flow tracing unavailable, more false positives |
 | No TypeScript 5.x runtime | Same — `typescript-language-server` won't start without a `tsserver.js`. `isitsecure setup --lsp` provisions one; see [lsp-setup.md](lsp-setup.md) |
 | No repo URL | SAST skipped entirely. DAST-only scan |
+| Repo fails to clone | Code-only: the scan stops and exits 1 (no report). Full: DAST findings are kept, the reason is recorded in `ingestion_errors`, and the CLI exits 1 — a zero-finding report must never read as "your code is fine" |
 | No target URL | SAST-only scan against code |
 | No credentials | Authenticated scanners skipped. No IDOR cross-user, no privilege escalation |
 

--- a/isitsecure/cli.py
+++ b/isitsecure/cli.py
@@ -290,7 +290,9 @@ def _load_api_key(provider: str) -> str | None:
 def scan(
     target_url: Optional[str] = typer.Argument(None, help="URL to scan (DAST)"),
     repo: Optional[str] = typer.Option(None, "--repo", "-r", help="GitHub repo URL (SAST)"),
-    branch: str = typer.Option("main", "--branch", "-b", help="Git branch"),
+    branch: Optional[str] = typer.Option(
+        None, "--branch", "-b",
+        help="Git branch to scan (default: the repository's own default branch)"),
     github_token: Optional[str] = typer.Option(None, "--github-token", envvar="GITHUB_TOKEN"),
     mode: str = typer.Option("auto", "--mode", "-m", help="Scan mode: auto|url-only|code-only|authenticated|full"),
     depth: str = typer.Option("quick", "--depth", help="Scan depth: quick (fast, default) | deep (adds time-based SQLi, active XSS, and other slow/aggressive probes)"),
@@ -417,6 +419,7 @@ def scan(
         credentials_a=credentials_a,
         credentials_b=credentials_b,
         scan_mode=resolved_mode,
+        repo_branch=branch,
     ))
 
     # Suppression (#51) + baseline (#52): filter the findings once, so every
@@ -490,6 +493,18 @@ def scan(
             "[dim]Valid options for --output are: table, json, html, sarif, fixes.[/dim]"
         )
         _print_report_table(report)
+
+    # Something we were asked to scan couldn't be read. The findings above are
+    # real but partial, so don't let a green exit code say otherwise (#147).
+    if report.ingestion_errors:
+        err_console.print()
+        for problem in report.ingestion_errors:
+            err_console.print(f"  [red]•[/red] {problem}")
+        err_console.print(
+            "[yellow]Your code was not scanned — the results above cover only "
+            "the live site.[/yellow]"
+        )
+        raise typer.Exit(1)
 
 
 async def _generate_fixes(report, llm_client, repo_url: str | None) -> str:
@@ -567,6 +582,7 @@ async def _run_scan(agent, **kwargs):
     import time
 
     report = None
+    failure: str | None = None
     t0 = time.monotonic()
     last_phase = None
     err_console.print()
@@ -584,6 +600,11 @@ async def _run_scan(agent, **kwargs):
             from isitsecure.engine.models import DeepScanReport
             report = DeepScanReport.model_validate(data["report"])
             continue
+
+        # Keep the reason a phase gave up, so a scan that ends without a
+        # report can explain itself instead of shrugging (#147).
+        if data.get("error") and message:
+            failure = message
 
         status = data.get("status")
         if status == "start":
@@ -610,9 +631,14 @@ async def _run_scan(agent, **kwargs):
             err_console.print(f"{stamp}      [dim]· {message}[/dim]")
 
     if report is None:
+        if failure:
+            err_console.print(f"\n[red]{failure}[/red]")
+        else:
+            err_console.print(
+                "[red]The scan finished but didn't produce any results — something "
+                "went wrong along the way.[/red]"
+            )
         err_console.print(
-            "[red]The scan finished but didn't produce any results — something went "
-            "wrong along the way.[/red]\n"
             "[dim]Try re-running with -v (verbose) to see what happened, or check "
             "that your website address / code path is correct.[/dim]"
         )

--- a/isitsecure/engine/agent.py
+++ b/isitsecure/engine/agent.py
@@ -219,6 +219,7 @@ class DeepSecurityScanAgent:
         credentials_a: AuthCredentials | None = None,
         credentials_b: AuthCredentials | None = None,
         scan_mode: ScanMode | None = None,
+        repo_branch: str | None = None,
     ) -> AsyncGenerator[DeepScanEvent, None]:
         """Run a full deep security scan.
 
@@ -227,6 +228,8 @@ class DeepSecurityScanAgent:
         - URL + credentials       -> AUTHENTICATED
         - URL only                -> URL_ONLY
         - Repo only               -> CODE_ONLY
+
+        ``repo_branch`` defaults to the repository's own default branch.
         """
         start_time = time.monotonic()
         # Install an ambient progress reporter so scanners can narrate their
@@ -245,6 +248,7 @@ class DeepSecurityScanAgent:
 
         all_findings: list[DeepFinding] = []
         scanners_run: list[str] = []
+        ingestion_errors: list[str] = []
 
         snapshot: CodebaseSnapshot | None = None
         repo_snapshot: RepoSnapshot | None = None
@@ -654,7 +658,44 @@ class DeepSecurityScanAgent:
                 OrchestratorConfig.MSG_CLONING_REPO.format(repo_url=repo_url),
                 OrchestratorConfig.PROGRESS_CODE_INGESTION,
             )
-            repo_snapshot = await self._ingest_repo(repo_url, github_token)
+            try:
+                repo_snapshot = await self._ingest_repo(
+                    repo_url, github_token, repo_branch
+                )
+            except Exception as e:
+                repo_snapshot = None
+                logger.error(
+                    OrchestratorConfig.ERROR_REPO_FAILED.format(error=e)
+                )
+                ingestion_errors.append(str(e))
+
+            if repo_snapshot is None:
+                if not ingestion_errors:
+                    # No exception, no snapshot: no ingestion service wired.
+                    ingestion_errors.append(
+                        "the repository could not be read"
+                    )
+                reason = ingestion_errors[-1]
+                # Code-only: the repo was the entire scan. Reporting "no
+                # findings" here would read as a clean bill of health for
+                # code we never opened (issue #147).
+                if mode is ScanMode.CODE_ONLY:
+                    yield DeepScanEvent(
+                        DeepScanPhase.COMPLETE,
+                        OrchestratorConfig.ERROR_REPO_FAILED.format(
+                            error=reason
+                        ),
+                        data={"error": True},
+                    )
+                    return
+                # Full scan: the live-site half is still real, so finish it —
+                # but the report has to say the code was never scanned.
+                yield DeepScanEvent(
+                    DeepScanPhase.CODE_INGESTION,
+                    OrchestratorConfig.ERROR_REPO_FAILED.format(error=reason),
+                    OrchestratorConfig.PROGRESS_CODE_INGESTION,
+                    data={"error": True},
+                )
 
         # ==============================================================
         # Phase 6.5: LSP Initialization (optional — graceful degradation)
@@ -1010,6 +1051,7 @@ class DeepSecurityScanAgent:
             idor_results=idor_results,
             scan_duration_seconds=round(duration, 2),
             scanners_run=scanners_run,
+            ingestion_errors=ingestion_errors,
             themes=themes,
             token_usage=self._collect_token_usage(),
         )
@@ -2232,17 +2274,23 @@ class DeepSecurityScanAgent:
             )
             return None
 
-    async def _ingest_repo(self, repo_url: str, github_token: str | None = None) -> RepoSnapshot | None:
-        """Ingest a repository using the repo ingestion service."""
+    async def _ingest_repo(
+        self,
+        repo_url: str,
+        github_token: str | None = None,
+        branch: str | None = None,
+    ) -> RepoSnapshot | None:
+        """Ingest a repository using the repo ingestion service.
+
+        Lets the ingestion service's failure propagate: the caller decides
+        whether it ends the scan or merely degrades it, and it needs the
+        reason to say which (issue #147).
+        """
         if not self._repo_ingestion:
             return None
-        try:
-            return await self._repo_ingestion.ingest(repo_url, github_token=github_token)
-        except Exception as e:
-            logger.error(
-                OrchestratorConfig.ERROR_REPO_FAILED.format(error=e),
-            )
-            return None
+        return await self._repo_ingestion.ingest(
+            repo_url, branch=branch, github_token=github_token
+        )
 
     def _build_category_summary(self, endpoints: list[DiscoveredEndpoint]) -> dict:
         """Build a summary of endpoint categories."""

--- a/isitsecure/engine/code_analysis/repo_ingestion.py
+++ b/isitsecure/engine/code_analysis/repo_ingestion.py
@@ -75,11 +75,16 @@ class RepoIngestionService:
     async def ingest(
         self,
         repo_url: str,
-        branch: str = "main",
+        branch: str | None = None,
         github_token: str | None = None,
         full_history: bool = False,
     ) -> RepoSnapshot:
         """Clone a repo and return an indexed RepoSnapshot.
+
+        Args:
+            branch: Branch to scan.  ``None`` (the default) means the
+                remote's own default branch — assuming ``main`` made every
+                ``master``-default repository unscannable (issue #147).
 
         Steps:
             1. Create temp directory and git clone
@@ -98,6 +103,13 @@ class RepoIngestionService:
 
             # Capture the exact commit hash for the report
             commit_hash = await self._get_commit_hash(clone_dir)
+
+            # Report the branch we actually got, not the one we asked for:
+            # `branch=None` resolves to the remote's default, and a local
+            # directory is copied as-is regardless of what was requested.
+            resolved_branch = (
+                await self._get_branch_name(clone_dir) or branch or ""
+            )
 
             # Detect workspaces (monorepo support)
             workspaces = []
@@ -135,7 +147,7 @@ class RepoIngestionService:
 
             return RepoSnapshot(
                 repo_url=repo_url,
-                branch=branch,
+                branch=resolved_branch,
                 commit_hash=commit_hash,
                 clone_path=clone_dir,
                 framework=framework,
@@ -318,10 +330,13 @@ class RepoIngestionService:
     _SCP_LIKE = re.compile(r"^[\w.-]+@[\w.-]+:")   # git@host:path
 
     @classmethod
-    def _validate_remote(cls, url: str, branch: str) -> None:
+    def _validate_remote(cls, url: str, branch: str | None) -> None:
         """Reject repository URLs/branches that could inject git options or
         reach unsafe transports (ext::/fd:: run commands; file:// reads local)."""
-        for label, value in (("repository URL", url), ("branch", branch)):
+        checks = [("repository URL", url)]
+        if branch is not None:
+            checks.append(("branch", branch))
+        for label, value in checks:
             if value.startswith("-"):
                 raise RuntimeError(f"Refusing {label} that begins with '-'.")
         lowered = url.lower()
@@ -336,7 +351,7 @@ class RepoIngestionService:
     async def _clone_repo(
         self,
         repo_url: str,
-        branch: str,
+        branch: str | None,
         clone_path: str,
         github_token: str | None,
         full_history: bool,
@@ -374,8 +389,10 @@ class RepoIngestionService:
         cmd = ["git", "clone"]
         if not full_history:
             cmd.extend(["--depth", "1"])
+        if branch:
+            cmd.extend(["--branch", branch])
         # "--" ends option parsing so the URL/path can't be read as flags.
-        cmd.extend(["--branch", branch, "--", url, clone_path])
+        cmd.extend(["--", url, clone_path])
         # Restrict git to safe transports; never prompt for credentials.
         env = {
             **os.environ,
@@ -400,9 +417,15 @@ class RepoIngestionService:
                 if github_token:
                     error_msg = error_msg.replace(github_token, "***")
                 if "not found" in error_msg.lower():
+                    # Without an explicit branch we never asked git for one,
+                    # so this is the repository missing, not the branch.
                     raise RuntimeError(
                         RepoIngestionConfig.ERROR_BRANCH_NOT_FOUND.format(
                             branch=branch
+                        )
+                        if branch
+                        else RepoIngestionConfig.ERROR_REPO_NOT_FOUND.format(
+                            repo_url=repo_url
                         )
                     )
                 raise RuntimeError(
@@ -451,6 +474,30 @@ class RepoIngestionService:
             )
             if process.returncode == 0:
                 return stdout.decode().strip()
+        except Exception:
+            pass
+        return ""
+
+    @staticmethod
+    async def _get_branch_name(clone_path: str) -> str:
+        """Read the checked-out branch name from a cloned repo.
+
+        Returns ``""`` for a detached HEAD, a non-git directory, or any git
+        failure — callers fall back to whatever branch was requested.
+        """
+        try:
+            process = await asyncio.create_subprocess_exec(
+                "git", "rev-parse", "--abbrev-ref", "HEAD",
+                cwd=clone_path,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            stdout, _ = await asyncio.wait_for(
+                process.communicate(), timeout=5
+            )
+            if process.returncode == 0:
+                name = stdout.decode().strip()
+                return "" if name == "HEAD" else name
         except Exception:
             pass
         return ""

--- a/isitsecure/engine/constants.py
+++ b/isitsecure/engine/constants.py
@@ -621,6 +621,12 @@ class RepoIngestionConfig:
     ERROR_CLONE_TIMEOUT = "Repository clone timed out after {timeout}s"
     ERROR_REPO_TOO_LARGE = "Repository exceeds maximum size of {max_size}MB"
     ERROR_BRANCH_NOT_FOUND = "Branch '{branch}' not found in repository"
+    # With no branch requested we clone the remote's default, so git's "not
+    # found" is about the repository itself — saying "branch 'main'" there
+    # sent people looking for the wrong problem (issue #147).
+    ERROR_REPO_NOT_FOUND = (
+        "Repository not found (or not accessible): {repo_url}"
+    )
 
 
 class FrameworkDetectorConfig:

--- a/isitsecure/engine/models.py
+++ b/isitsecure/engine/models.py
@@ -296,6 +296,11 @@ class DeepScanReport(BaseModel):
     scan_duration_seconds: float = 0.0
     scanners_run: list[str] = Field(default_factory=list)
 
+    # What we could not read. A repo that failed to clone used to produce a
+    # clean-looking report with zero findings, which reads as "you're fine"
+    # rather than "we never saw your code" (issue #147).
+    ingestion_errors: list[str] = Field(default_factory=list)
+
     # Thematic grouping of findings
     themes: list[SecurityTheme] = Field(default_factory=list)
 

--- a/isitsecure/server/app.py
+++ b/isitsecure/server/app.py
@@ -59,7 +59,7 @@ class ScanRequest(BaseModel):
     target_url: Optional[str] = None
     repo_url: Optional[str] = None
     github_token: Optional[str] = None
-    branch: str = "main"
+    branch: Optional[str] = None  # None = the repository's default branch
     scan_mode: Optional[str] = None
     auth_email: Optional[str] = None
     auth_password: Optional[str] = None
@@ -538,6 +538,7 @@ async def _run_scan_background(scan_id: str, request: ScanRequest) -> None:
             github_token=request.github_token,
             credentials_a=credentials_a,
             scan_mode=scan_mode,
+            repo_branch=request.branch,
         ):
             phase = getattr(event, "phase", "")
             message = getattr(event, "message", "")

--- a/tests/engine/test_code_analysis/test_repo_ingestion.py
+++ b/tests/engine/test_code_analysis/test_repo_ingestion.py
@@ -173,3 +173,141 @@ class TestRepoIngestionService:
         """Should return empty list when no .env files exist."""
         result = self.service._find_env_files(str(tmp_path))
         assert result == []
+
+
+# ---------------------------------------------------------------------------
+# #147 — branch selection
+# ---------------------------------------------------------------------------
+
+
+class _FakeProcess:
+    """Stand-in for the git subprocess, with a scripted result."""
+
+    def __init__(self, returncode: int = 0, stderr: bytes = b"") -> None:
+        self.returncode = returncode
+        self._stderr = stderr
+
+    async def communicate(self):
+        return b"", self._stderr
+
+
+class TestBranchSelection:
+    """The branch a scan reads must be the one the caller asked for — and,
+    when they asked for nothing, the repository's own default rather than an
+    assumed ``main`` (issue #147)."""
+
+    def setup_method(self) -> None:
+        self.service = RepoIngestionService(
+            framework_detector=FrameworkDetector(), route_mappers=[],
+        )
+
+    async def _clone_argv(self, monkeypatch, branch, returncode=0, stderr=b""):
+        """Run _clone_repo against a stubbed git and return its argv."""
+        captured: list[str] = []
+
+        async def fake_exec(*cmd, **_kwargs):
+            captured.extend(cmd)
+            return _FakeProcess(returncode, stderr)
+
+        monkeypatch.setattr(
+            "isitsecure.engine.code_analysis.repo_ingestion."
+            "asyncio.create_subprocess_exec",
+            fake_exec,
+        )
+        await self.service._clone_repo(
+            "https://github.com/org/repo", branch, "/tmp/clone", None, False
+        )
+        return captured
+
+    @pytest.mark.asyncio
+    async def test_no_branch_lets_git_pick_the_default(self, monkeypatch) -> None:
+        """Without --branch, git clones the remote's own default branch."""
+        argv = await self._clone_argv(monkeypatch, None)
+        assert "--branch" not in argv
+        assert "main" not in argv
+
+    @pytest.mark.asyncio
+    async def test_explicit_branch_is_passed_to_git(self, monkeypatch) -> None:
+        argv = await self._clone_argv(monkeypatch, "master")
+        assert argv[argv.index("--branch") + 1] == "master"
+
+    @pytest.mark.asyncio
+    async def test_url_still_terminated_by_double_dash(self, monkeypatch) -> None:
+        """The arg-injection guard survives the branch becoming optional."""
+        argv = await self._clone_argv(monkeypatch, None)
+        assert argv[argv.index("--") + 1] == "https://github.com/org/repo"
+
+    @pytest.mark.asyncio
+    async def test_missing_branch_is_reported_as_a_branch_problem(
+        self, monkeypatch
+    ) -> None:
+        with pytest.raises(RuntimeError, match="Branch 'nope' not found"):
+            await self._clone_argv(
+                monkeypatch, "nope", returncode=1, stderr=b"remote branch not found",
+            )
+
+    @pytest.mark.asyncio
+    async def test_missing_repo_is_not_blamed_on_a_branch(
+        self, monkeypatch
+    ) -> None:
+        """We asked git for no branch, so 'not found' is about the repo —
+        blaming a branch nobody requested is what sent people astray."""
+        with pytest.raises(RuntimeError) as exc:
+            await self._clone_argv(
+                monkeypatch, None, returncode=1, stderr=b"repository not found",
+            )
+        assert "Branch" not in str(exc.value)
+        assert "https://github.com/org/repo" in str(exc.value)
+
+    @pytest.mark.asyncio
+    async def test_snapshot_records_the_branch_actually_checked_out(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """`branch=None` must not leave the snapshot claiming 'main'."""
+        (tmp_path / "package.json").write_text("{}")
+        monkeypatch.setattr(
+            RepoIngestionService, "_get_branch_name",
+            AsyncMock(return_value="develop"),
+        )
+        with patch.object(self.service, "_clone_repo", new_callable=AsyncMock):
+            with patch(
+                "isitsecure.engine.code_analysis.repo_ingestion.tempfile"
+            ) as mock_tmp:
+                mock_tmp.mkdtemp.return_value = str(tmp_path)
+                snapshot = await self.service.ingest(
+                    repo_url="https://github.com/org/repo",
+                )
+        assert snapshot.branch == "develop"
+
+    @pytest.mark.asyncio
+    async def test_requested_branch_is_the_fallback_when_git_cannot_answer(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        (tmp_path / "package.json").write_text("{}")
+        monkeypatch.setattr(
+            RepoIngestionService, "_get_branch_name", AsyncMock(return_value=""),
+        )
+        with patch.object(self.service, "_clone_repo", new_callable=AsyncMock):
+            with patch(
+                "isitsecure.engine.code_analysis.repo_ingestion.tempfile"
+            ) as mock_tmp:
+                mock_tmp.mkdtemp.return_value = str(tmp_path)
+                snapshot = await self.service.ingest(
+                    repo_url="https://github.com/org/repo", branch="release",
+                )
+        assert snapshot.branch == "release"
+
+    def test_validate_remote_still_rejects_option_like_branches(self) -> None:
+        with pytest.raises(RuntimeError, match="branch"):
+            RepoIngestionService._validate_remote(
+                "https://github.com/org/repo", "--upload-pack=evil",
+            )
+
+    def test_validate_remote_accepts_no_branch(self) -> None:
+        RepoIngestionService._validate_remote(
+            "https://github.com/org/repo", None,
+        )  # must not raise
+
+    def test_validate_remote_still_rejects_unsafe_transports(self) -> None:
+        with pytest.raises(RuntimeError):
+            RepoIngestionService._validate_remote("ext::sh -c evil", None)

--- a/tests/engine/test_orchestrator.py
+++ b/tests/engine/test_orchestrator.py
@@ -578,3 +578,105 @@ class TestSeverityOrder:
     def test_boosted_info_info(self) -> None:
         result = _SeverityOrder.boosted(SeverityLevel.INFO, SeverityLevel.INFO)
         assert result == SeverityLevel.LOW
+
+
+# ===========================================================================
+# #147 — a repo we couldn't read must not read as a clean scan
+# ===========================================================================
+
+class TestRepoIngestionFailures:
+    """A failed clone used to log an error and return a zero-finding report,
+    which in CI is indistinguishable from "your code is fine"."""
+
+    @pytest.mark.asyncio
+    async def test_branch_is_passed_to_the_ingestion_service(self) -> None:
+        repo_ingestion = AsyncMock()
+        repo_ingestion.ingest.return_value = MagicMock(
+            branch="release", commit_hash="abc123",
+        )
+        agent = _make_mock_agent(repo_ingestion_service=repo_ingestion)
+
+        await _collect_events(agent.scan(
+            repo_url="https://github.com/org/repo",
+            scan_mode=ScanMode.CODE_ONLY,
+            repo_branch="release",
+        ))
+
+        assert repo_ingestion.ingest.await_args.kwargs["branch"] == "release"
+
+    @pytest.mark.asyncio
+    async def test_no_branch_requested_stays_none(self) -> None:
+        """None must reach the service so it can use the remote's default —
+        substituting 'main' here is the bug."""
+        repo_ingestion = AsyncMock()
+        repo_ingestion.ingest.return_value = MagicMock(
+            branch="master", commit_hash="abc123",
+        )
+        agent = _make_mock_agent(repo_ingestion_service=repo_ingestion)
+
+        await _collect_events(agent.scan(
+            repo_url="https://github.com/org/repo", scan_mode=ScanMode.CODE_ONLY,
+        ))
+
+        assert repo_ingestion.ingest.await_args.kwargs["branch"] is None
+
+    @pytest.mark.asyncio
+    async def test_code_only_failure_ends_the_scan_with_an_error(self) -> None:
+        repo_ingestion = AsyncMock()
+        repo_ingestion.ingest.side_effect = RuntimeError(
+            "Branch 'nope' not found in repository"
+        )
+        agent = _make_mock_agent(repo_ingestion_service=repo_ingestion)
+
+        events = await _collect_events(agent.scan(
+            repo_url="https://github.com/org/repo", scan_mode=ScanMode.CODE_ONLY,
+        ))
+
+        final = events[-1]
+        assert final.phase == DeepScanPhase.COMPLETE
+        assert final.data.get("error") is True
+        # No report at all — better than a clean-looking empty one.
+        assert "report" not in final.data
+        assert "nope" in final.message
+
+    @pytest.mark.asyncio
+    async def test_full_scan_keeps_dast_findings_but_records_the_failure(
+        self,
+    ) -> None:
+        """The live-site half is still real, so don't throw it away — but the
+        report has to admit the code was never scanned."""
+        repo_ingestion = AsyncMock()
+        repo_ingestion.ingest.side_effect = RuntimeError("Repository not found")
+
+        xss = AsyncMock()
+        xss.scanner_name = "xss"
+        xss.scan.return_value = [_make_dast_finding()]
+
+        agent = _make_mock_agent(
+            endpoints=[DiscoveredEndpoint(url="https://example.com/api/users")],
+            dast_scanners=[xss],
+            repo_ingestion_service=repo_ingestion,
+        )
+        events = await _collect_events(agent.scan(
+            target_url="https://example.com",
+            repo_url="https://github.com/org/repo",
+            scan_mode=ScanMode.FULL,
+        ))
+
+        report = events[-1].data["report"]
+        assert report["ingestion_errors"] == ["Repository not found"]
+        assert len(report["findings"]) == 1  # the DAST half survived
+
+    @pytest.mark.asyncio
+    async def test_successful_scan_records_no_ingestion_errors(self) -> None:
+        repo_ingestion = AsyncMock()
+        repo_ingestion.ingest.return_value = MagicMock(
+            branch="main", commit_hash="abc123",
+        )
+        agent = _make_mock_agent(repo_ingestion_service=repo_ingestion)
+
+        events = await _collect_events(agent.scan(
+            repo_url="https://github.com/org/repo", scan_mode=ScanMode.CODE_ONLY,
+        ))
+
+        assert events[-1].data["report"]["ingestion_errors"] == []

--- a/tests/test_cli_onboarding.py
+++ b/tests/test_cli_onboarding.py
@@ -295,3 +295,82 @@ def test_missing_npm_gives_guidance_instead_of_installing(monkeypatch, tmp_path)
     out, calls = _run_ensure_runtime(monkeypatch, tmp_path, runtime=None, npm=False)
     assert calls == []
     assert "ISITSECURE_TSSERVER_PATH" in out
+
+
+# ---------------------------------------------------------------------------
+# #147 — a scan that couldn't read the code must not exit clean
+# ---------------------------------------------------------------------------
+
+def _run_scan_cli(monkeypatch, report, argv):
+    """Invoke `scan` with the engine stubbed out; return (exit_code, stderr)."""
+    import io
+
+    from rich.console import Console
+    from typer.testing import CliRunner
+
+    monkeypatch.setattr(cli, "_print_welcome", lambda: None)
+    monkeypatch.setattr(cli, "_preflight_checks", lambda *a, **k: None)
+    buf = io.StringIO()
+    monkeypatch.setattr(cli, "err_console", Console(file=buf, force_terminal=False))
+    monkeypatch.setattr(cli, "console", Console(file=buf, force_terminal=False))
+
+    import isitsecure.engine.factory as factory
+    monkeypatch.setattr(factory, "create_repo_ingestion_service", lambda *a, **k: None)
+    monkeypatch.setattr(
+        factory, "create_deep_security_scan_agent", lambda *a, **k: object()
+    )
+
+    async def fake_run_scan(agent, **kwargs):
+        return report
+
+    monkeypatch.setattr(cli, "_run_scan", fake_run_scan)
+
+    result = CliRunner().invoke(cli.app, argv)
+    return result.exit_code, buf.getvalue()
+
+
+def _empty_report(**kwargs):
+    from isitsecure.engine.models import DeepScanReport
+    return DeepScanReport(scan_mode="full", **kwargs)
+
+
+def test_scan_exits_nonzero_when_the_repo_could_not_be_read(monkeypatch, tmp_path):
+    # A partial scan that reports zero code findings reads as "your code is
+    # fine" in CI. It has to say the code was never scanned, and exit non-zero.
+    report = _empty_report(
+        ingestion_errors=["Repository not found (or not accessible): git@x/y"],
+    )
+    code, out = _run_scan_cli(
+        monkeypatch, report,
+        ["scan", "https://example.com", "--repo", "git@x/y", "--llm", "none",
+         "--output", "json", "--output-file", str(tmp_path / "r.json")],
+    )
+    assert code == 1
+    assert "Repository not found" in out
+    assert "not scanned" in out
+
+
+def test_failed_ingestion_is_recorded_in_the_report_itself(monkeypatch, tmp_path):
+    """Not just on the terminal — a saved report has to carry the caveat."""
+    import json
+
+    out_file = tmp_path / "r.json"
+    _run_scan_cli(
+        monkeypatch,
+        _empty_report(ingestion_errors=["Repository not found"]),
+        ["scan", "https://example.com", "--repo", "git@x/y", "--llm", "none",
+         "--output", "json", "--output-file", str(out_file)],
+    )
+    assert json.loads(out_file.read_text())["ingestion_errors"] == [
+        "Repository not found"
+    ]
+
+
+def test_scan_exits_clean_when_nothing_failed(monkeypatch, tmp_path):
+    code, out = _run_scan_cli(
+        monkeypatch, _empty_report(),
+        ["scan", "https://example.com", "--llm", "none",
+         "--output", "json", "--output-file", str(tmp_path / "r.json")],
+    )
+    assert code == 0
+    assert "not scanned" not in out


### PR DESCRIPTION
Fixes #147.

## Root cause

`--branch` was declared on `scan` and read by nothing — `grep -n branch isitsecure/cli.py` returned only the option declaration itself. The value never reached `RepoIngestionService.ingest`, so **every repo scan cloned `main`**. Any repository whose default branch is `master` couldn't be scanned at all, and passing the right branch explicitly didn't help either. `ScanRequest.branch` on the HTTP API was dead in exactly the same way.

## What changed

**The branch is threaded through** — `cli` → `agent.scan(repo_branch=…)` → `_ingest_repo` → `ingest(branch=…)`, and the same on `server/app.py`.

**"No branch given" now means the remote's own default**, not an assumed `main`: the clone omits `--branch` and lets git choose, which costs no extra round trip and requires no guessing. The snapshot then records the branch *actually checked out* rather than the one requested, so `repo_branch` is ground truth — and empty for a local directory copy, where a branch never applied.

Two things fall out of that:

- git's "not found" is no longer blamed on a branch nobody asked for. With no `--branch`, that error is about the repository, and the message says so.
- The arg-injection guard still validates a branch when there is one, and skips the check rather than crashing on `None` — with a test, so making the branch optional can't quietly disarm it.

**A failed clone no longer reports a clean scan.** This was the more expensive half: a zero-finding report is indistinguishable from "your code is fine" in CI.

- **code-only** — the repo *was* the entire scan, so it stops with the real reason and exits 1, rather than emitting a clean-looking empty report.
- **full** — the live-site half is genuine, so it finishes, but the reason lands in a new `DeepScanReport.ingestion_errors`, the CLI says the code was not scanned, and it exits 1.
- `_run_scan` reports *why* it produced nothing instead of "something went wrong along the way".

## Verification

| Check | Result |
|---|---|
| Unit tests | 2234 passed, 1 xfailed (+18 new) |
| sast-injection benchmark | 46/46 taint recall, 0 false positives |
| VAmPI benchmark | 3/3 recall |
| The reported repro (juice-shop, no `--branch`) | clones `master`, records `branch='master'`, **198 findings** — matches a local clone of the same tree |
| Explicit `-b v18.0.0` | reaches that ref — 237 findings |
| Bad branch, code-only | exit **1**, `Branch 'no-such-branch' not found in repository` |
| Bad branch, full mode (live vs VAmPI) | exit **1**, 10 DAST findings kept, SAST correctly absent, `ingestion_errors` populated |
| Local path, no branch | 114 findings — matches baseline exactly; `repo_branch=''` |

MCP was worth checking, since it also calls `agent.scan`: it only scans local paths (branch is moot) and already handled a `None` report with an explicit error, so it gets stricter rather than broken.

## Docs

`README.md` (the `--branch` default, and a note that `scan` exits 1 when something it was asked to scan couldn't be read) and `docs/architecture.md` (a "repo fails to clone" row in the degradation table).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EZ4QoTqRoYWE25CNoV2Wfy
