### PR TITLE
feat(lsp): choose the language server from the project, not the machine

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -277,7 +277,7 @@ The scanner works at any completeness level:
 |---|---|
 | No LLM API key | Rule-based scanners only. No business logic review, no semantic verification, no triage enrichment |
 | No Playwright | URL ingestion falls back to httpx. No authenticated crawl, no DOM XSS |
-| No TypeScript/Node.js | LSP validation skipped. Auth flow tracing unavailable, more false positives |
+| No language server for the project's language | LSP validation skipped. Auth flow tracing unavailable, more false positives. The server is chosen from the code (see [lsp-setup.md](lsp-setup.md)), so an installed server for a *different* language is never substituted |
 | No TypeScript 5.x runtime | Same — `typescript-language-server` won't start without a `tsserver.js`. `isitsecure setup --lsp` provisions one; see [lsp-setup.md](lsp-setup.md) |
 | No repo URL | SAST skipped entirely. DAST-only scan |
 | Repo fails to clone | Code-only: the scan stops and exits 1 (no report). Full: DAST findings are kept, the reason is recorded in `ingestion_errors`, and the CLI exits 1 — a zero-finding report must never read as "your code is fine" |

--- a/docs/lsp-setup.md
+++ b/docs/lsp-setup.md
@@ -28,7 +28,7 @@ Route file: app/api/tasks/[id]/route.ts
 | **Python** | pylsp or pyright | `pip install python-lsp-server` or `pip install pyright` | Traces Depends(), decorators |
 | **Java/Kotlin** | jdtls | See [jdtls install guide](https://github.com/eclipse-jdtls/eclipse.jdt.ls#installation) | Traces @PreAuthorize, SecurityConfig |
 
-isitsecure auto-detects which LSP servers are installed and uses the first available one. If none are installed, regex-based auth detection is used (still effective, slightly higher false positive rate).
+isitsecure picks the server that matches the language your project is written in, and uses regex-based auth detection when there isn't one (still effective, slightly higher false positive rate).
 
 ## TypeScript LSP Setup
 
@@ -108,20 +108,20 @@ isitsecure setup --check
 typescript-language-server --version
 ```
 
-### How isitsecure Detects LSP
+### When the TypeScript server is considered usable
 
-When a scan starts, isitsecure automatically checks:
+For a project detected as TypeScript (see [How the Server Is Chosen](#how-the-server-is-chosen)),
+isitsecure checks that:
 
-1. Is Node.js available? (`node --version`)
-2. Is `typescript-language-server` installed globally? (`which typescript-language-server`)
-3. Is `npx` available as a fallback? (`which npx`)
+1. Node.js is available (`node --version`)
+2. `typescript-language-server` is on PATH, or `npx` is available as a fallback
+3. A TypeScript 5.x runtime can be found (see above)
 
-If all checks fail, you'll see:
+If any of those is missing you'll see the reason and the fix:
 
 ```
-LSP DISABLED: Node.js not found on this system.
-Install Node.js to enable TypeScript flow analysis.
-Scan will use regex-only analysis (higher false positive rate).
+No typescript language server installed — auth-flow tracing is skipped for
+this scan. Install one with `isitsecure setup --lsp`.
 ```
 
 The scan still works — you just get regex-based auth detection instead of LSP-based tracing.
@@ -163,11 +163,18 @@ LSP adds ~2-5 seconds to the scan for initialization and ~0.5s per route traced.
 
 ### Troubleshooting
 
-**"LSP DISABLED: Node.js found but typescript-language-server is not installed"**
+**"No &lt;language&gt; language server installed"**
+
+Your project was detected as that language, but its server isn't installed.
+Install it:
 
 ```bash
 isitsecure setup --lsp
 ```
+
+isitsecure deliberately won't substitute a server for a different language —
+one that can't read your code would report no findings, which is worse than
+saying it didn't look.
 
 **"LSP initialize failed: … Could not find a valid TypeScript installation"**
 
@@ -302,16 +309,33 @@ public SecurityFilterChain filterChain(HttpSecurity http) {
 - **Java 17+** — required for jdtls
 - **Maven or Gradle** — jdtls needs a build tool to resolve dependencies
 
-## How Auto-Detection Works
+## How the Server Is Chosen
 
-isitsecure tries LSP servers in this order:
+The choice is made **per scan, from your code** — not from what happens to be
+installed. Once your project has been ingested, isitsecure counts its source
+files and picks the server for whichever language most of it is written in:
 
-1. **TypeScript** — if `typescript-language-server` or `npx` is available
-   (it also needs a TypeScript 5.x runtime to start — see above)
-2. **Python** — if `pylsp` or `pyright-langserver` is available
-3. **Java** — if `java` runtime + `jdtls` is available
-4. **NoOp** — fallback, regex-only analysis
+| Language | Counted extensions | Server |
+|---|---|---|
+| TypeScript / JavaScript | `.ts` `.tsx` `.js` `.jsx` `.mjs` `.cjs` | typescript-language-server |
+| Python | `.py` `.pyi` | pylsp or pyright-langserver |
+| Java / Kotlin | `.java` `.kt` `.kts` | jdtls |
 
-The first available server is used. If your project is Python but you have TypeScript LSP installed, the TS LSP will be initialized — but it won't find any routes and auth flow tracing will be skipped. The regex-based Python auth detection still works regardless of which LSP is active.
+Vendored and generated directories (`node_modules`, `.venv`, `dist`, `target`,
+and hidden directories) don't count toward the total, so a Python service with
+a bundled JavaScript dependency is still scanned as Python. If two languages
+tie, the order in the table wins, so repeated scans of the same repo always
+choose the same server.
 
-To force a specific LSP, install only the server for your language.
+**If the matching server isn't installed, no server is used** — isitsecure says
+which one it wanted and falls back to regex-only auth detection. It will not
+start a server for a different language: one that doesn't understand your code
+finds nothing, which reads as "no problems here" rather than "not checked".
+
+```
+No python language server installed — auth-flow tracing is skipped for this
+scan. Install one with `isitsecure setup --lsp`.
+```
+
+To see what a scan chose, run with `-v` and look for `Project language:` and
+`LSP: using ...`.

--- a/isitsecure/engine/agent.py
+++ b/isitsecure/engine/agent.py
@@ -707,10 +707,14 @@ class DeepSecurityScanAgent:
             and self._lsp_client
             and mode in (ScanMode.CODE_ONLY, ScanMode.FULL)
         ):
+            from isitsecure.engine.code_analysis.lsp.noop_client import (
+                NoOpLSPClient,
+            )
             from isitsecure.engine.constants import LSPConfig
 
-            if not self._lsp_client.is_available and not hasattr(self._lsp_client, '_process'):
-                # NoOpLSPClient — LSP was disabled at factory level
+            if isinstance(self._lsp_client, NoOpLSPClient):
+                # LSP was disabled when the agent was built. Ask the client
+                # what it is, rather than sniffing for a private attribute.
                 logger.info(LSPConfig.MSG_UNAVAILABLE)
             else:
                 yield DeepScanEvent(

--- a/isitsecure/engine/code_analysis/lsp/language_router.py
+++ b/isitsecure/engine/code_analysis/lsp/language_router.py
@@ -1,0 +1,187 @@
+"""Pick the language server that matches the project being scanned.
+
+Why this exists: the LSP client used to be chosen when the *agent* was built,
+which is before anything has been ingested — so the only thing it could go on
+was what happened to be installed on the machine. With Node present that was
+always the TypeScript server, and a pure-Python repository would be handed
+tsserver while a working pyright sat idle. The language server for a language
+the project isn't written in finds nothing, so those scans silently fell back
+to regex-only auth analysis.
+
+``initialize(project_path)`` is the first moment the project actually exists,
+so that is where the choice belongs. ``LanguageRoutingLSPClient`` implements
+``LSPClientProtocol`` and delegates to whichever concrete client fits, which
+keeps the decision out of the agent entirely.
+
+If the project's language has no server installed we stop, rather than falling
+back to a server for some other language: a mismatched server is not a partial
+answer, it is a confident silence.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from collections import Counter
+from collections.abc import Callable, Mapping
+
+from isitsecure.engine.code_analysis.lsp.protocols import (
+    LSPClientProtocol,
+    LSPLocation,
+)
+from isitsecure.engine.constants import LSPConfig
+
+logger = logging.getLogger(__name__)
+
+# (is the server installed?, build a client for it)
+LanguageSupport = tuple[Callable[[], bool], Callable[[], LSPClientProtocol]]
+
+
+def detect_project_language(project_path: str) -> str | None:
+    """Return the language most of the project is written in, or ``None``.
+
+    Counts source files by extension.  Ties break toward the order languages
+    are declared in ``LSPConfig.LANGUAGE_EXTENSIONS``, so a repo with equal
+    amounts of two languages resolves the same way every scan.
+    """
+    by_extension: dict[str, str] = {
+        ext: language
+        for language, exts in LSPConfig.LANGUAGE_EXTENSIONS.items()
+        for ext in exts
+    }
+    counts: Counter[str] = Counter()
+    seen = 0
+
+    for _root, dirnames, filenames in os.walk(project_path):
+        dirnames[:] = [
+            d for d in dirnames
+            if d not in LSPConfig.LANGUAGE_SCAN_SKIP_DIRS and not d.startswith(".")
+        ]
+        for name in filenames:
+            language = by_extension.get(os.path.splitext(name)[1].lower())
+            if language:
+                counts[language] += 1
+            seen += 1
+        if seen >= LSPConfig.LANGUAGE_SCAN_MAX_FILES:
+            break
+
+    if not counts:
+        return None
+    best = max(counts.values())
+    # Declaration order is the tiebreak, so the answer is stable.
+    for language in LSPConfig.LANGUAGE_EXTENSIONS:
+        if counts.get(language) == best:
+            logger.info(
+                "Project language: %s (%s)",
+                language,
+                ", ".join(f"{lang} {n}" for lang, n in counts.most_common()),
+            )
+            return language
+    return None
+
+
+def default_language_support() -> Mapping[str, LanguageSupport]:
+    """The languages we can serve, and how to tell whether we can serve them."""
+    import shutil
+
+    from isitsecure.engine.code_analysis.lsp.java_client import JavaLSPClient
+    from isitsecure.engine.code_analysis.lsp.python_client import PythonLSPClient
+    from isitsecure.engine.code_analysis.lsp.tsserver_client import (
+        TypeScriptLSPClient,
+    )
+
+    def typescript_available() -> bool:
+        return TypeScriptLSPClient.is_node_available() and any(
+            shutil.which(binary)
+            for binary in ("typescript-language-server", "npx")
+        )
+
+    return {
+        "typescript": (typescript_available, TypeScriptLSPClient),
+        "python": (PythonLSPClient.is_server_available, PythonLSPClient),
+        "java": (
+            lambda: JavaLSPClient.is_runtime_available()
+            and JavaLSPClient.is_server_available(),
+            JavaLSPClient,
+        ),
+    }
+
+
+class LanguageRoutingLSPClient:
+    """An ``LSPClientProtocol`` that picks its concrete client per project."""
+
+    def __init__(
+        self, support: Mapping[str, LanguageSupport] | None = None
+    ) -> None:
+        self._support = support
+        self._delegate: LSPClientProtocol | None = None
+        self._last_error: str | None = None
+
+    @property
+    def is_available(self) -> bool:
+        return self._delegate is not None and self._delegate.is_available
+
+    @property
+    def last_error(self) -> str | None:
+        if self._delegate is not None and self._delegate.last_error:
+            return self._delegate.last_error
+        return self._last_error
+
+    async def initialize(self, project_path: str) -> bool:
+        self._delegate = None
+        self._last_error = None
+
+        support = self._support
+        if support is None:
+            support = default_language_support()
+
+        language = detect_project_language(project_path)
+        if language is None:
+            self._last_error = LSPConfig.MSG_LANGUAGE_UNRECOGNISED
+            logger.info(LSPConfig.MSG_LANGUAGE_UNRECOGNISED)
+            return False
+
+        entry = support.get(language)
+        if entry is None or not entry[0]():
+            self._last_error = LSPConfig.MSG_NO_SERVER_FOR_LANGUAGE.format(
+                language=language
+            )
+            logger.warning(self._last_error)
+            return False
+
+        delegate = entry[1]()
+        logger.info(
+            "LSP: using %s for this %s project",
+            type(delegate).__name__,
+            language,
+        )
+        initialized = await delegate.initialize(project_path)
+        # Keep the delegate either way: a failed one still knows why.
+        self._delegate = delegate
+        return initialized
+
+    async def get_definition(
+        self, file_path: str, line: int, character: int
+    ) -> list[LSPLocation] | None:
+        if self._delegate is None:
+            return None
+        return await self._delegate.get_definition(file_path, line, character)
+
+    async def get_references(
+        self, file_path: str, line: int, character: int
+    ) -> list[LSPLocation] | None:
+        if self._delegate is None:
+            return None
+        return await self._delegate.get_references(file_path, line, character)
+
+    async def get_hover(
+        self, file_path: str, line: int, character: int
+    ) -> str | None:
+        if self._delegate is None:
+            return None
+        return await self._delegate.get_hover(file_path, line, character)
+
+    async def shutdown(self) -> None:
+        if self._delegate is not None:
+            await self._delegate.shutdown()
+            self._delegate = None

--- a/isitsecure/engine/constants.py
+++ b/isitsecure/engine/constants.py
@@ -4920,6 +4920,37 @@ class LSPConfig:
     # File extensions worth tracing through LSP
     TRACEABLE_EXTENSIONS = (".ts", ".tsx", ".js", ".jsx", ".mjs")
 
+    # Which language server a project needs, by what it is written in.
+    # Counted over the scanned tree to pick one server per scan; the language
+    # with the most source files wins.
+    LANGUAGE_EXTENSIONS = {
+        "typescript": (".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"),
+        "python": (".py", ".pyi"),
+        "java": (".java", ".kt", ".kts"),
+    }
+
+    # Directories that say nothing about what a project is written in, and can
+    # be enormous. Ingestion strips most of these already; belt and braces for
+    # callers that point us at a working tree.
+    LANGUAGE_SCAN_SKIP_DIRS = frozenset({
+        "node_modules", ".git", ".venv", "venv", "env", "__pycache__",
+        "dist", "build", "out", "target", ".next", ".mypy_cache",
+        ".pytest_cache", ".ruff_cache", "vendor", "site-packages",
+    })
+
+    # Stop counting once a project's language is obvious — a monorepo should
+    # not cost a full-tree walk.
+    LANGUAGE_SCAN_MAX_FILES = 20_000
+
+    MSG_NO_SERVER_FOR_LANGUAGE = (
+        "No {language} language server installed — auth-flow tracing is "
+        "skipped for this scan. Install one with `isitsecure setup --lsp`."
+    )
+    MSG_LANGUAGE_UNRECOGNISED = (
+        "No language with LSP support detected in this project — "
+        "using regex-only analysis."
+    )
+
     # --- Log/event messages ---
     MSG_INIT = "Initializing TypeScript analysis..."
     MSG_TRACING = "Tracing auth flows across {count} routes..."

--- a/isitsecure/engine/factory.py
+++ b/isitsecure/engine/factory.py
@@ -369,62 +369,20 @@ def create_deep_security_scan_agent(
 
 
 def _create_lsp_client():
-    """Create an LSP client with auto-detection.
+    """Create the LSP client used for code analysis.
 
-    Tries language servers in order:
-    1. TypeScript (typescript-language-server) — for JS/TS projects
-    2. Python (pylsp / pyright) — for Python projects
-    3. Java (jdtls) — for Java/Kotlin projects
-    4. NoOpLSPClient — graceful fallback
-
-    The agent will initialize the first available client at scan time
-    based on the detected framework.
+    The concrete server is *not* chosen here. This runs while the agent is
+    being built, before anything has been ingested, so the only thing it could
+    go on is what happens to be installed on the machine — which is how a
+    Python project ended up handed the TypeScript server while a working
+    pyright sat idle. ``LanguageRoutingLSPClient`` defers the choice to
+    ``initialize()``, once the project exists and its language can be read
+    off it.
 
     SRP: LSP client selection is isolated from agent creation.
     """
-    import shutil
-
-    from isitsecure.engine.code_analysis.lsp.noop_client import (
-        NoOpLSPClient,
-    )
-    from isitsecure.engine.code_analysis.lsp.tsserver_client import (
-        TypeScriptLSPClient,
-    )
-    from isitsecure.engine.code_analysis.lsp.python_client import (
-        PythonLSPClient,
-    )
-    from isitsecure.engine.code_analysis.lsp.java_client import (
-        JavaLSPClient,
+    from isitsecure.engine.code_analysis.lsp.language_router import (
+        LanguageRoutingLSPClient,
     )
 
-    # Try TypeScript LSP first (most common for target audience)
-    if TypeScriptLSPClient.is_node_available():
-        has_ts_ls = shutil.which("typescript-language-server") is not None
-        has_npx = shutil.which("npx") is not None
-
-        if has_ts_ls or has_npx:
-            logger.info(
-                "LSP ENABLED: TypeScript Language Server "
-                "(typescript-language-server=%s, npx=%s)",
-                "yes" if has_ts_ls else "no",
-                "yes" if has_npx else "no",
-            )
-            return TypeScriptLSPClient()
-
-    # Try Python LSP
-    if PythonLSPClient.is_server_available():
-        logger.info("LSP ENABLED: Python Language Server (pylsp/pyright)")
-        return PythonLSPClient()
-
-    # Try Java LSP
-    if JavaLSPClient.is_runtime_available() and JavaLSPClient.is_server_available():
-        logger.info("LSP ENABLED: Java Language Server (jdtls)")
-        return JavaLSPClient()
-
-    logger.warning(
-        "LSP DISABLED: No language server found. "
-        "Install one of: npm install -g typescript-language-server, "
-        "pip install python-lsp-server, or install jdtls. "
-        "Scan will use regex-only analysis (higher false positive rate)."
-    )
-    return NoOpLSPClient()
+    return LanguageRoutingLSPClient()

--- a/tests/engine/test_code_analysis/test_language_router.py
+++ b/tests/engine/test_code_analysis/test_language_router.py
@@ -1,0 +1,242 @@
+"""Tests for choosing the language server that matches the project.
+
+The behaviour these pin down: the client used to be chosen when the agent was
+built — before ingestion — so it could only go on what was installed. With Node
+present that was always TypeScript, and a Python repository was handed tsserver
+while a working pyright sat idle.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from isitsecure.engine.code_analysis.lsp.language_router import (
+    LanguageRoutingLSPClient,
+    detect_project_language,
+)
+
+
+def _tree(root: Path, files: dict[str, int]) -> Path:
+    """Create ``{"src/a.ts": 3}`` as three .ts files under src/."""
+    for spec, count in files.items():
+        directory, _, name = spec.rpartition("/")
+        stem, ext = name.rsplit(".", 1)
+        target = root / directory if directory else root
+        target.mkdir(parents=True, exist_ok=True)
+        for i in range(count):
+            (target / f"{stem}{i}.{ext}").write_text("x")
+    return root
+
+
+class _StubClient:
+    """A concrete client stand-in that records how it was driven."""
+
+    def __init__(self, *, initializes: bool = True) -> None:
+        self.initializes = initializes
+        self.initialized_with: str | None = None
+        self.shutdown_called = False
+        self.last_error: str | None = None if initializes else "server said no"
+
+    @property
+    def is_available(self) -> bool:
+        return self.initialized_with is not None and self.initializes
+
+    async def initialize(self, project_path: str) -> bool:
+        self.initialized_with = project_path
+        return self.initializes
+
+    async def get_definition(self, *_a):
+        return ["definition"]
+
+    async def get_references(self, *_a):
+        return ["reference"]
+
+    async def get_hover(self, *_a):
+        return "hover"
+
+    async def shutdown(self) -> None:
+        self.shutdown_called = True
+
+
+def _support(installed: dict[str, _StubClient], missing: tuple[str, ...] = ()):
+    entries = {
+        lang: (lambda: True, lambda c=client: c)
+        for lang, client in installed.items()
+    }
+    for lang in missing:
+        entries[lang] = (lambda: False, lambda: _StubClient())
+    return entries
+
+
+# ---------------------------------------------------------------------------
+# detect_project_language
+# ---------------------------------------------------------------------------
+
+
+class TestDetectProjectLanguage:
+    def test_typescript_project(self, tmp_path: Path) -> None:
+        _tree(tmp_path, {"src/app.ts": 5, "src/util.js": 2})
+        assert detect_project_language(str(tmp_path)) == "typescript"
+
+    def test_python_project(self, tmp_path: Path) -> None:
+        _tree(tmp_path, {"pkg/mod.py": 6})
+        assert detect_project_language(str(tmp_path)) == "python"
+
+    def test_java_and_kotlin_count_as_one_language(self, tmp_path: Path) -> None:
+        _tree(tmp_path, {"src/A.java": 2, "src/B.kt": 2, "web/app.ts": 3})
+        assert detect_project_language(str(tmp_path)) == "java"
+
+    def test_majority_wins_in_a_mixed_repo(self, tmp_path: Path) -> None:
+        _tree(tmp_path, {"api/svc.py": 20, "web/app.ts": 3})
+        assert detect_project_language(str(tmp_path)) == "python"
+
+    def test_vendored_directories_do_not_decide_the_language(
+        self, tmp_path: Path
+    ) -> None:
+        """A Python app with a bundled JS dependency is still a Python app."""
+        _tree(tmp_path, {"app/main.py": 4})
+        _tree(tmp_path, {"node_modules/pkg/index.js": 50})
+        assert detect_project_language(str(tmp_path)) == "python"
+
+    def test_hidden_directories_are_skipped(self, tmp_path: Path) -> None:
+        _tree(tmp_path, {"app/main.py": 3})
+        _tree(tmp_path, {".cache/gen/thing.ts": 40})
+        assert detect_project_language(str(tmp_path)) == "python"
+
+    def test_no_recognised_source_returns_none(self, tmp_path: Path) -> None:
+        _tree(tmp_path, {"docs/readme.md": 3})
+        assert detect_project_language(str(tmp_path)) is None
+
+    def test_empty_project_returns_none(self, tmp_path: Path) -> None:
+        assert detect_project_language(str(tmp_path)) is None
+
+    def test_tie_is_broken_deterministically(self, tmp_path: Path) -> None:
+        """Equal counts must resolve the same way on every scan."""
+        _tree(tmp_path, {"a/x.ts": 3, "b/y.py": 3})
+        first = detect_project_language(str(tmp_path))
+        assert first == detect_project_language(str(tmp_path))
+        assert first == "typescript"  # declaration order in LANGUAGE_EXTENSIONS
+
+
+# ---------------------------------------------------------------------------
+# LanguageRoutingLSPClient
+# ---------------------------------------------------------------------------
+
+
+class TestLanguageRouting:
+    @pytest.mark.asyncio
+    async def test_python_project_gets_the_python_server(
+        self, tmp_path: Path
+    ) -> None:
+        """The whole point: this used to hand a Python repo tsserver."""
+        _tree(tmp_path, {"app/main.py": 5})
+        py, ts = _StubClient(), _StubClient()
+        client = LanguageRoutingLSPClient(
+            _support({"python": py, "typescript": ts})
+        )
+
+        assert await client.initialize(str(tmp_path)) is True
+        assert py.initialized_with == str(tmp_path)
+        assert ts.initialized_with is None
+
+    @pytest.mark.asyncio
+    async def test_typescript_project_gets_the_typescript_server(
+        self, tmp_path: Path
+    ) -> None:
+        _tree(tmp_path, {"src/app.ts": 5})
+        py, ts = _StubClient(), _StubClient()
+        client = LanguageRoutingLSPClient(
+            _support({"python": py, "typescript": ts})
+        )
+
+        assert await client.initialize(str(tmp_path)) is True
+        assert ts.initialized_with == str(tmp_path)
+        assert py.initialized_with is None
+
+    @pytest.mark.asyncio
+    async def test_missing_server_does_not_fall_back_to_another_language(
+        self, tmp_path: Path
+    ) -> None:
+        """A server for the wrong language is a confident silence, not a
+        partial answer — which is exactly the bug this replaces."""
+        _tree(tmp_path, {"app/main.py": 5})
+        ts = _StubClient()
+        client = LanguageRoutingLSPClient(
+            _support({"typescript": ts}, missing=("python",))
+        )
+
+        assert await client.initialize(str(tmp_path)) is False
+        assert ts.initialized_with is None
+        assert "python" in (client.last_error or "")
+        assert "setup --lsp" in (client.last_error or "")
+
+    @pytest.mark.asyncio
+    async def test_unrecognised_project_reports_why(self, tmp_path: Path) -> None:
+        _tree(tmp_path, {"docs/readme.md": 2})
+        client = LanguageRoutingLSPClient(_support({"python": _StubClient()}))
+
+        assert await client.initialize(str(tmp_path)) is False
+        assert "No language" in (client.last_error or "")
+
+    @pytest.mark.asyncio
+    async def test_delegate_failure_surfaces_its_reason(
+        self, tmp_path: Path
+    ) -> None:
+        _tree(tmp_path, {"app/main.py": 3})
+        py = _StubClient(initializes=False)
+        client = LanguageRoutingLSPClient(_support({"python": py}))
+
+        assert await client.initialize(str(tmp_path)) is False
+        assert client.last_error == "server said no"
+
+    @pytest.mark.asyncio
+    async def test_requests_reach_the_chosen_delegate(
+        self, tmp_path: Path
+    ) -> None:
+        _tree(tmp_path, {"app/main.py": 3})
+        client = LanguageRoutingLSPClient(_support({"python": _StubClient()}))
+        await client.initialize(str(tmp_path))
+
+        assert await client.get_definition("f", 0, 0) == ["definition"]
+        assert await client.get_references("f", 0, 0) == ["reference"]
+        assert await client.get_hover("f", 0, 0) == "hover"
+        assert client.is_available is True
+
+    @pytest.mark.asyncio
+    async def test_requests_before_initialize_are_safe(self) -> None:
+        client = LanguageRoutingLSPClient(_support({}))
+        assert await client.get_definition("f", 0, 0) is None
+        assert await client.get_references("f", 0, 0) is None
+        assert await client.get_hover("f", 0, 0) is None
+        assert client.is_available is False
+        await client.shutdown()  # must not raise
+
+    @pytest.mark.asyncio
+    async def test_shutdown_closes_the_delegate(self, tmp_path: Path) -> None:
+        _tree(tmp_path, {"app/main.py": 3})
+        py = _StubClient()
+        client = LanguageRoutingLSPClient(_support({"python": py}))
+        await client.initialize(str(tmp_path))
+
+        await client.shutdown()
+
+        assert py.shutdown_called is True
+        assert client.is_available is False
+
+    @pytest.mark.asyncio
+    async def test_reinitialising_reselects(self, tmp_path: Path) -> None:
+        """One agent can scan a Python repo and then a TypeScript one."""
+        py, ts = _StubClient(), _StubClient()
+        client = LanguageRoutingLSPClient(
+            _support({"python": py, "typescript": ts})
+        )
+        python_repo = _tree(tmp_path / "py", {"app/main.py": 3})
+        ts_repo = _tree(tmp_path / "ts", {"src/app.ts": 3})
+
+        await client.initialize(str(python_repo))
+        await client.initialize(str(ts_repo))
+
+        assert py.initialized_with == str(python_repo)
+        assert ts.initialized_with == str(ts_repo)


### PR DESCRIPTION
## The problem

The LSP client was chosen while the **agent** was being built — before anything had been ingested — so the only thing the choice could go on was what happened to be installed. With Node present that was always the TypeScript server:

```
$ isitsecure scan --repo <a pure-Python repo> --mode code-only -v
LSP ENABLED: TypeScript Language Server (typescript-language-server=yes, npx=yes)
```

A server that can't read the code finds nothing, so those scans quietly fell back to regex-only auth analysis. The Python and Java clients were effectively unreachable on any machine with Node — which is also why the pylsp bug in #154 survived four green benchmark runs.

## The change

`initialize(project_path)` is the first moment the project actually exists, so the choice belongs there. `LanguageRoutingLSPClient` implements `LSPClientProtocol` and delegates to whichever concrete client fits — which keeps the decision out of the agent and collapses the factory's availability chain to one line.

Language is read off the tree by counting source files:

| Language | Counted | Server |
|---|---|---|
| TypeScript / JavaScript | `.ts` `.tsx` `.js` `.jsx` `.mjs` `.cjs` | typescript-language-server |
| Python | `.py` `.pyi` | pylsp / pyright-langserver |
| Java / Kotlin | `.java` `.kt` `.kts` | jdtls |

Vendored, generated and hidden directories don't count, so a Python service with a bundled JavaScript dependency is still scanned as Python. Ties break on declaration order, so repeated scans of one repo always choose the same server.

**It won't substitute.** If the project's language has no server installed, it stops and names the one it wanted:

```
No python language server installed — auth-flow tracing is skipped for this
scan. Install one with `isitsecure setup --lsp`.
```

A mismatched server isn't a partial answer — it reports nothing, which reads as "no problems here" rather than "not checked". That's the bug being replaced; keeping it as a fallback would preserve it.

**One landmine cleared:** the agent detected the no-op client with `hasattr(client, '_process')` — sniffing a private attribute. The routing client has no `_process`, so that check would have skipped LSP entirely. It now asks the client what it is.

## Verification

| Check | Result |
|---|---|
| **Python repo** | `Project language: python (python 178, typescript 14)` → **`PythonLSPClient`** (was TypeScript) |
| **Python repo, no python server installed** | Names the missing server, declines the available TypeScript one, regex fallback |
| test-app | typescript → `TypeScriptLSPClient`, **114** findings |
| juice-shop repo-mode | typescript → `TypeScriptLSPClient`, **198** findings |
| Juice Shop live DAST | **26** findings — category-for-category identical |
| sast-injection benchmark | **46/46 recall, 0 FP** |
| VAmPI benchmark | **3/3 recall** |
| Unit suite | **2267 passed**, 1 xfailed (+18 new) |
| Ruff | no delta on any touched file; new module clean |

**Behaviour change worth calling out:** the injection benchmark's fixture is polyglot (4 `.ts`, 3 `.py`, 3 `.java`, 3 `.kt`), and `.java`+`.kt` together outnumber `.ts` — so it now routes to **jdtls** instead of tsserver. Correct for that tree, recall and FP unchanged, ~2.6s slower. Flagging because it's a real routing change on a benchmark path.

## Docs

`docs/lsp-setup.md` documented first-available selection, including the now-false line *"If your project is Python but you have TypeScript LSP installed, the TS LSP will be initialized — but it won't find any routes"*. Replaced with the extension table and the no-substitution rule; also removed a quoted `LSP DISABLED:` message that no longer exists in the code. `docs/architecture.md` degradation row updated.

## Known limit

Detection is by file count — a good proxy, not infallible. A small Python API with a large generated TypeScript client would route to TypeScript. `repo_snapshot.framework` is already computed during ingestion and could refine this, but the router deliberately takes only a path so it works for any caller and stays testable. Contained follow-up if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EZ4QoTqRoYWE25CNoV2Wfy
