### PR TITLE
refactor(cli): split cli.py into a package by concern

### DIFF
--- a/isitsecure/cli/__init__.py
+++ b/isitsecure/cli/__init__.py
@@ -1,0 +1,30 @@
+"""isitsecure CLI - AI-powered security scanner for modern web apps.
+
+Usage:
+    isitsecure scan https://myapp.com                          # URL-only DAST scan
+    isitsecure scan --repo github.com/me/app --mode code-only  # SAST only
+    isitsecure scan https://myapp.com --repo github.com/me/app --mode full  # Full scan
+    isitsecure launch                                          # Open web UI
+
+Split by concern: ``environment`` detects what is installed on the machine,
+``setup_lsp`` owns the ``setup`` command that acts on it, and ``main`` holds
+the remaining commands.
+
+This module is a façade over those: it exposes ``app`` for the entry point
+(``isitsecure.cli:app``) and the shared consoles, and nothing else. Reach into
+the owning module for anything internal — patching a name here would not
+affect the module that actually uses it.
+
+The command-module imports below are load-bearing, not incidental: importing
+them is what registers their commands on ``app``, and their order is the order
+``--help`` lists them in.
+"""
+
+from __future__ import annotations
+
+from isitsecure.cli import main as _main_module  # noqa: F401  (registers commands)
+from isitsecure.cli import setup_lsp as _setup_lsp_module  # noqa: F401  (registers `setup`)
+from isitsecure.cli._app import app
+from isitsecure.cli._io import console, err_console
+
+__all__ = ["app", "console", "err_console"]

--- a/isitsecure/cli/_app.py
+++ b/isitsecure/cli/_app.py
@@ -1,0 +1,17 @@
+"""The Typer application object.
+
+Its own module to break a cycle: command modules need ``app`` to register
+themselves with ``@app.command()``, and ``cli/__init__`` needs to import those
+command modules for the registration to happen. Importing ``app`` from here
+lets both sides do that without importing each other.
+"""
+
+from __future__ import annotations
+
+import typer
+
+app = typer.Typer(
+    name="isitsecure",
+    help="AI-powered security scanner for modern web apps. SAST + DAST + LLM review.",
+    no_args_is_help=True,
+)

--- a/isitsecure/cli/_io.py
+++ b/isitsecure/cli/_io.py
@@ -1,0 +1,17 @@
+"""The CLI's two Rich consoles.
+
+Kept in their own module so every command module shares one pair rather than
+constructing its own. Neither is given an explicit ``file``: Rich resolves
+``sys.stdout``/``sys.stderr`` at write time, which is what lets Typer's
+``CliRunner`` and pytest's ``capsys`` capture CLI output without either of
+them being rebound.
+"""
+
+from __future__ import annotations
+
+from rich.console import Console
+
+console = Console()
+# Decorative output (welcome banner, scan progress) goes to stderr so stdout
+# stays clean for piped data (JSON/SARIF/report bodies).
+err_console = Console(stderr=True)

--- a/isitsecure/cli/config.py
+++ b/isitsecure/cli/config.py
@@ -1,0 +1,24 @@
+"""Config-directory and API-key access for the CLI.
+
+Thin wrappers over ``isitsecure.config``, in their own module because both the
+scan commands and ``setup`` need them — the alternative was each defining its
+own copy.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from isitsecure.config import CONFIG_DIR, CONFIG_FILE, load_api_key
+
+__all__ = ["CONFIG_DIR", "CONFIG_FILE", "_ensure_config_dir", "_load_api_key"]
+
+
+def _ensure_config_dir() -> Path:
+    CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+    return CONFIG_DIR
+
+
+def _load_api_key(provider: str) -> str | None:
+    """Load API key from env, .env file, or config (see isitsecure.config)."""
+    return load_api_key(provider)

--- a/isitsecure/cli/environment.py
+++ b/isitsecure/cli/environment.py
@@ -1,0 +1,105 @@
+"""What is installed on this machine.
+
+Detection only — no installing, no reporting. ``setup_lsp`` acts on what this
+module finds, and the scan pre-flight warns about it; keeping the two apart
+means the "is it there?" checks can be reused (and stubbed) without dragging
+in the install machinery.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Optional
+
+# ---------------------------------------------------------------------------
+# Language-server (LSP) setup
+# ---------------------------------------------------------------------------
+
+# The scan auto-detects each language server via shutil.which; this table drives
+# `setup` installing/verifying them. `needs` is the tool that must be on PATH to
+# run `cmd` (None = uses the current interpreter's pip, always available).
+_LSP_SPECS = [
+    {
+        "lang": "Python",
+        "bins": ("pylsp", "pyright-langserver", "basedpyright-langserver"),
+        "runtime": (),
+        "needs": None,
+        "cmd": [sys.executable, "-m", "pip", "install", "python-lsp-server"],
+        "hint": "pip install python-lsp-server",
+    },
+    {
+        "lang": "TypeScript / JavaScript",
+        "bins": ("typescript-language-server",),
+        "runtime": ("node",),
+        "needs": "npm",
+        # No `typescript` here on purpose: `typescript@latest` is now 7.x (the
+        # Go rewrite), which ships no lib/tsserver.js and can't drive the
+        # language server. `_ensure_tsserver_runtime` provisions a private 5.x
+        # runtime instead of touching the user's global install (issue #145).
+        "cmd": ["npm", "install", "-g", "typescript-language-server"],
+        "hint": {
+            "macos": "install Node.js (`brew install node`), then re-run `isitsecure setup --lsp`",
+            "windows": "install Node.js (`winget install OpenJS.NodeJS` or nodejs.org), then re-run `isitsecure setup --lsp`",
+            "linux": "install Node.js (your package manager or nodejs.org), then re-run `isitsecure setup --lsp`",
+        },
+    },
+    {
+        "lang": "Java / Kotlin",
+        "bins": ("jdtls", "jdt-language-server"),
+        "runtime": ("java",),
+        "needs": "brew",
+        "cmd": ["brew", "install", "jdtls"],
+        "hint": {
+            "macos": "install a JDK (`brew install openjdk`) + jdtls — https://github.com/eclipse-jdtls/eclipse.jdt.ls#installation",
+            "windows": "install a JDK (`winget install Microsoft.OpenJDK`) + jdtls — https://github.com/eclipse-jdtls/eclipse.jdt.ls#installation",
+            "linux": "install a JDK + jdtls — https://github.com/eclipse-jdtls/eclipse.jdt.ls#installation",
+        },
+    },
+]
+
+
+def _os_key() -> str:
+    import os
+    if os.name == "nt":
+        return "windows"
+    return "macos" if sys.platform == "darwin" else "linux"
+
+
+def _os_hint(spec) -> str:
+    """The install hint for this OS (specs use a str or a per-OS dict)."""
+    hint = spec["hint"]
+    return hint if isinstance(hint, str) else hint.get(_os_key(), next(iter(hint.values())))
+
+
+def _resolve_install_cmd(cmd):
+    """Make an install command launchable across platforms.
+
+    Resolves argv[0] to its real path (so PATHEXT lookups like npm.cmd resolve),
+    and on Windows launches .cmd/.bat shims via ``cmd /c`` — CreateProcess can't
+    run those directly, which is why a bare ["npm", ...] fails on Windows.
+    """
+    import os
+    import shutil
+    exe = shutil.which(cmd[0]) or cmd[0]
+    if os.name == "nt" and exe.lower().endswith((".cmd", ".bat")):
+        return ["cmd", "/c", exe, *cmd[1:]]
+    return [exe, *cmd[1:]]
+
+
+def _first_which(bins) -> Optional[str]:
+    import shutil
+    for b in bins:
+        if shutil.which(b):
+            return b
+    return None
+
+
+def _chromium_installed() -> bool:
+    """True if Playwright's Chromium is installed (best effort, no launch)."""
+    try:
+        from playwright.sync_api import sync_playwright
+        with sync_playwright() as p:
+            return bool(p.chromium.executable_path) and Path(p.chromium.executable_path).exists()
+    except Exception:
+        return False

