### PR TITLE
test(orchestrator): stop the scan tests reaching the live internet

### DIFF
--- a/tests/engine/test_orchestrator.py
+++ b/tests/engine/test_orchestrator.py
@@ -20,6 +20,59 @@ from isitsecure.engine.models import (
     FindingSource,
 )
 from isitsecure.engine.enums import FindingCategory, SeverityLevel
+from isitsecure.engine.scanners.dom_xss_scanner import DOMXSSScanner
+
+
+# ---------------------------------------------------------------------------
+# Keep these tests off the network
+# ---------------------------------------------------------------------------
+
+
+class _StubOOBCallbackService:
+    """OOB service that never registers, so both OOB phases no-op."""
+
+    is_registered = False
+
+    async def register(self) -> bool:
+        return False
+
+
+class _StubDOMXSSScanner:
+    """DOM XSS scanner that finds nothing without launching a browser.
+
+    Keeps the real scanner name so the phase still records itself in
+    ``scanners_run`` exactly as a live run would.
+    """
+
+    SCANNER_NAME = DOMXSSScanner.SCANNER_NAME
+
+    async def scan(self, **_kwargs) -> list:
+        return []
+
+
+@pytest.fixture(autouse=True)
+def stub_networked_scanners(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Stop ``scan()`` reaching the live internet from a unit test.
+
+    ``scan()`` constructs the OOB callback service and the DOM XSS scanner
+    itself, so there is no seam to inject through — and un-stubbed, every test
+    that drives it registered a real session against the production
+    oob.isitsecure.ai and launched a real Playwright browser against
+    example.com. That cost ~58s per test, ~5 of the suite's 7 minutes, and made
+    these tests fail whenever the OOB host was unreachable.
+
+    Neither collaborator is what this module covers: the OOB service (including
+    the agent's own ``_inject_oob_payloads``) is tested in
+    ``test_oob_callback.py``, and DOM XSS in ``test_dom_xss_scanner.py``.
+    """
+    monkeypatch.setattr(
+        "isitsecure.engine.shared.oob_callback.OOBCallbackService",
+        _StubOOBCallbackService,
+    )
+    monkeypatch.setattr(
+        "isitsecure.engine.scanners.dom_xss_scanner.DOMXSSScanner",
+        _StubDOMXSSScanner,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -214,6 +267,21 @@ class TestDeepSecurityScanAgent:
         report = final.data["report"]
         assert "xss_scanner" in report["scanners_run"]
         assert len(report["findings"]) >= 1
+
+    @pytest.mark.asyncio
+    async def test_dom_xss_phase_runs_on_a_url_only_scan(self) -> None:
+        """The DOM XSS phase must still execute, browser or not.
+
+        Also guards ``stub_networked_scanners``: a stub that skipped the phase
+        instead of standing in for it would make these tests fast and wrong.
+        """
+        agent = _make_mock_agent(
+            endpoints=[DiscoveredEndpoint(url="https://example.com/api/users")],
+        )
+        events = await _collect_events(agent.scan(target_url="https://example.com"))
+
+        report = events[-1].data["report"]
+        assert DOMXSSScanner.SCANNER_NAME in report["scanners_run"]
 
     @pytest.mark.asyncio
     async def test_sast_scanners_run_for_code_only(self) -> None:


### PR DESCRIPTION
## The problem

Every test that drove `agent.scan()` took **~58 seconds**, and not because the suite is slow — because it was doing real I/O. A trace of one test:

```
   0.6s  POST http://oob.isitsecure.ai/register  200 OK      ← the live production host
   0.6s → 46.6s   DOMXSSScanner: real Playwright browser vs example.com
  46.6s → 58.7s   3× GET oob.isitsecure.ai/poll, with sleeps between
```

Five such tests, ~5 of the suite's 7 minutes, on every CI run across four Python versions. And they'd fail outright any time that host was unreachable — a unit suite with a network dependency on a production service.

`scan()` constructs both collaborators inline, so there was no seam to inject through; the tests couldn't opt out of either.

## The fix

An autouse fixture stubbing both. **No production code changed.**

The pattern already existed in this repo — `test_infra_fingerprint.py` drives the same `scan()` in 0.28s precisely because it stubs `OOBCallbackService` and empties the DOM XSS page list. This hoists it into a fixture rather than inventing anything, and applies it by default instead of per test.

One deliberate difference from that precedent: the DOM XSS stub keeps the **real** `SCANNER_NAME` and returns no findings, so the phase still runs end to end — construction, `run_scanner_safe`, the timeout wrapper, the `scanners_run` append — and a stubbed report still lists `dom_xss_scanner` exactly as a live one does. Skipping the phase would have been faster to write and quietly wrong, so `test_dom_xss_phase_runs_on_a_url_only_scan` holds that line.

The OOB stub reports `is_registered=False`, which costs no coverage: `_inject_oob_payloads` has its own five tests in `test_oob_callback.py`, and with zero interactions the live run never appended `oob_callback` to `scanners_run` either — so report content is unchanged.

## Results

| | Before | After |
|---|---:|---:|
| `test_orchestrator.py` | 290s | **1.46s** |
| Slowest test in the file | 58.3s | 0.22s |
| Full suite | 419s | **132s** |
| Outbound connections from this module | real POST + 3× GET to `oob.isitsecure.ai` | **0** |
| Tests | 2234 pass | **2235 pass** (+1 guard), 1 xfailed |

## Not addressed here

The remaining slow tests are a legitimately different class — they test the scanners themselves (`test_dom_xss_scanner.py` 28.5s, `test_rate_limit_scanner.py` ~60s across four tests). Rate-limit logic is mostly `asyncio.sleep`, so a time-mock would likely reclaim most of that; left for separate work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EZ4QoTqRoYWE25CNoV2Wfy
