### PR TITLE
fix(lsp): read the whole header block, so pylsp works at all

### DIFF
--- a/docs/lsp-setup.md
+++ b/docs/lsp-setup.md
@@ -193,6 +193,16 @@ The project may have a very large `node_modules` or complex tsconfig. Try:
 cd your-project && npm install
 ```
 
+**"LSP reader stopped: ..."**
+
+The language server sent something the client could not read, so the session is
+dead and the scan falls back to regex analysis. The text after the colon is the
+parse failure itself — include it if you file an issue, since it identifies the
+server and the message that broke.
+
+This is reported immediately rather than after the initialization timeout, so a
+scan that prints this has not silently waited 30 seconds first.
+
 **"LSP trace returned no results for route X"**
 
 The route may use a pattern the tracer doesn't recognize yet. The scan falls back to regex analysis for that route. File an issue with the route code and we'll add support.

--- a/isitsecure/engine/code_analysis/lsp/base_client.py
+++ b/isitsecure/engine/code_analysis/lsp/base_client.py
@@ -16,6 +16,7 @@ import shutil
 from pathlib import Path
 from typing import Any
 
+from isitsecure.engine.code_analysis.lsp.framing import read_message
 from isitsecure.engine.code_analysis.lsp.protocols import LSPLocation
 from isitsecure.engine.code_analysis.lsp.rpc_errors import format_rpc_error
 from isitsecure.engine.constants import LSPConfig
@@ -247,16 +248,9 @@ class BaseLSPClient:
             return
         try:
             while True:
-                header = await self._process.stdout.readline()
-                if not header:
+                data = await read_message(self._process.stdout)
+                if data is None:
                     break
-                header_str = header.decode().strip()
-                if not header_str.startswith("Content-Length:"):
-                    continue
-                content_length = int(header_str.split(":")[1].strip())
-                await self._process.stdout.readline()
-                body = await self._process.stdout.readexactly(content_length)
-                data = json.loads(body.decode())
                 req_id = data.get("id")
                 rpc_error = format_rpc_error(data)
                 if rpc_error:
@@ -268,10 +262,21 @@ class BaseLSPClient:
                     future = self._pending[req_id]
                     if not future.done():
                         future.set_result(None if rpc_error else data.get("result"))
-        except (asyncio.CancelledError, asyncio.IncompleteReadError):
+        except asyncio.CancelledError:
             pass
         except Exception as e:
-            logger.debug("LSP reader error: %s", e)
+            # The reader dying means no request can ever complete. Say so and
+            # release the waiters, instead of letting each one burn its full
+            # timeout and report "no response from the server".
+            self._fail_pending(f"LSP reader stopped: {e}")
+
+    def _fail_pending(self, reason: str) -> None:
+        """Record why the session is dead and unblock every waiting request."""
+        self._last_error = reason
+        logger.warning("%s", reason)
+        for future in self._pending.values():
+            if not future.done():
+                future.set_result(None)
 
     # --- File management ---
 

--- a/isitsecure/engine/code_analysis/lsp/framing.py
+++ b/isitsecure/engine/code_analysis/lsp/framing.py
@@ -1,0 +1,69 @@
+"""Reading LSP messages off a server's stdout.
+
+The wire format is HTTP-like: a header block, a blank line, then exactly
+``Content-Length`` bytes of JSON.
+
+DRY: every client reads the same format, so the framing lives here rather than
+once per client.
+
+The header block is a *block* — that is the whole point of this module. Both
+readers used to take ``Content-Length`` and then consume a single line as the
+separator, which works only for a server that sends no other header. pylsp
+sends the ``Content-Type`` the spec explicitly permits::
+
+    Content-Length: 888
+    Content-Type: application/vscode-jsonrpc; charset=utf8
+
+so that lone ``readline()`` ate the Content-Type, the body read then started on
+the real blank line, and every message came back truncated by two bytes —
+killing the reader task and leaving initialization to time out 30s later with
+"no response from the server".
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_CONTENT_LENGTH = "content-length"
+_CONTENT_TYPE = "content-type"
+
+
+async def read_message(stream: asyncio.StreamReader) -> dict[str, Any] | None:
+    """Read one framed LSP message, or ``None`` at end of stream.
+
+    Raises ``asyncio.IncompleteReadError`` if the stream ends mid-body and
+    ``json.JSONDecodeError`` if the body is not JSON — both of which the
+    caller reports rather than swallowing.
+    """
+    content_length: int | None = None
+
+    while True:
+        line = await stream.readline()
+        if not line:
+            return None  # EOF — the server exited
+        text = line.decode(errors="replace").strip()
+
+        if not text:
+            if content_length is None:
+                # A blank line before any header is noise, not a separator.
+                continue
+            break  # end of the header block; the body follows
+
+        name, _, value = text.partition(":")
+        name = name.strip().lower()
+        if name == _CONTENT_LENGTH:
+            try:
+                content_length = int(value.strip())
+            except ValueError:
+                logger.debug("LSP: unparseable Content-Length: %s", text[:200])
+        elif name != _CONTENT_TYPE:
+            # Not a header we know — usually npx/tooling chatter on stdout.
+            logger.debug("LSP stdout (non-header): %s", text[:200])
+
+    body = await stream.readexactly(content_length)
+    return json.loads(body.decode())

--- a/isitsecure/engine/code_analysis/lsp/tsserver_client.py
+++ b/isitsecure/engine/code_analysis/lsp/tsserver_client.py
@@ -23,6 +23,7 @@ import shutil
 from pathlib import Path
 from typing import Any
 
+from isitsecure.engine.code_analysis.lsp.framing import read_message
 from isitsecure.engine.code_analysis.lsp.protocols import (
     LSPLocation,
 )
@@ -421,25 +422,9 @@ class TypeScriptLSPClient:
 
         try:
             while True:
-                # Read Content-Length header
-                header = await self._process.stdout.readline()
-                if not header:
+                data = await read_message(self._process.stdout)
+                if data is None:
                     break
-
-                header_str = header.decode().strip()
-                if not header_str.startswith("Content-Length:"):
-                    if header_str:
-                        logger.debug("LSP stdout (non-header): %s", header_str[:200])
-                    continue
-
-                content_length = int(header_str.split(":")[1].strip())
-
-                # Read blank line separator
-                await self._process.stdout.readline()
-
-                # Read body
-                body = await self._process.stdout.readexactly(content_length)
-                data = json.loads(body.decode())
 
                 # Dispatch response to pending future
                 req_id = data.get("id")
@@ -460,10 +445,21 @@ class TypeScriptLSPClient:
                             None if rpc_error else data.get("result")
                         )
 
-        except (asyncio.CancelledError, asyncio.IncompleteReadError):
+        except asyncio.CancelledError:
             pass
         except Exception as e:
-            logger.debug("LSP reader error: %s", e)
+            # The reader dying means no request can ever complete. Say so and
+            # release the waiters, instead of letting each one burn its full
+            # timeout and report "no response from the server".
+            self._fail_pending(f"LSP reader stopped: {e}")
+
+    def _fail_pending(self, reason: str) -> None:
+        """Record why the session is dead and unblock every waiting request."""
+        self._last_error = reason
+        logger.warning("%s", reason)
+        for future in self._pending.values():
+            if not future.done():
+                future.set_result(None)
 
     # ------------------------------------------------------------------
     # File management

--- a/tests/engine/test_code_analysis/test_lsp_framing.py
+++ b/tests/engine/test_code_analysis/test_lsp_framing.py
@@ -1,0 +1,104 @@
+"""Tests for LSP message framing.
+
+The bug these exist to prevent: the readers took ``Content-Length`` and then
+consumed exactly one line as the separator, which silently truncated every
+message from any server that sends a second header. pylsp sends the
+``Content-Type`` the spec permits, so the Python language server never worked.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+
+from isitsecure.engine.code_analysis.lsp.framing import read_message
+
+
+def _stream(raw: bytes) -> asyncio.StreamReader:
+    reader = asyncio.StreamReader()
+    reader.feed_data(raw)
+    reader.feed_eof()
+    return reader
+
+
+def _framed(payload: dict, *, extra_headers: tuple[str, ...] = ()) -> bytes:
+    body = json.dumps(payload).encode()
+    head = f"Content-Length: {len(body)}\r\n"
+    for h in extra_headers:
+        head += f"{h}\r\n"
+    return head.encode() + b"\r\n" + body
+
+
+class TestReadMessage:
+    @pytest.mark.asyncio
+    async def test_content_length_only(self) -> None:
+        """The shape typescript-language-server and jdtls send."""
+        msg = {"jsonrpc": "2.0", "id": 1, "result": {"capabilities": {}}}
+        assert await read_message(_stream(_framed(msg))) == msg
+
+    @pytest.mark.asyncio
+    async def test_content_type_header_is_tolerated(self) -> None:
+        """The shape pylsp sends — the case that was broken."""
+        msg = {"jsonrpc": "2.0", "id": 1, "result": {"capabilities": {}}}
+        raw = _framed(
+            msg,
+            extra_headers=("Content-Type: application/vscode-jsonrpc; charset=utf8",),
+        )
+        assert await read_message(_stream(raw)) == msg
+
+    @pytest.mark.asyncio
+    async def test_many_headers_in_any_order(self) -> None:
+        msg = {"jsonrpc": "2.0", "id": 7, "result": "ok"}
+        raw = _framed(
+            msg,
+            extra_headers=(
+                "Content-Type: application/vscode-jsonrpc; charset=utf8",
+                "X-Something: whatever",
+            ),
+        )
+        assert await read_message(_stream(raw)) == msg
+
+    @pytest.mark.asyncio
+    async def test_header_name_is_case_insensitive(self) -> None:
+        body = json.dumps({"id": 1}).encode()
+        raw = b"content-length: %d\r\nCONTENT-TYPE: x\r\n\r\n" % len(body) + body
+        assert await read_message(_stream(raw)) == {"id": 1}
+
+    @pytest.mark.asyncio
+    async def test_length_counts_bytes_not_characters(self) -> None:
+        """A non-ASCII body must not be truncated."""
+        msg = {"jsonrpc": "2.0", "id": 1, "result": "héllo → wörld ✓"}
+        assert await read_message(_stream(_framed(msg))) == msg
+
+    @pytest.mark.asyncio
+    async def test_two_messages_back_to_back(self) -> None:
+        first = {"id": 1, "result": "a"}
+        second = {"id": 2, "result": "b"}
+        raw = _framed(first, extra_headers=("Content-Type: x",)) + _framed(second)
+        stream = _stream(raw)
+        assert await read_message(stream) == first
+        assert await read_message(stream) == second
+
+    @pytest.mark.asyncio
+    async def test_leading_noise_is_skipped(self) -> None:
+        """npx and friends print to stdout before the server speaks."""
+        msg = {"id": 1, "result": "ok"}
+        raw = b"npm WARN: something\r\n" + _framed(msg)
+        assert await read_message(_stream(raw)) == msg
+
+    @pytest.mark.asyncio
+    async def test_eof_returns_none(self) -> None:
+        assert await read_message(_stream(b"")) is None
+
+    @pytest.mark.asyncio
+    async def test_eof_after_headers_raises(self) -> None:
+        """A half-written message is an error, not a silent empty read."""
+        with pytest.raises(asyncio.IncompleteReadError):
+            await read_message(_stream(b"Content-Length: 99\r\n\r\n{}"))
+
+    @pytest.mark.asyncio
+    async def test_non_json_body_raises(self) -> None:
+        with pytest.raises(json.JSONDecodeError):
+            await read_message(_stream(b"Content-Length: 3\r\n\r\nnot"))

--- a/tests/engine/test_code_analysis/test_lsp_protocols.py
+++ b/tests/engine/test_code_analysis/test_lsp_protocols.py
@@ -7,6 +7,8 @@ Verifies default values, field assignment, and Pydantic behavior for
 
 from __future__ import annotations
 
+import asyncio
+
 import pytest
 
 from isitsecure.engine.code_analysis.lsp.java_client import JavaLSPClient
@@ -138,3 +140,30 @@ class TestLastErrorContract:
     def test_noop_client_never_reports_an_error(self) -> None:
         # It never attempts anything, so it has nothing to explain.
         assert NoOpLSPClient().last_error is None
+
+
+class TestBaseClientReaderFailure:
+    """The Python and Java clients share BaseLSPClient's reader, so they need
+    the same guarantee: a dead reader is reported, not silently waited on."""
+
+    @pytest.mark.asyncio
+    async def test_fail_pending_records_and_releases(self) -> None:
+        client = PythonLSPClient()
+        waiting: asyncio.Future = asyncio.get_running_loop().create_future()
+        client._pending[1] = waiting
+
+        client._fail_pending("LSP reader stopped: boom")
+
+        assert client.last_error == "LSP reader stopped: boom"
+        assert waiting.done() and waiting.result() is None
+
+    @pytest.mark.asyncio
+    async def test_already_resolved_futures_are_left_alone(self) -> None:
+        client = JavaLSPClient()
+        settled: asyncio.Future = asyncio.get_running_loop().create_future()
+        settled.set_result({"capabilities": {}})
+        client._pending[1] = settled
+
+        client._fail_pending("LSP reader stopped: boom")
+
+        assert settled.result() == {"capabilities": {}}

--- a/tests/engine/test_code_analysis/test_tsserver_client.py
+++ b/tests/engine/test_code_analysis/test_tsserver_client.py
@@ -424,3 +424,59 @@ class TestErrorReporting:
 
         assert "something else went wrong" in caplog.text
         assert "setup --lsp" not in caplog.text
+
+
+# ------------------------------------------------------------------
+# TestReaderFailure — a dead reader must say so, fast
+# ------------------------------------------------------------------
+
+
+class _BrokenStdout:
+    """A stream whose body never matches its declared Content-Length."""
+
+    def __init__(self) -> None:
+        self._buffer = b"Content-Length: 500\r\n\r\n{truncated"
+
+    async def readline(self) -> bytes:
+        index = self._buffer.find(b"\r\n")
+        if index == -1:
+            chunk, self._buffer = self._buffer, b""
+            return chunk
+        line, self._buffer = self._buffer[: index + 2], self._buffer[index + 2:]
+        return line
+
+    async def readexactly(self, count: int) -> bytes:
+        if count > len(self._buffer):
+            raise asyncio.IncompleteReadError(self._buffer, count)
+        chunk, self._buffer = self._buffer[:count], self._buffer[count:]
+        return chunk
+
+
+class TestReaderFailure:
+    """A reader that dies used to leave every request to time out and then
+    report "no response from the server" — pointing at the wrong problem."""
+
+    @pytest.mark.asyncio
+    async def test_reader_crash_is_recorded_and_releases_waiters(self) -> None:
+        client = TypeScriptLSPClient()
+        client._process = _FakeProcess([])  # type: ignore[assignment]
+        client._process.stdout = _BrokenStdout()  # type: ignore[assignment]
+        waiting: asyncio.Future = asyncio.get_running_loop().create_future()
+        client._pending[1] = waiting
+
+        await client._read_responses()
+
+        assert client.last_error is not None
+        assert "reader stopped" in client.last_error
+        # The waiter is resolved rather than left to burn its full timeout.
+        assert waiting.done() and waiting.result() is None
+
+    @pytest.mark.asyncio
+    async def test_clean_eof_is_not_reported_as_a_failure(self) -> None:
+        """A server exiting normally at shutdown is not a reader crash."""
+        client = TypeScriptLSPClient()
+        client._process = _FakeProcess([])  # type: ignore[assignment]
+
+        await client._read_responses()
+
+        assert client.last_error is None


### PR DESCRIPTION
## The bug

The LSP wire format is a header **block**, a blank line, then `Content-Length` bytes of JSON. Both readers took `Content-Length` and then consumed exactly *one* line as the separator — which works only for a server that sends no other header.

pylsp sends the `Content-Type` the spec explicitly permits:

```
pylsp:                                                  typescript-language-server:
  Content-Length: 888                                     Content-Length: 233
  Content-Type: application/vscode-jsonrpc; charset=utf8