--- a/isitsecure/cli/main.py
+++ b/isitsecure/cli/main.py
@@ -17,21 +17,19 @@ from pathlib import Path
 from typing import Optional
 
 import typer
-from rich.console import Console
 from rich.panel import Panel
 from rich.table import Table
 
 from isitsecure import __version__
 
-app = typer.Typer(
-    name="isitsecure",
-    help="AI-powered security scanner for modern web apps. SAST + DAST + LLM review.",
-    no_args_is_help=True,
+from isitsecure.cli._app import app
+from isitsecure.cli._io import console, err_console
+from isitsecure.cli.environment import (
+    _LSP_SPECS,
+    _chromium_installed,
+    _first_which,
 )
-console = Console()
-# Decorative output (welcome banner, scan progress) goes to stderr so stdout
-# stays clean for piped data (JSON/SARIF/report bodies).
-err_console = Console(stderr=True)
+
 
 
 # ---------------------------------------------------------------------------
@@ -167,12 +165,7 @@ def _main(ctx: typer.Context) -> None:
 # Config management
 # ---------------------------------------------------------------------------
 
-from isitsecure.config import CONFIG_DIR, CONFIG_FILE, load_api_key
-
-
-def _ensure_config_dir() -> Path:
-    CONFIG_DIR.mkdir(parents=True, exist_ok=True)
-    return CONFIG_DIR
+from isitsecure.cli.config import _load_api_key
 
 
 def _drop_findings_from_themes(report, hidden_ids: set) -> None:
@@ -275,11 +268,6 @@ def _apply_trust_filters(
         err_console.print(
             f"[dim]{len(known)} known finding(s) hidden by baseline; showing {len(new)} new.[/dim]"
         )
-
-
-def _load_api_key(provider: str) -> str | None:
-    """Load API key from env, .env file, or config (see isitsecure.config)."""
-    return load_api_key(provider)
 
 
 # ---------------------------------------------------------------------------
@@ -904,6 +892,11 @@ def launch(
 
     # UI users start the UI from a terminal — offer the deeper-analysis setup
     # here so they get it too (interactive, one-time, skippable).
+    # Imported here, not at module scope: `setup_lsp` registers the `setup`
+    # command, and importing it before this module's own commands are defined
+    # would reorder them in `--help`.
+    from isitsecure.cli.setup_lsp import _lsp_offer
+
     _lsp_offer()
 
     console.print(Panel(
@@ -1428,99 +1421,6 @@ def mcp() -> None:
 # ---------------------------------------------------------------------------
 
 # ---------------------------------------------------------------------------
-# Language-server (LSP) setup
-# ---------------------------------------------------------------------------
-
-# The scan auto-detects each language server via shutil.which; this table drives
-# `setup` installing/verifying them. `needs` is the tool that must be on PATH to
-# run `cmd` (None = uses the current interpreter's pip, always available).
-_LSP_SPECS = [
-    {
-        "lang": "Python",
-        "bins": ("pylsp", "pyright-langserver", "basedpyright-langserver"),
-        "runtime": (),
-        "needs": None,
-        "cmd": [sys.executable, "-m", "pip", "install", "python-lsp-server"],
-        "hint": "pip install python-lsp-server",
-    },
-    {
-        "lang": "TypeScript / JavaScript",
-        "bins": ("typescript-language-server",),
-        "runtime": ("node",),
-        "needs": "npm",
-        # No `typescript` here on purpose: `typescript@latest` is now 7.x (the
-        # Go rewrite), which ships no lib/tsserver.js and can't drive the
-        # language server. `_ensure_tsserver_runtime` provisions a private 5.x
-        # runtime instead of touching the user's global install (issue #145).
-        "cmd": ["npm", "install", "-g", "typescript-language-server"],
-        "hint": {
-            "macos": "install Node.js (`brew install node`), then re-run `isitsecure setup --lsp`",
-            "windows": "install Node.js (`winget install OpenJS.NodeJS` or nodejs.org), then re-run `isitsecure setup --lsp`",
-            "linux": "install Node.js (your package manager or nodejs.org), then re-run `isitsecure setup --lsp`",
-        },
-    },
-    {
-        "lang": "Java / Kotlin",
-        "bins": ("jdtls", "jdt-language-server"),
-        "runtime": ("java",),
-        "needs": "brew",
-        "cmd": ["brew", "install", "jdtls"],
-        "hint": {
-            "macos": "install a JDK (`brew install openjdk`) + jdtls — https://github.com/eclipse-jdtls/eclipse.jdt.ls#installation",
-            "windows": "install a JDK (`winget install Microsoft.OpenJDK`) + jdtls — https://github.com/eclipse-jdtls/eclipse.jdt.ls#installation",
-            "linux": "install a JDK + jdtls — https://github.com/eclipse-jdtls/eclipse.jdt.ls#installation",
-        },
-    },
-]
-
-
-def _os_key() -> str:
-    import os
-    if os.name == "nt":
-        return "windows"
-    return "macos" if sys.platform == "darwin" else "linux"
-
-
-def _os_hint(spec) -> str:
-    """The install hint for this OS (specs use a str or a per-OS dict)."""
-    hint = spec["hint"]
-    return hint if isinstance(hint, str) else hint.get(_os_key(), next(iter(hint.values())))
-
-
-def _resolve_install_cmd(cmd):
-    """Make an install command launchable across platforms.
-
-    Resolves argv[0] to its real path (so PATHEXT lookups like npm.cmd resolve),
-    and on Windows launches .cmd/.bat shims via ``cmd /c`` — CreateProcess can't
-    run those directly, which is why a bare ["npm", ...] fails on Windows.
-    """
-    import os
-    import shutil
-    exe = shutil.which(cmd[0]) or cmd[0]
-    if os.name == "nt" and exe.lower().endswith((".cmd", ".bat")):
-        return ["cmd", "/c", exe, *cmd[1:]]
-    return [exe, *cmd[1:]]
-
-
-def _first_which(bins) -> Optional[str]:
-    import shutil
-    for b in bins:
-        if shutil.which(b):
-            return b
-    return None
-
-
-def _chromium_installed() -> bool:
-    """True if Playwright's Chromium is installed (best effort, no launch)."""
-    try:
-        from playwright.sync_api import sync_playwright
-        with sync_playwright() as p:
-            return bool(p.chromium.executable_path) and Path(p.chromium.executable_path).exists()
-    except Exception:
-        return False
-
-
-# ---------------------------------------------------------------------------
 # Smart first-run: pick the scan mode from what the user gave us (issue #56)
 # ---------------------------------------------------------------------------
 
@@ -1643,260 +1543,3 @@ def _preflight_checks(
         err_console.print()
 
 
-def _print_status_report() -> None:
-    """`setup --check`: report what's configured without changing anything."""
-    import shutil
-    console.print("\n[bold]isitsecure environment[/bold]")
-
-    key = _load_api_key("anthropic") or _load_api_key("google")
-    mark = "[green]✓[/green]" if key else "[yellow]•[/yellow]"
-    console.print(f"  {mark} LLM API key: "
-                  + ("configured" if key else "[dim]not set — rule-based scanning only[/dim]"))
-
-    browser = _chromium_installed()
-    mark = "[green]✓[/green]" if browser else "[yellow]•[/yellow]"
-    console.print(f"  {mark} DAST browser (Chromium): "
-                  + ("installed" if browser else "[dim]not installed — run `isitsecure setup`[/dim]"))
-
-    console.print("\n  [dim]Language servers (deeper code analysis, fewer false positives):[/dim]")
-    for spec in _LSP_SPECS:
-        found = _first_which(spec["bins"])
-        missing_rt = [r for r in spec["runtime"] if not shutil.which(r)]
-        if found and not missing_rt:
-            console.print(f"  [green]✓[/green] {spec['lang']}: [dim]{found}[/dim]")
-        elif found and missing_rt:
-            console.print(f"  [yellow]![/yellow] {spec['lang']}: {found} found, but "
-                          f"[dim]{', '.join(missing_rt)}[/dim] not on PATH to run it")
-        else:
-            console.print(f"  [yellow]•[/yellow] {spec['lang']}: [dim]not installed[/dim]")
-
-    if _first_which(("typescript-language-server",)):
-        from isitsecure.engine.code_analysis.lsp.tsserver_locator import (
-            find_tsserver_js,
-        )
-        tsserver = find_tsserver_js()
-        if tsserver:
-            console.print("  [green]✓[/green] TypeScript runtime (tsserver.js): "
-                          f"[dim]{tsserver}[/dim]")
-        else:
-            console.print("  [yellow]•[/yellow] TypeScript runtime (tsserver.js): "
-                          "[dim]missing — the TS language server can't start; "
-                          "run `isitsecure setup --lsp`[/dim]")
-    console.print("\n[dim]Install missing language servers with:[/dim] isitsecure setup --lsp")
-
-
-def _setup_lsps() -> None:
-    """Install any missing language servers we can, guide for the rest."""
-    import shutil
-    import subprocess
-    console.print("\n[bold]Language servers (LSP)[/bold] "
-                  "[dim]— trace auth flows, reduce false positives on code scans[/dim]")
-    for spec in _LSP_SPECS:
-        found = _first_which(spec["bins"])
-        if found:
-            console.print(f"  [green]✓[/green] {spec['lang']}: already installed [dim]({found})[/dim]")
-            continue
-        needs = spec["needs"]
-        if needs is not None and not shutil.which(needs):
-            console.print(f"  [yellow]•[/yellow] {spec['lang']}: [dim]{_os_hint(spec)}[/dim]")
-            continue
-        console.print(f"  [cyan]→[/cyan] {spec['lang']}: installing…")
-        try:
-            res = subprocess.run(
-                _resolve_install_cmd(spec["cmd"]),
-                capture_output=True, text=True, timeout=600,
-            )
-        except Exception as exc:
-            console.print(f"  [red]✗[/red] {spec['lang']}: {exc}")
-            console.print(f"      [dim]{_os_hint(spec)}[/dim]")
-            continue
-        if res.returncode == 0 and _first_which(spec["bins"]):
-            console.print(f"  [green]✓[/green] {spec['lang']}: installed")
-        else:
-            tail = (res.stderr or res.stdout or "install did not complete").strip().splitlines()
-            console.print(f"  [yellow]![/yellow] {spec['lang']}: {(tail[-1] if tail else '')[:120]}")
-            console.print(f"      [dim]{_os_hint(spec)}[/dim]")
-        missing_rt = [r for r in spec["runtime"] if not shutil.which(r)]
-        if missing_rt:
-            console.print(f"      [dim](also needs {', '.join(missing_rt)} on PATH to run)[/dim]")
-
-    _ensure_tsserver_runtime()
-
-
-def _ensure_tsserver_runtime() -> None:
-    """Make sure the TypeScript language server has a TypeScript to run.
-
-    typescript-language-server ships no TypeScript of its own and resolves it
-    from the workspace — but scans run against an ingested copy with no
-    ``node_modules``, so there is never one to find and the server refuses to
-    start. We install a private TypeScript 5.x under ``~/.isitsecure/lsp`` and
-    pass it as ``tsserver.path``; 5.x specifically, because ``typescript@latest``
-    is now the Go rewrite with no ``lib/tsserver.js`` (issue #145).
-    """
-    import shutil
-    import subprocess
-
-    from isitsecure.engine.code_analysis.lsp.tsserver_locator import (
-        PROVISIONED_ROOT,
-        TYPESCRIPT_PACKAGE_SPEC,
-        find_tsserver_js,
-    )
-
-    if not _first_which(("typescript-language-server",)):
-        return  # nothing to feed — the server itself isn't installed
-
-    found = find_tsserver_js()
-    if found:
-        console.print(f"  [green]✓[/green] TypeScript runtime: [dim]{found}[/dim]")
-        return
-
-    if not shutil.which("npm"):
-        console.print("  [yellow]![/yellow] TypeScript runtime: [dim]npm not on PATH — "
-                      f"install {TYPESCRIPT_PACKAGE_SPEC} and set "
-                      "ISITSECURE_TSSERVER_PATH to its lib/tsserver.js[/dim]")
-        return
-
-    console.print(f"  [cyan]→[/cyan] TypeScript runtime: installing {TYPESCRIPT_PACKAGE_SPEC}…")
-    try:
-        PROVISIONED_ROOT.mkdir(parents=True, exist_ok=True)
-        res = subprocess.run(
-            _resolve_install_cmd([
-                "npm", "install", "--prefix", str(PROVISIONED_ROOT),
-                TYPESCRIPT_PACKAGE_SPEC, "--no-audit", "--no-fund",
-            ]),
-            capture_output=True, text=True, timeout=600,
-        )
-    except Exception as exc:
-        console.print(f"  [red]✗[/red] TypeScript runtime: {exc}")
-        return
-
-    found = find_tsserver_js()
-    if res.returncode == 0 and found:
-        console.print("  [green]✓[/green] TypeScript runtime: installed "
-                      f"[dim]({found})[/dim]")
-    else:
-        tail = (res.stderr or res.stdout or "install did not complete").strip().splitlines()
-        console.print("  [yellow]![/yellow] TypeScript runtime: "
-                      f"{(tail[-1] if tail else '')[:120]}")
-        console.print("      [dim]Auth-flow tracing will fall back to regex-only analysis.[/dim]")
-
-
-def _lsp_offer() -> None:
-    """Offer, once, to install missing language servers.
-
-    Used by ``launch`` so UI users — who start the UI from a terminal — get the
-    same deeper-analysis setup. No-op when everything is ready, when running
-    non-interactively, or after the user has declined once.
-    """
-    missing = [s for s in _LSP_SPECS if not _first_which(s["bins"])]
-    if not missing or not sys.stdin.isatty():
-        return
-    marker = CONFIG_DIR / ".lsp_dismissed"
-    try:
-        if marker.exists():
-            return
-    except OSError:
-        pass
-
-    console.print(
-        "\n[bold]Enable deeper code analysis?[/bold] [dim](recommended)[/dim]\n"
-        "  isitsecure can trace how your code actually enforces login and\n"
-        "  permissions — catching more real issues and cutting false alarms on\n"
-        "  code scans. It installs a small language-analysis helper.\n"
-        f"  [dim]Not set up yet: {', '.join(s['lang'] for s in missing)}[/dim]"
-    )
-    if typer.confirm("Set it up now?", default=True):
-        _setup_lsps()
-    else:
-        try:
-            CONFIG_DIR.mkdir(parents=True, exist_ok=True)
-            marker.write_text("")  # remember the decline; don't nag on relaunch
-        except OSError:
-            pass
-        console.print(
-            "[dim]Skipped — set up any time with `isitsecure setup --lsp`.[/dim]"
-        )
-
-
-@app.command()
-def setup(
-    lsp: bool = typer.Option(
-        False, "--lsp", help="Only install/verify the code-analysis language servers"),
-    check: bool = typer.Option(
-        False, "--check", help="Report what's installed (API key, browser, LSP) — installs nothing"),
-) -> None:
-    """First-time setup — API key, DAST browser, and code-analysis language servers."""
-    _ensure_config_dir()
-
-    if check:
-        _print_status_report()
-        return
-
-    if lsp:
-        _setup_lsps()
-        console.print("\n[green]Language-server setup done.[/green]")
-        return
-
-    console.print(Panel(
-        "[bold]isitsecure setup[/bold]\n"
-        "Configure API keys, install the DAST browser, and set up language servers.",
-        border_style="bright_magenta",
-    ))
-
-    # API key
-    console.print("\n[bold]1. AI review key (optional, but recommended)[/bold]")
-    console.print("   With an AI key, isitsecure turns the report into plain English you")
-    console.print("   can actually read and gives you specific fix suggestions. Without")
-    console.print("   one, scans still run — you just get the raw findings.")
-    console.print("   [dim]Get a key at console.anthropic.com. It saves to "
-                  "~/.isitsecure/config.toml.[/dim]\n")
-
-    key = typer.prompt("Paste your Anthropic API key (or press Enter to skip)", default="", show_default=False)
-    if key:
-        import os
-        CONFIG_DIR.mkdir(parents=True, exist_ok=True)
-        # Escape for a TOML basic string so a stray quote/backslash in the key
-        # can't corrupt the file.
-        safe_key = key.replace("\\", "\\\\").replace('"', '\\"')
-        CONFIG_FILE.write_text(f'[llm]\nanthropic_api_key = "{safe_key}"\n')
-        # The file holds a secret — restrict it to the owner.
-        try:
-            os.chmod(CONFIG_DIR, 0o700)
-            os.chmod(CONFIG_FILE, 0o600)
-        except OSError:
-            pass
-        console.print("[green]Saved to ~/.isitsecure/config.toml (perms 0600)[/green]")
-
-    # Playwright
-    console.print("\n[bold]2. Browser for live-site testing[/bold]")
-    console.print("   isitsecure opens your website in a real browser to test it the way")
-    console.print("   an attacker would. This installs that browser (Chromium).")
-    install_browser = typer.confirm("Install it now?", default=True)
-    if install_browser:
-        import subprocess
-        console.print("Installing Chromium...")
-        result = subprocess.run(
-            [sys.executable, "-m", "playwright", "install", "chromium"],
-            capture_output=True,
-            text=True,
-        )
-        if result.returncode == 0:
-            console.print("[green]Chromium installed successfully[/green]")
-        else:
-            console.print(
-                "[red]The browser download didn't finish.[/red] "
-                "[dim]Live-site testing won't work until it's installed.[/dim]"
-            )
-            console.print("You can try again any time with: python -m playwright install chromium")
-            if result.stderr:
-                console.print(f"[dim]Details: {result.stderr.strip().splitlines()[-1][:200]}[/dim]")
-
-    # Language servers
-    console.print("\n[bold]3. Language servers (deeper code analysis)[/bold]")
-    console.print("   Let the scanner trace auth flows through your code and cut false")
-    console.print("   positives. Optional — scans still work with regex-based detection.")
-    if typer.confirm("Install/verify language servers now?", default=True):
-        _setup_lsps()
-
-    console.print("\n[green bold]Setup complete![/green bold]")
-    console.print("Run: isitsecure scan https://your-app.com")

--- a/isitsecure/cli/setup_lsp.py
+++ b/isitsecure/cli/setup_lsp.py
@@ -1,0 +1,286 @@
+"""The ``setup`` command: install and report on scan prerequisites.
+
+Acts on what ``environment`` detects — API key, DAST browser, language servers,
+and the TypeScript runtime the TS language server needs to start at all.
+"""
+
+from __future__ import annotations
+
+import sys
+
+import typer
+from rich.panel import Panel
+
+from isitsecure.cli._app import app
+from isitsecure.cli._io import console
+from isitsecure.cli.environment import (
+    _LSP_SPECS,
+    _chromium_installed,
+    _first_which,
+    _os_hint,
+    _resolve_install_cmd,
+)
+from isitsecure.cli.config import (
+    CONFIG_DIR,
+    CONFIG_FILE,
+    _ensure_config_dir,
+    _load_api_key,
+)
+
+def _print_status_report() -> None:
+    """`setup --check`: report what's configured without changing anything."""
+    import shutil
+    console.print("\n[bold]isitsecure environment[/bold]")
+
+    key = _load_api_key("anthropic") or _load_api_key("google")
+    mark = "[green]✓[/green]" if key else "[yellow]•[/yellow]"
+    console.print(f"  {mark} LLM API key: "
+                  + ("configured" if key else "[dim]not set — rule-based scanning only[/dim]"))
+
+    browser = _chromium_installed()
+    mark = "[green]✓[/green]" if browser else "[yellow]•[/yellow]"
+    console.print(f"  {mark} DAST browser (Chromium): "
+                  + ("installed" if browser else "[dim]not installed — run `isitsecure setup`[/dim]"))
+
+    console.print("\n  [dim]Language servers (deeper code analysis, fewer false positives):[/dim]")
+    for spec in _LSP_SPECS:
+        found = _first_which(spec["bins"])
+        missing_rt = [r for r in spec["runtime"] if not shutil.which(r)]
+        if found and not missing_rt:
+            console.print(f"  [green]✓[/green] {spec['lang']}: [dim]{found}[/dim]")
+        elif found and missing_rt:
+            console.print(f"  [yellow]![/yellow] {spec['lang']}: {found} found, but "
+                          f"[dim]{', '.join(missing_rt)}[/dim] not on PATH to run it")
+        else:
+            console.print(f"  [yellow]•[/yellow] {spec['lang']}: [dim]not installed[/dim]")
+
+    if _first_which(("typescript-language-server",)):
+        from isitsecure.engine.code_analysis.lsp.tsserver_locator import (
+            find_tsserver_js,
+        )
+        tsserver = find_tsserver_js()
+        if tsserver:
+            console.print("  [green]✓[/green] TypeScript runtime (tsserver.js): "
+                          f"[dim]{tsserver}[/dim]")
+        else:
+            console.print("  [yellow]•[/yellow] TypeScript runtime (tsserver.js): "
+                          "[dim]missing — the TS language server can't start; "
+                          "run `isitsecure setup --lsp`[/dim]")
+    console.print("\n[dim]Install missing language servers with:[/dim] isitsecure setup --lsp")
+
+
+def _setup_lsps() -> None:
+    """Install any missing language servers we can, guide for the rest."""
+    import shutil
+    import subprocess
+    console.print("\n[bold]Language servers (LSP)[/bold] "
+                  "[dim]— trace auth flows, reduce false positives on code scans[/dim]")
+    for spec in _LSP_SPECS:
+        found = _first_which(spec["bins"])
+        if found:
+            console.print(f"  [green]✓[/green] {spec['lang']}: already installed [dim]({found})[/dim]")
+            continue
+        needs = spec["needs"]
+        if needs is not None and not shutil.which(needs):
+            console.print(f"  [yellow]•[/yellow] {spec['lang']}: [dim]{_os_hint(spec)}[/dim]")
+            continue
+        console.print(f"  [cyan]→[/cyan] {spec['lang']}: installing…")
+        try:
+            res = subprocess.run(
+                _resolve_install_cmd(spec["cmd"]),
+                capture_output=True, text=True, timeout=600,
+            )
+        except Exception as exc:
+            console.print(f"  [red]✗[/red] {spec['lang']}: {exc}")
+            console.print(f"      [dim]{_os_hint(spec)}[/dim]")
+            continue
+        if res.returncode == 0 and _first_which(spec["bins"]):
+            console.print(f"  [green]✓[/green] {spec['lang']}: installed")
+        else:
+            tail = (res.stderr or res.stdout or "install did not complete").strip().splitlines()
+            console.print(f"  [yellow]![/yellow] {spec['lang']}: {(tail[-1] if tail else '')[:120]}")
+            console.print(f"      [dim]{_os_hint(spec)}[/dim]")
+        missing_rt = [r for r in spec["runtime"] if not shutil.which(r)]
+        if missing_rt:
+            console.print(f"      [dim](also needs {', '.join(missing_rt)} on PATH to run)[/dim]")
+
+    _ensure_tsserver_runtime()
+
+
+def _ensure_tsserver_runtime() -> None:
+    """Make sure the TypeScript language server has a TypeScript to run.
+
+    typescript-language-server ships no TypeScript of its own and resolves it
+    from the workspace — but scans run against an ingested copy with no
+    ``node_modules``, so there is never one to find and the server refuses to
+    start. We install a private TypeScript 5.x under ``~/.isitsecure/lsp`` and
+    pass it as ``tsserver.path``; 5.x specifically, because ``typescript@latest``
+    is now the Go rewrite with no ``lib/tsserver.js`` (issue #145).
+    """
+    import shutil
+    import subprocess
+
+    from isitsecure.engine.code_analysis.lsp.tsserver_locator import (
+        PROVISIONED_ROOT,
+        TYPESCRIPT_PACKAGE_SPEC,
+        find_tsserver_js,
+    )
+
+    if not _first_which(("typescript-language-server",)):
+        return  # nothing to feed — the server itself isn't installed
+
+    found = find_tsserver_js()
+    if found:
+        console.print(f"  [green]✓[/green] TypeScript runtime: [dim]{found}[/dim]")
+        return
+
+    if not shutil.which("npm"):
+        console.print("  [yellow]![/yellow] TypeScript runtime: [dim]npm not on PATH — "
+                      f"install {TYPESCRIPT_PACKAGE_SPEC} and set "
+                      "ISITSECURE_TSSERVER_PATH to its lib/tsserver.js[/dim]")
+        return
+
+    console.print(f"  [cyan]→[/cyan] TypeScript runtime: installing {TYPESCRIPT_PACKAGE_SPEC}…")
+    try:
+        PROVISIONED_ROOT.mkdir(parents=True, exist_ok=True)
+        res = subprocess.run(
+            _resolve_install_cmd([
+                "npm", "install", "--prefix", str(PROVISIONED_ROOT),
+                TYPESCRIPT_PACKAGE_SPEC, "--no-audit", "--no-fund",
+            ]),
+            capture_output=True, text=True, timeout=600,
+        )
+    except Exception as exc:
+        console.print(f"  [red]✗[/red] TypeScript runtime: {exc}")
+        return
+
+    found = find_tsserver_js()
+    if res.returncode == 0 and found:
+        console.print("  [green]✓[/green] TypeScript runtime: installed "
+                      f"[dim]({found})[/dim]")
+    else:
+        tail = (res.stderr or res.stdout or "install did not complete").strip().splitlines()
+        console.print("  [yellow]![/yellow] TypeScript runtime: "
+                      f"{(tail[-1] if tail else '')[:120]}")
+        console.print("      [dim]Auth-flow tracing will fall back to regex-only analysis.[/dim]")
+
+
+def _lsp_offer() -> None:
+    """Offer, once, to install missing language servers.
+
+    Used by ``launch`` so UI users — who start the UI from a terminal — get the
+    same deeper-analysis setup. No-op when everything is ready, when running
+    non-interactively, or after the user has declined once.
+    """
+    missing = [s for s in _LSP_SPECS if not _first_which(s["bins"])]
+    if not missing or not sys.stdin.isatty():
+        return
+    marker = CONFIG_DIR / ".lsp_dismissed"
+    try:
+        if marker.exists():
+            return
+    except OSError:
+        pass
+
+    console.print(
+        "\n[bold]Enable deeper code analysis?[/bold] [dim](recommended)[/dim]\n"
+        "  isitsecure can trace how your code actually enforces login and\n"
+        "  permissions — catching more real issues and cutting false alarms on\n"
+        "  code scans. It installs a small language-analysis helper.\n"
+        f"  [dim]Not set up yet: {', '.join(s['lang'] for s in missing)}[/dim]"
+    )
+    if typer.confirm("Set it up now?", default=True):
+        _setup_lsps()
+    else:
+        try:
+            CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+            marker.write_text("")  # remember the decline; don't nag on relaunch
+        except OSError:
+            pass
+        console.print(
+            "[dim]Skipped — set up any time with `isitsecure setup --lsp`.[/dim]"
+        )
+
+
+@app.command()
+def setup(
+    lsp: bool = typer.Option(
+        False, "--lsp", help="Only install/verify the code-analysis language servers"),
+    check: bool = typer.Option(
+        False, "--check", help="Report what's installed (API key, browser, LSP) — installs nothing"),
+) -> None:
+    """First-time setup — API key, DAST browser, and code-analysis language servers."""
+    _ensure_config_dir()
+
+    if check:
+        _print_status_report()
+        return
+
+    if lsp:
+        _setup_lsps()
+        console.print("\n[green]Language-server setup done.[/green]")
+        return
+
+    console.print(Panel(
+        "[bold]isitsecure setup[/bold]\n"
+        "Configure API keys, install the DAST browser, and set up language servers.",
+        border_style="bright_magenta",
+    ))
+
+    # API key
+    console.print("\n[bold]1. AI review key (optional, but recommended)[/bold]")
+    console.print("   With an AI key, isitsecure turns the report into plain English you")
+    console.print("   can actually read and gives you specific fix suggestions. Without")
+    console.print("   one, scans still run — you just get the raw findings.")
+    console.print("   [dim]Get a key at console.anthropic.com. It saves to "
+                  "~/.isitsecure/config.toml.[/dim]\n")
+
+    key = typer.prompt("Paste your Anthropic API key (or press Enter to skip)", default="", show_default=False)
+    if key:
+        import os
+        CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+        # Escape for a TOML basic string so a stray quote/backslash in the key
+        # can't corrupt the file.
+        safe_key = key.replace("\\", "\\\\").replace('"', '\\"')
+        CONFIG_FILE.write_text(f'[llm]\nanthropic_api_key = "{safe_key}"\n')
+        # The file holds a secret — restrict it to the owner.
+        try:
+            os.chmod(CONFIG_DIR, 0o700)
+            os.chmod(CONFIG_FILE, 0o600)
+        except OSError:
+            pass
+        console.print("[green]Saved to ~/.isitsecure/config.toml (perms 0600)[/green]")
+
+    # Playwright
+    console.print("\n[bold]2. Browser for live-site testing[/bold]")
+    console.print("   isitsecure opens your website in a real browser to test it the way")
+    console.print("   an attacker would. This installs that browser (Chromium).")
+    install_browser = typer.confirm("Install it now?", default=True)
+    if install_browser:
+        import subprocess
+        console.print("Installing Chromium...")
+        result = subprocess.run(
+            [sys.executable, "-m", "playwright", "install", "chromium"],
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode == 0:
+            console.print("[green]Chromium installed successfully[/green]")
+        else:
+            console.print(
+                "[red]The browser download didn't finish.[/red] "
+                "[dim]Live-site testing won't work until it's installed.[/dim]"
+            )
+            console.print("You can try again any time with: python -m playwright install chromium")
+            if result.stderr:
+                console.print(f"[dim]Details: {result.stderr.strip().splitlines()[-1][:200]}[/dim]")
+
+    # Language servers
+    console.print("\n[bold]3. Language servers (deeper code analysis)[/bold]")
+    console.print("   Let the scanner trace auth flows through your code and cut false")
+    console.print("   positives. Optional — scans still work with regex-based detection.")
+    if typer.confirm("Install/verify language servers now?", default=True):
+        _setup_lsps()
+
+    console.print("\n[green bold]Setup complete![/green bold]")
+    console.print("Run: isitsecure scan https://your-app.com")

--- a/tests/test_cli_onboarding.py
+++ b/tests/test_cli_onboarding.py
@@ -9,7 +9,11 @@ from __future__ import annotations
 
 import pytest
 
-from isitsecure import cli
+# Patch where a name is *used*, not where it is defined: `main` and
+# `setup_lsp` each bind their own reference to the environment helpers.
+from isitsecure.cli import app as cli_app
+from isitsecure.cli import main as cli
+from isitsecure.cli import setup_lsp
 
 
 # ---------------------------------------------------------------------------
@@ -187,7 +191,7 @@ def test_scan_with_no_target_shows_human_error(monkeypatch):
     monkeypatch.setattr(cli, "err_console", Console(file=buf, force_terminal=False))
 
     runner = CliRunner()
-    result = runner.invoke(cli.app, ["scan"])
+    result = runner.invoke(cli_app, ["scan"])
     assert result.exit_code == 1
     out = buf.getvalue()
     # Plain-language, not the old terse "provide a target URL, a --repo".
@@ -210,7 +214,8 @@ def _run_ensure_runtime(
     from isitsecure.engine.code_analysis.lsp import tsserver_locator
 
     monkeypatch.setattr(
-        cli, "_first_which", lambda bins: "found" if server_installed else None
+        setup_lsp, "_first_which",
+        lambda bins: "found" if server_installed else None,
     )
     monkeypatch.setattr(
         shutil, "which", lambda name: "/usr/bin/npm" if (npm and name == "npm") else None
@@ -234,9 +239,10 @@ def _run_ensure_runtime(
 
     printed: list[str] = []
     monkeypatch.setattr(
-        cli.console, "print", lambda *a, **k: printed.append(" ".join(str(x) for x in a))
+        setup_lsp.console, "print",
+        lambda *a, **k: printed.append(" ".join(str(x) for x in a)),
     )
-    cli._ensure_tsserver_runtime()
+    setup_lsp._ensure_tsserver_runtime()
     return "\n".join(printed), calls
 
 
@@ -325,7 +331,7 @@ def _run_scan_cli(monkeypatch, report, argv):
 
     monkeypatch.setattr(cli, "_run_scan", fake_run_scan)
 
-    result = CliRunner().invoke(cli.app, argv)
+    result = CliRunner().invoke(cli_app, argv)
     return result.exit_code, buf.getvalue()
 
 

--- a/tests/test_cli_trust_filters.py
+++ b/tests/test_cli_trust_filters.py
@@ -7,7 +7,9 @@ running a full scan.
 
 from __future__ import annotations
 
-from isitsecure import cli
+# `cli` here is the module that owns these helpers; the `isitsecure.cli`
+# package façade deliberately re-exports only `app` and the consoles.
+from isitsecure.cli import main as cli
 from isitsecure.engine import baseline as B
 from isitsecure.engine.enums import FindingCategory, SeverityLevel
 from isitsecure.engine.models import DeepFinding, DeepScanReport, FindingSource

--- a/tests/test_cli_verify.py
+++ b/tests/test_cli_verify.py
@@ -7,7 +7,9 @@ import json
 import pytest
 import typer
 
-from isitsecure import cli
+# `cli` here is the module that owns these helpers; the `isitsecure.cli`
+# package façade deliberately re-exports only `app` and the consoles.
+from isitsecure.cli import main as cli
 from isitsecure.engine import reverify as R
 from isitsecure.engine.enums import FindingCategory, SeverityLevel
 from isitsecure.engine.models import DeepFinding, DeepScanReport, FindingSource


### PR DESCRIPTION
## Why this file

`cli.py` had reached 1,902 lines and was the **most-churned source file in the repo** — +21% across the last four releases. That churn, not raw size, is why it goes ahead of larger but stable files like `constants.py` (6,958 lines, +0.3% over the same span).

It held eight Typer commands plus report rendering, SARIF/HTML/badge generation, language-server provisioning, trust filters and onboarding.

## The seams were already there

An AST pass over the candidate groups showed each needed almost nothing from the rest of the file beyond `console`, `err_console` and `app`:

| Group | Needs from the rest of `cli.py` |
|---|---|
| setup / LSP | `console` ×50, `err_console` ×6, `_load_api_key`, `_ensure_config_dir`, `app` |
| render | `console` ×10 |
| fix | `console` ×39, `err_console` ×6, `_print_report_table`, `_run_scan`, `app` |

Only the shared Rich consoles and the Typer app held them together.

## Layout

| Module | Lines | Holds |
|---|---:|---|
| `__init__.py` | 30 | Façade: `app` + consoles, and the imports that register commands |
| `_app.py` | 17 | The Typer `app` — own module so command modules register without importing `__init__` |
| `_io.py` | 17 | The two shared consoles |
| `config.py` | 24 | Config dir + API key access |
| `environment.py` | 105 | Detection only: what is installed on this machine |
| `setup_lsp.py` | 286 | The `setup` command, which acts on what `environment` finds |
| `main.py` | 1,545 | The remaining seven commands — to be split further |

**Detection was separated from action deliberately.** The scan pre-flight and the `setup` command both need `_first_which`/`_chromium_installed`/`_LSP_SPECS`; a scan path importing from a setup module would have been the wrong dependency direction.

**`__init__` is a real façade, not a compatibility shim.** It exposes only `app` and the consoles. Re-exporting the private helpers would have kept the old `cli._x` test seams working while quietly breaking them — a name patched there no longer affects the module that uses it. Tests now patch where each name is used, which is the correct idiom and makes the module boundaries real.

## Two things this turned up

- Importing `setup_lsp` at `main`'s module scope registered `setup` first and **silently reordered `--help`**. `launch` now imports `_lsp_offer` lazily; order is back to `scan verify launch fix badge version mcp setup`.
- The first cut left `_ensure_config_dir`/`_load_api_key` defined in *two* modules. Caught with an AST duplicate check; they're now shared via `config.py`.

## Verification

**32 of 34 top-level functions moved byte-identical**, none lost, none duplicated (AST diff against the pre-split file). The two exceptions are the lazy import in `launch` and the deduplicated `_load_api_key`.

Because the entry point moved, unit tests alone weren't enough:

| Check | Result |
|---|---|
| Unit suite | 2234 passed, 1 xfailed |
| sast-injection benchmark | 46/46 recall, **0 FP** |
| VAmPI benchmark (live) | 3/3 recall |
| Juice Shop repo-mode | 198 findings, `branch='master'`, `lsp_validator` ran |
| Juice Shop live DAST | 26 findings — category-for-category unchanged |
| test-app (Next.js/TS) | 114 findings |
| `--help` command order | unchanged |
| #147 bad-branch exit code | still 1 |
| Wheel built + installed into a **fresh venv** | `isitsecure.cli:app` resolves, 8 commands, `setup --check` runs |
| Ruff `F401`/`F811`/`F821` in the package | none |

The clean-install check mattered: this changes the distribution layout from a module to a package, which an editable install would not have caught.

Not a single finding count moved.

## Next

`main.py` goes from 1,545 to ~950 by extracting `fix_cmd.py` (~380) and `render.py` (~210) — same seams, groundwork now in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EZ4QoTqRoYWE25CNoV2Wfy