```

So that lone `readline()` ate the `Content-Type`, the body read began on the real blank line, and every message came back two bytes short:

```
LSP reader error: Expecting ',' delimiter: line 2 column 887 (char 888)
... 30s later ...
LSP initialize failed: no response from the server
```

The reader task died on the truncated JSON, and initialization then timed out blaming the server — which had in fact answered correctly in **0.2s** to a raw handshake.

**Why it mattered:** pylsp is the *first* entry in `PythonLSPClient.SERVER_OPTIONS` and `setup --lsp` installs `python-lsp-server`. The documented, recommended Python setup was the broken one; pyright only worked by being second in the list.

**Why we never saw it:** `typescript-language-server` and jdtls both send only `Content-Length` (verified on the wire), so every scan previously validated passed.

## The fix

**Read the block properly, in one place.** New `lsp/framing.py` drains headers until a blank line — tolerating unknown headers, matching names case-insensitively, and still skipping pre-server chatter on stdout. Both readers now call it, which also removes the duplicated framing they each carried.

**Stop a dead reader presenting as a timeout.** When the reader task fails it now records the parse error and resolves the pending futures, instead of leaving each to burn its full timeout and then blame the server for not answering:

```
Before:  (30s) LSP initialize failed: no response from the server     last_error=None
After:         LSP reader stopped: Expecting value: line 1 column 1   last_error set
```

A server that *stalls* mid-body is deliberately untouched — that really is a timeout and still reports as one.

## All four supported servers, verified live

| Server | init | hover | go-to-def | Before this PR |
|---|---|---|---|---|
| **pylsp 1.15.0** | ✅ | ✅ | ✅ | ❌ 30s hang → regex-only |
| pyright-langserver | ✅ | ✅ | ✅ | ✅ |
| jdtls | ✅ | ✅ | ✅ | ✅ |
| typescript-language-server | ✅ | ✅ | ✅ | ✅ |

jdtls was never hit by this, but shares `base_client`, so it gains the crash reporting and is covered if a future version adds the header.

## Verification

| Check | Result |
|---|---|
| Unit suite | 2249 passed, 1 xfailed (+14 new) |
| sast-injection benchmark | 46/46 recall, **0 FP** |
| VAmPI benchmark | 3/3 recall |
| Juice Shop repo-mode | 198 findings — unchanged, `lsp_validator` ran |
| Juice Shop live DAST | 26 findings — category-for-category identical |
| test-app | 114 findings — unchanged |

New tests cover the framing directly (Content-Type, multiple headers, case-insensitivity, byte-vs-character length with non-ASCII bodies, back-to-back messages, leading noise, EOF, truncation, non-JSON) and the reader-crash path on both client families.

## Not addressed here

`_create_lsp_client()` returns the TypeScript client whenever Node is present, and runs at agent construction — before repo ingestion, so it cannot know the project's language. A pure-Python repo therefore gets the TypeScript server even with pyright installed and working. Pre-existing, already noted in `docs/lsp-setup.md`, and its own piece of work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EZ4QoTqRoYWE25CNoV2Wfy
