### PR TITLE
fix(lsp): make auth-flow tracing and LSP suppression actually work

### DIFF
--- a/isitsecure/engine/agent.py
+++ b/isitsecure/engine/agent.py
@@ -807,16 +807,20 @@ class DeepSecurityScanAgent:
                 )
 
                 # Validate SAST findings with LSP results
+                before_ids = {f.id for f in sast_code_findings}
                 for scanner in self._sast_scanners:
                     if hasattr(scanner, "validate_with_lsp"):
                         sast_code_findings = scanner.validate_with_lsp(
                             sast_code_findings, auth_flow_results
                         )
 
-                # Rebuild all_findings from validated sast_code_findings
-                # (remove suppressed findings from the deep findings list)
-                suppressed_ids = {
-                    f.id for f in sast_code_findings if f.lsp_suppressed
+                # Drop the deep findings whose code findings the tracer
+                # disproved. Derive that from what actually left the list:
+                # validate_with_lsp *removes* suppressed findings rather than
+                # returning them flagged, so filtering the returned list on
+                # `lsp_suppressed` always found nothing.
+                suppressed_ids = before_ids - {
+                    f.id for f in sast_code_findings
                 }
                 all_findings = [
                     f for f in all_findings
@@ -2258,6 +2262,10 @@ class DeepSecurityScanAgent:
                 github_url=cf.github_url,
             )
         return DeepFinding(
+            # Keep the code finding's identity: LSP validation matches deep
+            # findings back to the code findings it suppressed, and a fresh
+            # uuid here made that match impossible.
+            id=cf.id,
             source=FindingSource.SAST_CODE,
             category=cf.category,
             severity=cf.severity,

--- a/isitsecure/engine/code_analysis/lsp/auth_flow_tracer.py
+++ b/isitsecure/engine/code_analysis/lsp/auth_flow_tracer.py
@@ -324,7 +324,20 @@ class AuthFlowTracer:
     async def _trace_inline_auth(
         self, content: str, abs_path: str
     ) -> AuthFlowResult | None:
-        """Check for inline auth calls (getUser, getSession, etc.)."""
+        """Check for inline auth calls, following local helpers one hop.
+
+        A route may verify auth itself (``supabase.auth.getUser()`` in the
+        handler), which the terminal patterns catch directly. Far more often
+        it calls the project's own helper::
+
+            import { getUserFromRequest } from "@/lib/auth"
+            const user = getUserFromRequest(request)   // -> verifyToken()
+
+        The terminal is then a file away, and no pattern list can name it —
+        ``getUserFromRequest`` is this project's invention. Resolving it is
+        exactly what go-to-definition is for, and not doing so meant every
+        such route looked unauthenticated.
+        """
         auth_method = self._find_auth_terminal(content)
         if auth_method:
             return AuthFlowResult(
@@ -334,11 +347,102 @@ class AuthFlowTracer:
                 confidence=LSPConfig.CONFIDENCE_LSP_CONFIRMED,
                 trace_depth=0,
             )
+
+        for symbol in self._called_local_imports(content):
+            match = re.search(rf"\b{re.escape(symbol)}\s*\(", content)
+            if not match:
+                continue
+            line, char = self._offset_to_position(content, match.start())
+            definition = await self._trace_definition_body(abs_path, line, char)
+            if not definition:
+                continue
+
+            auth_method = self._find_auth_terminal(definition)
+            if auth_method:
+                return AuthFlowResult(
+                    has_verified_auth=True,
+                    auth_method=auth_method,
+                    middleware_chain=[symbol],
+                    confidence=LSPConfig.CONFIDENCE_LSP_CONFIRMED,
+                    trace_depth=1,
+                )
         return None
+
+    @staticmethod
+    def _called_local_imports(content: str) -> list[str]:
+        """Named imports from the project's own modules that this file calls.
+
+        Package imports are skipped: a helper that verifies *this* app's
+        sessions lives in the app. Note ``@/lib/auth`` is a project alias
+        while ``@supabase/supabase-js`` is a package — only the former starts
+        with ``@/``.
+        """
+        symbols: list[str] = []
+        for match in re.finditer(
+            r"import\s*\{([^}]*)\}\s*from\s*[\'\"]([^\'\"]+)[\'\"]", content
+        ):
+            names, module = match.group(1), match.group(2)
+            if not module.startswith(LSPConfig.LOCAL_MODULE_PREFIXES):
+                continue
+            for raw in names.split(","):
+                # `foo as bar` is called as `bar`
+                name = raw.split(" as ")[-1].strip()
+                if not name or name in symbols:
+                    continue
+                if re.search(rf"\b{re.escape(name)}\s*\(", content):
+                    symbols.append(name)
+        return symbols[: LSPConfig.MAX_INLINE_TRACE_SYMBOLS]
 
     # ------------------------------------------------------------------
     # LSP-powered definition tracing
     # ------------------------------------------------------------------
+
+    async def _resolve_definition(
+        self, file_path: str, line: int, character: int
+    ) -> list | None:
+        """Go-to-definition, waiting out the project load if it isn't ready.
+
+        tsserver builds its program asynchronously after the first
+        ``didOpen``. Until that finishes it still answers definition
+        requests — by pointing at the *import statement* in the querying
+        file rather than the declaration it names. That answer is
+        indistinguishable from success unless you look at where it landed,
+        so every trace silently stopped at the import and no route ever
+        looked authenticated.
+
+        A loaded project answers correctly on the first try and pays
+        nothing here; a cold one is retried until it does.
+        """
+        for attempt in range(LSPConfig.PROJECT_LOAD_RETRIES):
+            locations = await self._lsp.get_definition(
+                file_path, line, character
+            )
+            if not locations or not self._is_unresolved(locations, file_path):
+                return locations
+            await asyncio.sleep(
+                LSPConfig.PROJECT_LOAD_BACKOFF_SECONDS * (attempt + 1)
+            )
+        return locations
+
+    def _is_unresolved(self, locations: list, file_path: str) -> bool:
+        """True when every location is an import line in the querying file.
+
+        That is the shape tsserver returns before its program is built. A
+        genuinely local declaration also lands in the same file, so the
+        import check is what separates "not ready" from "defined here".
+        """
+        content = self._get_file_content_absolute(file_path)
+        if not content:
+            return False
+        lines = content.split("\n")
+        for loc in locations:
+            if loc.file_path != file_path:
+                return False
+            if not (0 <= loc.line < len(lines)):
+                return False
+            if not lines[loc.line].lstrip().startswith(("import ", "import{")):
+                return False
+        return True
 
     async def _trace_definition(
         self,
@@ -354,7 +458,7 @@ class AuthFlowTracer:
         if depth >= LSPConfig.MAX_TRACE_DEPTH:
             return None
 
-        locations = await self._lsp.get_definition(file_path, line, character)
+        locations = await self._resolve_definition(file_path, line, character)
         if not locations:
             return None
 
@@ -373,6 +477,51 @@ class AuthFlowTracer:
                 return def_content
 
         return None
+
+    async def _trace_definition_body(
+        self, file_path: str, line: int, character: int
+    ) -> str | None:
+        """Go-to-definition, returning only the resolved symbol's own body.
+
+        Scoping matters: helper functions cluster in one module, so a file
+        reached by resolving *any* symbol usually also contains the auth
+        terminals belonging to its siblings. Searching the whole file made a
+        login route — which imports ``signToken`` from the same module that
+        defines ``verifyToken`` — look authenticated.
+        """
+        locations = await self._resolve_definition(file_path, line, character)
+        if not locations:
+            return None
+
+        for loc in locations:
+            if loc.file_path == file_path and loc.line == line:
+                continue
+            if "node_modules" in loc.file_path:
+                continue
+            content = self._get_file_content_absolute(loc.file_path)
+            if content:
+                return self._enclosing_block(content, loc.line)
+        return None
+
+    @staticmethod
+    def _enclosing_block(content: str, line: int) -> str:
+        """The declaration starting at ``line``, up to its closing brace.
+
+        Ends at the first closing brace in the declaration's own column, so a
+        top-level function stops before its neighbours. Falls back to the
+        remainder of the file if no such brace is found.
+        """
+        lines = content.split("\n")
+        if not (0 <= line < len(lines)):
+            return content
+
+        start = lines[line]
+        indent = len(start) - len(start.lstrip())
+        closing = (" " * indent) + "}"
+        for end in range(line + 1, len(lines)):
+            if lines[end].rstrip() == closing:
+                return "\n".join(lines[line : end + 1])
+        return "\n".join(lines[line:])
 
     # ------------------------------------------------------------------
     # Pattern matching helpers (DRY — shared across strategies)

--- a/isitsecure/engine/constants.py
+++ b/isitsecure/engine/constants.py
@@ -4752,6 +4752,23 @@ class LSPConfig:
         "exclude": ["node_modules", "dist", "build", ".next"],
     }
 
+    # tsserver loads a project asynchronously after the first didOpen, and
+    # answers definition requests in the meantime by pointing at the import
+    # statement rather than the real declaration. These bound the wait for it
+    # to finish: a loaded project answers correctly first time and pays
+    # nothing, a cold one is retried until it does.
+    PROJECT_LOAD_RETRIES = 6
+    PROJECT_LOAD_BACKOFF_SECONDS = 0.5
+
+    # How many project-local helpers a route may be followed through when
+    # looking for the auth terminal. Routes import few symbols; this only
+    # bounds a pathological file.
+    MAX_INLINE_TRACE_SYMBOLS = 6
+
+    # Module prefixes that mean "this project's own code", as opposed to a
+    # package in node_modules. The auth helper we're chasing is project code.
+    LOCAL_MODULE_PREFIXES = (".", "@/", "~/", "src/")
+
     # --- Auth terminal patterns ---
     # Functions/methods that confirm real authentication is happening.
     # Generic patterns that work across frameworks (Supabase, Firebase,

--- a/tests/engine/test_code_analysis/test_auth_flow_tracer.py
+++ b/tests/engine/test_code_analysis/test_auth_flow_tracer.py
@@ -573,3 +573,155 @@ class TestTraceFallback:
         # trace it, so the tracer can't confirm it — falls to fallback
         assert result.has_verified_auth is False
         assert result.confidence == 0.5
+
+
+# ---------------------------------------------------------------------------
+# Definition resolution: local helpers, scoping, and project-load readiness
+# ---------------------------------------------------------------------------
+
+
+class _Loc:
+    def __init__(self, file_path: str, line: int) -> None:
+        self.file_path, self.line = file_path, line
+
+
+# ---------------------------------------------------------------------------
+# _called_local_imports
+# ---------------------------------------------------------------------------
+
+
+class TestCalledLocalImports:
+    def test_finds_a_called_helper_from_a_project_alias(self) -> None:
+        src = '''
+import { getUserFromRequest } from "@/lib/auth"
+export async function GET(request: Request) {
+  const user = getUserFromRequest(request)
+}
+'''
+        assert AuthFlowTracer._called_local_imports(src) == ["getUserFromRequest"]
+
+    def test_relative_imports_count_as_local(self) -> None:
+        src = 'import { requireUser } from "../lib/auth"\nrequireUser(req)\n'
+        assert AuthFlowTracer._called_local_imports(src) == ["requireUser"]
+
+    def test_package_imports_are_skipped(self) -> None:
+        """`@/lib/auth` is a project alias; `@supabase/supabase-js` is a
+        package. Only the first is this app's own code."""
+        src = (
+            'import { createClient } from "@supabase/supabase-js"\n'
+            'import { NextResponse } from "next/server"\n'
+            "createClient()\nNextResponse.json({})\n"
+        )
+        assert AuthFlowTracer._called_local_imports(src) == []
+
+    def test_imported_but_never_called_is_ignored(self) -> None:
+        src = 'import { helper, unused } from "@/lib/x"\nhelper()\n'
+        assert AuthFlowTracer._called_local_imports(src) == ["helper"]
+
+    def test_aliased_import_is_matched_on_its_local_name(self) -> None:
+        src = 'import { getUser as currentUser } from "@/lib/auth"\ncurrentUser(req)\n'
+        assert AuthFlowTracer._called_local_imports(src) == ["currentUser"]
+
+    def test_duplicates_are_not_repeated(self) -> None:
+        src = 'import { f } from "@/a"\nimport { f } from "@/b"\nf()\n'
+        assert AuthFlowTracer._called_local_imports(src) == ["f"]
+
+    def test_the_number_of_symbols_is_bounded(self) -> None:
+        """One definition request per symbol — a wide import list must not
+        turn one route into a dozen LSP round trips."""
+        from isitsecure.engine.constants import LSPConfig
+
+        names = [f"f{i}" for i in range(20)]
+        src = (
+            'import { ' + ", ".join(names) + ' } from "@/lib/x"\n'
+            + "\n".join(f"{n}()" for n in names)
+        )
+        found = AuthFlowTracer._called_local_imports(src)
+        assert len(found) == LSPConfig.MAX_INLINE_TRACE_SYMBOLS
+
+
+# ---------------------------------------------------------------------------
+# _enclosing_block
+# ---------------------------------------------------------------------------
+
+
+MODULE = '''export function signToken(payload: object) {
+  return sign(payload)
+}
+
+export function verifyToken(token: string) {
+  return jwt.verify(token, SECRET)
+}
+'''
+
+
+class TestEnclosingBlock:
+    def test_returns_only_the_declaration_at_that_line(self) -> None:
+        """The bug this prevents: a login route imports `signToken` from the
+        module that also defines `verifyToken`, and searching the whole file
+        made the route look authenticated."""
+        block = AuthFlowTracer._enclosing_block(MODULE, 0)
+        assert "signToken" in block
+        assert "verifyToken" not in block
+
+    def test_a_later_declaration_is_scoped_too(self) -> None:
+        block = AuthFlowTracer._enclosing_block(MODULE, 4)
+        assert "jwt.verify" in block
+        assert "signToken" not in block
+
+    def test_out_of_range_line_returns_everything(self) -> None:
+        assert AuthFlowTracer._enclosing_block(MODULE, 999) == MODULE
+
+    def test_unterminated_declaration_returns_the_remainder(self) -> None:
+        src = "export function open() {\n  doThing()\n"
+        assert "doThing" in AuthFlowTracer._enclosing_block(src, 0)
+
+    def test_indented_declaration_ends_at_its_own_indent(self) -> None:
+        src = "class A {\n  method() {\n    check()\n  }\n\n  other() {}\n}\n"
+        block = AuthFlowTracer._enclosing_block(src, 1)
+        assert "check()" in block
+        assert "other()" not in block
+
+
+# ---------------------------------------------------------------------------
+# _is_unresolved
+# ---------------------------------------------------------------------------
+
+
+ROUTE = '''import { getUserFromRequest } from "@/lib/auth"
+
+export function GET(request: Request) {
+  const user = getUserFromRequest(request)
+}
+'''
+
+
+class TestIsUnresolved:
+    @staticmethod
+    def _tracer(content: str) -> AuthFlowTracer:
+        tracer = AuthFlowTracer.__new__(AuthFlowTracer)
+        tracer._get_file_content_absolute = lambda _p: content  # type: ignore[method-assign]
+        return tracer
+
+    def test_a_hit_on_the_import_line_means_the_project_is_still_loading(
+        self,
+    ) -> None:
+        """tsserver answers with the import statement until its program is
+        built — indistinguishable from success unless you look at where it
+        landed."""
+        tracer = self._tracer(ROUTE)
+        assert tracer._is_unresolved([_Loc("/r.ts", 0)], "/r.ts") is True
+
+    def test_a_definition_in_another_file_is_resolved(self) -> None:
+        tracer = self._tracer(ROUTE)
+        assert tracer._is_unresolved([_Loc("/lib/auth.ts", 5)], "/r.ts") is False
+
+    def test_a_same_file_declaration_is_resolved_not_pending(self) -> None:
+        """A locally-declared helper legitimately resolves to this file; only
+        landing on an *import* line means "not ready"."""
+        tracer = self._tracer(ROUTE)
+        assert tracer._is_unresolved([_Loc("/r.ts", 2)], "/r.ts") is False
+
+    def test_unknown_content_is_treated_as_resolved(self) -> None:
+        tracer = self._tracer("")
+        assert tracer._is_unresolved([_Loc("/r.ts", 0)], "/r.ts") is False

--- a/tests/engine/test_scan_phases.py
+++ b/tests/engine/test_scan_phases.py
@@ -358,6 +358,42 @@ class TestLSPInitialization:
 
 class TestLSPValidation:
     @pytest.mark.asyncio
+    async def test_a_disproved_finding_is_removed_from_the_report(self) -> None:
+        """The whole point of LSP validation.
+
+        `validate_with_lsp` *drops* the findings it disproves rather than
+        returning them flagged, so the suppressed set is what left the list.
+        """
+        kept, disproved = _code_finding(), _code_finding(suppressed=True)
+        scanner = _sast_scanner(
+            [kept, disproved],
+            # Mirrors the real analyzer: suppressed findings do not come back.
+            validate=lambda findings, _flows: [
+                f for f in findings if not f.lsp_suppressed
+            ],
+        )
+        ingestion = AsyncMock()
+        ingestion.ingest.return_value = _repo_snapshot()
+
+        agent = _agent(
+            repo_ingestion_service=ingestion,
+            lsp_client=_lsp_client(),
+            sast_scanners=[scanner],
+        )
+        with patch(
+            "isitsecure.engine.code_analysis.lsp.auth_flow_tracer.AuthFlowTracer"
+        ) as tracer_cls:
+            tracer_cls.return_value.trace_routes = AsyncMock(return_value={})
+            events = await _collect(agent.scan(
+                repo_url="https://github.com/o/r", scan_mode=ScanMode.CODE_ONLY
+            ))
+
+        report = _report(events)
+        assert "lsp_validator" in report["scanners_run"]
+        assert len(report["findings"]) == 1
+        assert report["findings"][0]["id"] == kept.id
+
+    @pytest.mark.asyncio
     async def test_findings_the_tracer_confirms_are_kept(self) -> None:
         """Suppression must remove only what was disproved, nothing else."""
         a, b = _code_finding(), _code_finding()

--- a/tests/engine/test_scan_phases.py
+++ b/tests/engine/test_scan_phases.py
@@ -1,0 +1,1002 @@
+"""Characterization tests for the scan phases that had no coverage.
+
+`DeepSecurityScanAgent.scan()` is 871 lines across 19 phases, and roughly 40%
+of it was unreachable by the existing tests — the phases needing an LLM client
+or authenticated sessions, which no unit test and no `--llm none` live scan
+ever executed.
+
+These pin down what those phases *currently do*, so that moving them (into a
+ScanContext-based decomposition) has to preserve it. They deliberately assert
+observable behaviour — which scanner names land in `scanners_run`, which
+findings survive, which collaborators get called with what — rather than
+internal structure, so they stay true across the refactor.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from isitsecure.engine.agent import DeepSecurityScanAgent
+from isitsecure.engine.enums import (
+    DeepScanPhase,
+    FindingCategory,
+    ScanMode,
+    SeverityLevel,
+)
+from isitsecure.engine.models import (
+    DeepFinding,
+    DiscoveredEndpoint,
+    FindingSource,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _finding(title: str = "A finding", **kwargs) -> DeepFinding:
+    defaults = {
+        "source": FindingSource.DAST_URL,
+        "category": FindingCategory.IDOR,
+        "severity": SeverityLevel.HIGH,
+        "title": title,
+        "description": "d",
+        "confidence": 0.9,
+        "scanner_name": "test_scanner",
+    }
+    defaults.update(kwargs)
+    return DeepFinding(**defaults)
+
+
+def _code_finding(suppressed: bool = False):
+    from isitsecure.engine.code_analysis.models import CodeFinding
+
+    return CodeFinding(
+        scanner_name="route_auth",
+        severity=SeverityLevel.HIGH,
+        category=FindingCategory.AUTH_WEAKNESS,
+        title="Missing auth",
+        description="d",
+        file_path="src/api/route.ts",
+        line_number=10,
+        confidence=0.85,
+        lsp_suppressed=suppressed,
+    )
+
+
+def _repo_snapshot():
+    return MagicMock(branch="main", commit_hash="abc123", route_map=["/api/a"])
+
+
+def _agent(**kwargs) -> DeepSecurityScanAgent:
+    """An agent whose network-touching collaborators are all inert."""
+    ingestion = AsyncMock()
+    snapshot = MagicMock()
+    snapshot.all_js_content = "js"
+    snapshot.html_content = "<html></html>"
+    snapshot.assets = []
+    ingestion.ingest.return_value = snapshot
+
+    endpoint_scanner = AsyncMock()
+    endpoint_scanner.discover.return_value = kwargs.pop("endpoints", [])
+
+    kwargs.setdefault("ingestion_service", ingestion)
+    kwargs.setdefault("endpoint_scanner", endpoint_scanner)
+    return DeepSecurityScanAgent(**kwargs)
+
+
+async def _collect(gen) -> list:
+    return [e async for e in gen]
+
+
+def _report(events) -> dict:
+    return events[-1].data["report"]
+
+
+@pytest.fixture(autouse=True)
+def _offline(monkeypatch):
+    """Keep every test in this module off the network.
+
+    `scan()` builds the OOB service and the DOM XSS scanner itself; unstubbed
+    they reach the live oob.isitsecure.ai and launch a browser.
+    """
+    class _NoOOB:
+        is_registered = False
+
+        async def register(self) -> bool:
+            return False
+
+    class _NoDOMXSS:
+        SCANNER_NAME = "dom_xss_scanner"
+
+        async def scan(self, **_kwargs) -> list:
+            return []
+
+    monkeypatch.setattr(
+        "isitsecure.engine.shared.oob_callback.OOBCallbackService", _NoOOB
+    )
+    monkeypatch.setattr(
+        "isitsecure.engine.scanners.dom_xss_scanner.DOMXSSScanner", _NoDOMXSS
+    )
+
+
+# ---------------------------------------------------------------------------
+# Phase 5.5 — cross-probe analysis
+# ---------------------------------------------------------------------------
+
+
+class TestCrossProbeAnalysis:
+    @pytest.mark.asyncio
+    async def test_analyzer_findings_are_added_and_recorded(self) -> None:
+        xss = AsyncMock()
+        xss.scanner_name = "xss_scanner"
+        xss.scan.return_value = [_finding("dast finding")]
+
+        analyzer = MagicMock()
+        analyzer.analyze = AsyncMock(return_value=[_finding("correlated")])
+
+        agent = _agent(
+            endpoints=[DiscoveredEndpoint(url="https://example.com/a")],
+            dast_scanners=[xss],
+        )
+        with patch(
+            "isitsecure.engine.shared.probe_analyzer.ProbeAnalyzer",
+            return_value=analyzer,
+        ):
+            events = await _collect(agent.scan(target_url="https://example.com"))
+
+        report = _report(events)
+        assert "probe_analyzer" in report["scanners_run"]
+        assert any(f["title"] == "correlated" for f in report["findings"])
+
+    @pytest.mark.asyncio
+    async def test_not_recorded_when_it_finds_nothing(self) -> None:
+        xss = AsyncMock()
+        xss.scanner_name = "xss_scanner"
+        xss.scan.return_value = [_finding()]
+        analyzer = MagicMock()
+        analyzer.analyze = AsyncMock(return_value=[])
+
+        agent = _agent(
+            endpoints=[DiscoveredEndpoint(url="https://example.com/a")],
+            dast_scanners=[xss],
+        )
+        with patch(
+            "isitsecure.engine.shared.probe_analyzer.ProbeAnalyzer",
+            return_value=analyzer,
+        ):
+            events = await _collect(agent.scan(target_url="https://example.com"))
+
+        assert "probe_analyzer" not in _report(events)["scanners_run"]
+
+    @pytest.mark.asyncio
+    async def test_a_failing_analyzer_does_not_lose_findings(self) -> None:
+        """Fail open — an analysis step must never cost us real findings."""
+        xss = AsyncMock()
+        xss.scanner_name = "xss_scanner"
+        xss.scan.return_value = [_finding("real")]
+        analyzer = MagicMock()
+        analyzer.analyze = AsyncMock(side_effect=RuntimeError("boom"))
+
+        agent = _agent(
+            endpoints=[DiscoveredEndpoint(url="https://example.com/a")],
+            dast_scanners=[xss],
+        )
+        with patch(
+            "isitsecure.engine.shared.probe_analyzer.ProbeAnalyzer",
+            return_value=analyzer,
+        ):
+            events = await _collect(agent.scan(target_url="https://example.com"))
+
+        report = _report(events)
+        assert any(f["title"] == "real" for f in report["findings"])
+        assert "probe_analyzer" not in report["scanners_run"]
+
+
+# ---------------------------------------------------------------------------
+# Phase 3.5 / 5.6 — OOB callback registration and collection
+# ---------------------------------------------------------------------------
+
+
+class TestOOBCallback:
+    @staticmethod
+    def _oob(findings, *, registered=True, poll_error=None):
+        service = MagicMock()
+        service.is_registered = registered
+        service.register = AsyncMock(return_value=registered)
+        service.poll = AsyncMock(side_effect=poll_error) if poll_error else AsyncMock()
+        service.get_findings = MagicMock(return_value=findings)
+        return service
+
+    @pytest.mark.asyncio
+    async def test_confirmed_callbacks_become_findings(self, monkeypatch) -> None:
+        service = self._oob([_finding("blind ssrf confirmed")])
+        monkeypatch.setattr(
+            "isitsecure.engine.shared.oob_callback.OOBCallbackService",
+            lambda: service,
+        )
+        agent = _agent(endpoints=[DiscoveredEndpoint(url="https://example.com/a")])
+
+        events = await _collect(agent.scan(target_url="https://example.com"))
+
+        report = _report(events)
+        assert "oob_callback" in report["scanners_run"]
+        assert any(f["title"] == "blind ssrf confirmed" for f in report["findings"])
+
+    @pytest.mark.asyncio
+    async def test_no_interactions_is_not_recorded_as_a_scanner(
+        self, monkeypatch
+    ) -> None:
+        service = self._oob([])
+        monkeypatch.setattr(
+            "isitsecure.engine.shared.oob_callback.OOBCallbackService",
+            lambda: service,
+        )
+        agent = _agent(endpoints=[DiscoveredEndpoint(url="https://example.com/a")])
+
+        events = await _collect(agent.scan(target_url="https://example.com"))
+
+        assert "oob_callback" not in _report(events)["scanners_run"]
+
+    @pytest.mark.asyncio
+    async def test_unregistered_service_is_never_polled(self, monkeypatch) -> None:
+        service = self._oob([], registered=False)
+        monkeypatch.setattr(
+            "isitsecure.engine.shared.oob_callback.OOBCallbackService",
+            lambda: service,
+        )
+        agent = _agent(endpoints=[DiscoveredEndpoint(url="https://example.com/a")])
+
+        await _collect(agent.scan(target_url="https://example.com"))
+
+        service.poll.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_a_failing_poll_does_not_end_the_scan(self, monkeypatch) -> None:
+        service = self._oob([], poll_error=RuntimeError("network gone"))
+        monkeypatch.setattr(
+            "isitsecure.engine.shared.oob_callback.OOBCallbackService",
+            lambda: service,
+        )
+        agent = _agent(endpoints=[DiscoveredEndpoint(url="https://example.com/a")])
+
+        events = await _collect(agent.scan(target_url="https://example.com"))
+
+        assert events[-1].phase == DeepScanPhase.COMPLETE
+        assert "report" in events[-1].data
+
+
+# ---------------------------------------------------------------------------
+# Phase 6.5 / 7.5 — LSP initialization and validation
+# ---------------------------------------------------------------------------
+
+
+def _lsp_client(*, initializes=True, error=None):
+    client = MagicMock()
+    client.is_available = initializes
+    client.last_error = error
+    client.initialize = AsyncMock(return_value=initializes)
+    client.shutdown = AsyncMock()
+    client._process = object()  # not the no-op client
+    return client
+
+
+def _sast_scanner(code_findings, *, validate=None):
+    scanner = AsyncMock()
+    scanner.scanner_name = "route_auth"
+    scanner.scan.return_value = code_findings
+    if validate is None:
+        # A scanner without validate_with_lsp must be skipped, not crashed on.
+        del scanner.validate_with_lsp
+    else:
+        scanner.validate_with_lsp = MagicMock(side_effect=validate)
+    return scanner
+
+
+class TestLSPInitialization:
+    @pytest.mark.asyncio
+    async def test_client_is_initialized_against_the_ingested_clone(
+        self, tmp_path
+    ) -> None:
+        client = _lsp_client()
+        repo = _repo_snapshot()
+        repo.clone_path = str(tmp_path)
+        ingestion = AsyncMock()
+        ingestion.ingest.return_value = repo
+
+        agent = _agent(repo_ingestion_service=ingestion, lsp_client=client)
+        await _collect(agent.scan(
+            repo_url="https://github.com/o/r", scan_mode=ScanMode.CODE_ONLY
+        ))
+
+        client.initialize.assert_awaited_once_with(str(tmp_path))
+
+    @pytest.mark.asyncio
+    async def test_failed_initialization_does_not_end_the_scan(self) -> None:
+        client = _lsp_client(initializes=False, error="no server installed")
+        ingestion = AsyncMock()
+        ingestion.ingest.return_value = _repo_snapshot()
+
+        agent = _agent(repo_ingestion_service=ingestion, lsp_client=client)
+        events = await _collect(agent.scan(
+            repo_url="https://github.com/o/r", scan_mode=ScanMode.CODE_ONLY
+        ))
+
+        report = _report(events)
+        assert "lsp_validator" not in report["scanners_run"]
+
+    @pytest.mark.asyncio
+    async def test_the_noop_client_skips_initialization_entirely(self) -> None:
+        from isitsecure.engine.code_analysis.lsp.noop_client import NoOpLSPClient
+
+        ingestion = AsyncMock()
+        ingestion.ingest.return_value = _repo_snapshot()
+        agent = _agent(repo_ingestion_service=ingestion, lsp_client=NoOpLSPClient())
+
+        events = await _collect(agent.scan(
+            repo_url="https://github.com/o/r", scan_mode=ScanMode.CODE_ONLY
+        ))
+
+        phases = [e.phase for e in events]
+        assert DeepScanPhase.LSP_INITIALIZATION not in phases
+
+    @pytest.mark.asyncio
+    async def test_the_client_is_shut_down_when_the_scan_ends(self) -> None:
+        client = _lsp_client()
+        ingestion = AsyncMock()
+        ingestion.ingest.return_value = _repo_snapshot()
+        agent = _agent(repo_ingestion_service=ingestion, lsp_client=client)
+
+        await _collect(agent.scan(
+            repo_url="https://github.com/o/r", scan_mode=ScanMode.CODE_ONLY
+        ))
+
+        client.shutdown.assert_awaited()
+
+
+class TestLSPValidation:
+    @pytest.mark.asyncio
+    async def test_findings_the_tracer_confirms_are_kept(self) -> None:
+        """Suppression must remove only what was disproved, nothing else."""
+        a, b = _code_finding(), _code_finding()
+        scanner = _sast_scanner([a, b], validate=lambda findings, _fl: findings)
+        ingestion = AsyncMock()
+        ingestion.ingest.return_value = _repo_snapshot()
+
+        agent = _agent(
+            repo_ingestion_service=ingestion,
+            lsp_client=_lsp_client(),
+            sast_scanners=[scanner],
+        )
+        with patch(
+            "isitsecure.engine.code_analysis.lsp.auth_flow_tracer.AuthFlowTracer"
+        ) as tracer_cls:
+            tracer_cls.return_value.trace_routes = AsyncMock(return_value={})
+            events = await _collect(agent.scan(
+                repo_url="https://github.com/o/r", scan_mode=ScanMode.CODE_ONLY
+            ))
+
+        assert len(_report(events)["findings"]) == 2
+
+    @pytest.mark.asyncio
+    async def test_scanners_without_lsp_validation_are_skipped_not_crashed_on(
+        self,
+    ) -> None:
+        scanner = _sast_scanner([_code_finding()])  # no validate_with_lsp
+        ingestion = AsyncMock()
+        ingestion.ingest.return_value = _repo_snapshot()
+
+        agent = _agent(
+            repo_ingestion_service=ingestion,
+            lsp_client=_lsp_client(),
+            sast_scanners=[scanner],
+        )
+        with patch(
+            "isitsecure.engine.code_analysis.lsp.auth_flow_tracer.AuthFlowTracer"
+        ) as tracer_cls:
+            tracer_cls.return_value.trace_routes = AsyncMock(return_value={})
+            events = await _collect(agent.scan(
+                repo_url="https://github.com/o/r", scan_mode=ScanMode.CODE_ONLY
+            ))
+
+        report = _report(events)
+        assert "lsp_validator" in report["scanners_run"]
+        assert len(report["findings"]) == 1
+
+    @pytest.mark.asyncio
+    async def test_a_failing_tracer_keeps_every_finding(self) -> None:
+        """Fail open: a broken tracer must not silently drop real findings."""
+        scanner = _sast_scanner([_code_finding()], validate=lambda f, _fl: f)
+        ingestion = AsyncMock()
+        ingestion.ingest.return_value = _repo_snapshot()
+
+        agent = _agent(
+            repo_ingestion_service=ingestion,
+            lsp_client=_lsp_client(),
+            sast_scanners=[scanner],
+        )
+        with patch(
+            "isitsecure.engine.code_analysis.lsp.auth_flow_tracer.AuthFlowTracer"
+        ) as tracer_cls:
+            tracer_cls.return_value.trace_routes = AsyncMock(
+                side_effect=RuntimeError("tracer died")
+            )
+            events = await _collect(agent.scan(
+                repo_url="https://github.com/o/r", scan_mode=ScanMode.CODE_ONLY
+            ))
+
+        report = _report(events)
+        assert "lsp_validator" not in report["scanners_run"]
+        assert len(report["findings"]) == 1
+
+    @pytest.mark.asyncio
+    async def test_validation_is_skipped_when_lsp_never_initialized(self) -> None:
+        scanner = _sast_scanner([_code_finding()], validate=lambda f, _fl: f)
+        ingestion = AsyncMock()
+        ingestion.ingest.return_value = _repo_snapshot()
+
+        agent = _agent(
+            repo_ingestion_service=ingestion,
+            lsp_client=_lsp_client(initializes=False),
+            sast_scanners=[scanner],
+        )
+        events = await _collect(agent.scan(
+            repo_url="https://github.com/o/r", scan_mode=ScanMode.CODE_ONLY
+        ))
+
+        assert "lsp_validator" not in _report(events)["scanners_run"]
+        scanner.validate_with_lsp.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Phase 8 — LLM code review
+# ---------------------------------------------------------------------------
+
+
+def _llm_reviewer(code_findings=None):
+    reviewer = AsyncMock()
+    reviewer.scan.return_value = code_findings or []
+    reviewer.set_sast_context = MagicMock()
+    reviewer.set_lsp_context = MagicMock()
+    # A real client exposes a dict here or nothing; auto-created mock
+    # attributes would make _collect_token_usage add a coroutine to an int and
+    # join a MagicMock into the model name.
+    reviewer.token_usage = None
+    reviewer._llm = None
+    return reviewer
+
+
+class TestLLMCodeReview:
+    @pytest.mark.asyncio
+    async def test_llm_findings_reach_the_report(self) -> None:
+        reviewer = _llm_reviewer([_code_finding()])
+        ingestion = AsyncMock()
+        ingestion.ingest.return_value = _repo_snapshot()
+
+        agent = _agent(repo_ingestion_service=ingestion, llm_code_reviewer=reviewer)
+        events = await _collect(agent.scan(
+            repo_url="https://github.com/o/r", scan_mode=ScanMode.CODE_ONLY
+        ))
+
+        report = _report(events)
+        assert "llm_review" in report["scanners_run"]
+        assert len(report["findings"]) == 1
+
+    @pytest.mark.asyncio
+    async def test_sast_findings_are_handed_over_as_context(self) -> None:
+        """Cross-scanner context: the reviewer is told what SAST already found
+        so it doesn't re-report the same things."""
+        reviewer = _llm_reviewer()
+        scanner = _sast_scanner([_code_finding()])
+        ingestion = AsyncMock()
+        ingestion.ingest.return_value = _repo_snapshot()
+
+        agent = _agent(
+            repo_ingestion_service=ingestion,
+            llm_code_reviewer=reviewer,
+            sast_scanners=[scanner],
+        )
+        await _collect(agent.scan(
+            repo_url="https://github.com/o/r", scan_mode=ScanMode.CODE_ONLY
+        ))
+
+        reviewer.set_sast_context.assert_called_once()
+        assert len(reviewer.set_sast_context.call_args[0][0]) == 1
+
+    @pytest.mark.asyncio
+    async def test_no_review_without_a_repo(self) -> None:
+        reviewer = _llm_reviewer([_code_finding()])
+        agent = _agent(
+            endpoints=[DiscoveredEndpoint(url="https://example.com/a")],
+            llm_code_reviewer=reviewer,
+        )
+
+        events = await _collect(agent.scan(target_url="https://example.com"))
+
+        assert "llm_review" not in _report(events)["scanners_run"]
+        reviewer.scan.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_a_failing_reviewer_does_not_end_the_scan(self) -> None:
+        reviewer = _llm_reviewer()
+        reviewer.scan.side_effect = RuntimeError("model unavailable")
+        ingestion = AsyncMock()
+        ingestion.ingest.return_value = _repo_snapshot()
+
+        agent = _agent(repo_ingestion_service=ingestion, llm_code_reviewer=reviewer)
+        events = await _collect(agent.scan(
+            repo_url="https://github.com/o/r", scan_mode=ScanMode.CODE_ONLY
+        ))
+
+        assert "report" in events[-1].data
+
+
+# ---------------------------------------------------------------------------
+# Phase 9.4 — injection false-positive adjudication
+# ---------------------------------------------------------------------------
+
+
+class TestInjectionAdjudication:
+    @pytest.mark.asyncio
+    async def test_dropped_false_positives_leave_the_report(self) -> None:
+        kept = _finding("real sqli")
+        xss = AsyncMock()
+        xss.scanner_name = "xss_scanner"
+        xss.scan.return_value = [kept, _finding("false positive")]
+
+        adjudicator = MagicMock()
+        adjudicator.adjudicate = AsyncMock(return_value=[kept])
+
+        agent = _agent(
+            endpoints=[DiscoveredEndpoint(url="https://example.com/a")],
+            dast_scanners=[xss],
+            injection_adjudicator=adjudicator,
+        )
+        events = await _collect(agent.scan(target_url="https://example.com"))
+
+        report = _report(events)
+        assert len(report["findings"]) == 1
+        assert "injection_adjudicator" in report["scanners_run"]
+
+    @pytest.mark.asyncio
+    async def test_not_recorded_when_it_drops_nothing(self) -> None:
+        found = _finding("real")
+        xss = AsyncMock()
+        xss.scanner_name = "xss_scanner"
+        xss.scan.return_value = [found]
+        adjudicator = MagicMock()
+        adjudicator.adjudicate = AsyncMock(return_value=[found])
+
+        agent = _agent(
+            endpoints=[DiscoveredEndpoint(url="https://example.com/a")],
+            dast_scanners=[xss],
+            injection_adjudicator=adjudicator,
+        )
+        events = await _collect(agent.scan(target_url="https://example.com"))
+
+        assert "injection_adjudicator" not in _report(events)["scanners_run"]
+
+    @pytest.mark.asyncio
+    async def test_it_fails_open_and_never_loses_findings(self) -> None:
+        """An adjudicator that errors must not delete real findings."""
+        xss = AsyncMock()
+        xss.scanner_name = "xss_scanner"
+        xss.scan.return_value = [_finding("real")]
+        adjudicator = MagicMock()
+        adjudicator.adjudicate = AsyncMock(side_effect=RuntimeError("boom"))
+
+        agent = _agent(
+            endpoints=[DiscoveredEndpoint(url="https://example.com/a")],
+            dast_scanners=[xss],
+            injection_adjudicator=adjudicator,
+        )
+        events = await _collect(agent.scan(target_url="https://example.com"))
+
+        assert len(_report(events)["findings"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# Phase 9.5 — LLM triage
+# ---------------------------------------------------------------------------
+
+
+class TestTriage:
+    @staticmethod
+    def _triage(findings, *, error=None):
+        service = MagicMock()
+        service.token_usage = None
+        service._llm = None
+        if error:
+            service.triage = AsyncMock(side_effect=error)
+        else:
+            from isitsecure.engine.models import OwnerSummary
+
+            result = MagicMock()
+            result.triaged_findings = findings
+            # A real OwnerSummary — the report model validates this field.
+            result.owner_summary = OwnerSummary(risk_summary="all good")
+            result.themes = []
+            service.triage = AsyncMock(return_value=result)
+        return service
+
+    @pytest.mark.asyncio
+    async def test_triaged_findings_replace_the_raw_ones(self) -> None:
+        raw = _finding("raw")
+        triaged = _finding("triaged and enriched")
+        xss = AsyncMock()
+        xss.scanner_name = "xss_scanner"
+        xss.scan.return_value = [raw]
+
+        agent = _agent(
+            endpoints=[DiscoveredEndpoint(url="https://example.com/a")],
+            dast_scanners=[xss],
+            llm_triage=self._triage([triaged]),
+        )
+        events = await _collect(agent.scan(target_url="https://example.com"))
+
+        report = _report(events)
+        assert [f["title"] for f in report["findings"]] == ["triaged and enriched"]
+        assert report["owner_summary"] is not None
+
+    @pytest.mark.asyncio
+    async def test_a_failing_triage_keeps_the_untriaged_findings(self) -> None:
+        """Triage is enrichment — losing it must not lose the findings."""
+        xss = AsyncMock()
+        xss.scanner_name = "xss_scanner"
+        xss.scan.return_value = [_finding("raw")]
+
+        agent = _agent(
+            endpoints=[DiscoveredEndpoint(url="https://example.com/a")],
+            dast_scanners=[xss],
+            llm_triage=self._triage([], error=RuntimeError("model down")),
+        )
+        events = await _collect(agent.scan(target_url="https://example.com"))
+
+        report = _report(events)
+        assert [f["title"] for f in report["findings"]] == ["raw"]
+        assert report["owner_summary"] is None
+
+    @pytest.mark.asyncio
+    async def test_triage_is_skipped_when_there_is_nothing_to_triage(self) -> None:
+        triage = self._triage([])
+        agent = _agent(
+            endpoints=[DiscoveredEndpoint(url="https://example.com/a")],
+            llm_triage=triage,
+        )
+        await _collect(agent.scan(target_url="https://example.com"))
+        triage.triage.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Phase 9.1 — SAST-guided DAST
+# ---------------------------------------------------------------------------
+
+
+class TestGuidedDAST:
+    @pytest.mark.asyncio
+    async def test_runs_in_full_mode_with_code_findings_and_endpoints(self) -> None:
+        runner = AsyncMock()
+        runner.run.return_value = [_finding("guided hit")]
+        ingestion = AsyncMock()
+        ingestion.ingest.return_value = _repo_snapshot()
+
+        agent = _agent(
+            endpoints=[DiscoveredEndpoint(url="https://example.com/a")],
+            repo_ingestion_service=ingestion,
+            sast_scanners=[_sast_scanner([_code_finding()])],
+            guided_dast_runner=runner,
+        )
+        events = await _collect(agent.scan(
+            target_url="https://example.com",
+            repo_url="https://github.com/o/r",
+            scan_mode=ScanMode.FULL,
+        ))
+
+        report = _report(events)
+        assert any(f["title"] == "guided hit" for f in report["findings"])
+
+    @pytest.mark.asyncio
+    async def test_skipped_in_code_only_mode(self) -> None:
+        """Guided DAST needs a live target; code-only has none."""
+        runner = AsyncMock()
+        runner.run.return_value = [_finding("guided hit")]
+        ingestion = AsyncMock()
+        ingestion.ingest.return_value = _repo_snapshot()
+
+        agent = _agent(
+            repo_ingestion_service=ingestion,
+            sast_scanners=[_sast_scanner([_code_finding()])],
+            guided_dast_runner=runner,
+        )
+        await _collect(agent.scan(
+            repo_url="https://github.com/o/r", scan_mode=ScanMode.CODE_ONLY
+        ))
+
+        runner.run.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Phase 3 / 5 — authenticated crawl and authenticated DAST
+# ---------------------------------------------------------------------------
+
+
+def _credentials(email: str = "a@example.com"):
+    from isitsecure.engine.auth.protocols import AuthCredentials, AuthProvider
+
+    return AuthCredentials(
+        provider=AuthProvider.SUPABASE, email=email, password="pw"
+    )
+
+
+def _crawl_result(*, pages=3, endpoints=(), tables=(), headers=None, errors=()):
+    result = MagicMock()
+    result.pages_visited = pages
+    result.discovered_endpoints = list(endpoints)
+    result.tables_discovered = list(tables)
+    result.auth_headers = headers or {}
+    result.errors = list(errors)
+    return result
+
+
+class TestAuthenticatedCrawl:
+    @pytest.mark.asyncio
+    async def test_crawler_endpoints_are_added_to_the_scan(self) -> None:
+        found = DiscoveredEndpoint(url="https://example.com/api/behind-login")
+        agent = _agent(endpoints=[DiscoveredEndpoint(url="https://example.com/a")])
+
+        with patch.object(
+            agent, "_run_authenticated_crawl",
+            AsyncMock(return_value=_crawl_result(endpoints=[found])),
+        ):
+            events = await _collect(agent.scan(
+                target_url="https://example.com",
+                credentials_a=_credentials(),
+                scan_mode=ScanMode.AUTHENTICATED,
+            ))
+
+        report = _report(events)
+        urls = [e["url"] for e in report["discovered_endpoints"]]
+        assert "https://example.com/api/behind-login" in urls
+
+    @pytest.mark.asyncio
+    async def test_endpoints_already_known_are_not_duplicated(self) -> None:
+        same = DiscoveredEndpoint(url="https://example.com/a")
+        agent = _agent(endpoints=[DiscoveredEndpoint(url="https://example.com/a")])
+
+        with patch.object(
+            agent, "_run_authenticated_crawl",
+            AsyncMock(return_value=_crawl_result(endpoints=[same])),
+        ):
+            events = await _collect(agent.scan(
+                target_url="https://example.com",
+                credentials_a=_credentials(),
+                scan_mode=ScanMode.AUTHENTICATED,
+            ))
+
+        urls = [e["url"] for e in _report(events)["discovered_endpoints"]]
+        assert urls.count("https://example.com/a") == 1
+
+    @pytest.mark.asyncio
+    async def test_a_crawl_that_visits_nothing_reports_why(self) -> None:
+        agent = _agent(endpoints=[DiscoveredEndpoint(url="https://example.com/a")])
+
+        with patch.object(
+            agent, "_run_authenticated_crawl",
+            AsyncMock(return_value=_crawl_result(pages=0, errors=["login failed"])),
+        ):
+            events = await _collect(agent.scan(
+                target_url="https://example.com",
+                credentials_a=_credentials(),
+                scan_mode=ScanMode.AUTHENTICATED,
+            ))
+
+        messages = " ".join(e.message or "" for e in events)
+        assert "login failed" in messages
+
+    @pytest.mark.asyncio
+    async def test_no_crawl_without_credentials(self) -> None:
+        agent = _agent(endpoints=[DiscoveredEndpoint(url="https://example.com/a")])
+        with patch.object(agent, "_run_authenticated_crawl", AsyncMock()) as crawl:
+            await _collect(agent.scan(target_url="https://example.com"))
+        crawl.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_api_auth_is_the_fallback_when_the_crawl_yields_no_session(
+        self,
+    ) -> None:
+        """Browser login is tried first; the auth provider backs it up."""
+        provider = AsyncMock()
+        provider.authenticate.return_value = MagicMock()
+        agent = _agent(
+            endpoints=[DiscoveredEndpoint(url="https://example.com/a")],
+            auth_provider=provider,
+        )
+
+        with patch.object(
+            agent, "_run_authenticated_crawl",
+            AsyncMock(return_value=_crawl_result(pages=0)),
+        ), patch.object(
+            agent, "_run_authenticated_scanners",
+            AsyncMock(return_value=([], [])),
+        ):
+            await _collect(agent.scan(
+                target_url="https://example.com",
+                credentials_a=_credentials(),
+                scan_mode=ScanMode.AUTHENTICATED,
+            ))
+
+        provider.authenticate.assert_awaited()
+
+    @pytest.mark.asyncio
+    async def test_a_failing_auth_provider_does_not_end_the_scan(self) -> None:
+        provider = AsyncMock()
+        provider.authenticate.side_effect = RuntimeError("bad credentials")
+        agent = _agent(
+            endpoints=[DiscoveredEndpoint(url="https://example.com/a")],
+            auth_provider=provider,
+        )
+
+        with patch.object(
+            agent, "_run_authenticated_crawl",
+            AsyncMock(return_value=_crawl_result(pages=0)),
+        ):
+            events = await _collect(agent.scan(
+                target_url="https://example.com",
+                credentials_a=_credentials(),
+                scan_mode=ScanMode.AUTHENTICATED,
+            ))
+
+        assert "report" in events[-1].data
+
+
+class TestAuthenticatedDAST:
+    @pytest.mark.asyncio
+    async def test_authenticated_scanners_run_once_a_session_exists(self) -> None:
+        provider = AsyncMock()
+        provider.authenticate.return_value = MagicMock()
+        agent = _agent(
+            endpoints=[DiscoveredEndpoint(url="https://example.com/a")],
+            auth_provider=provider,
+        )
+
+        with patch.object(
+            agent, "_run_authenticated_crawl",
+            AsyncMock(return_value=_crawl_result(pages=0)),
+        ), patch.object(
+            agent, "_run_authenticated_scanners",
+            AsyncMock(return_value=([_finding("idor cross-user")], ["idor_scanner"])),
+        ) as auth_scanners:
+            events = await _collect(agent.scan(
+                target_url="https://example.com",
+                credentials_a=_credentials(),
+                credentials_b=_credentials("b@example.com"),
+                scan_mode=ScanMode.AUTHENTICATED,
+            ))
+
+        auth_scanners.assert_awaited_once()
+        report = _report(events)
+        assert "idor_scanner" in report["scanners_run"]
+        assert any(f["title"] == "idor cross-user" for f in report["findings"])
+
+    @pytest.mark.asyncio
+    async def test_skipped_when_no_session_was_established(self) -> None:
+        agent = _agent(endpoints=[DiscoveredEndpoint(url="https://example.com/a")])
+        with patch.object(
+            agent, "_run_authenticated_crawl",
+            AsyncMock(return_value=_crawl_result(pages=0)),
+        ), patch.object(
+            agent, "_run_authenticated_scanners", AsyncMock()
+        ) as auth_scanners:
+            await _collect(agent.scan(
+                target_url="https://example.com",
+                credentials_a=_credentials(),
+                scan_mode=ScanMode.AUTHENTICATED,
+            ))
+        auth_scanners.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Phase 9.2 — LLM business-logic attacks
+# ---------------------------------------------------------------------------
+
+
+class TestBusinessLogic:
+    """This phase is gated on eight preconditions at once, so most of what
+    matters is which combinations do *not* run it."""
+
+    @staticmethod
+    def _agent_with_everything(scanner_findings):
+        reviewer = _llm_reviewer()
+        # The phase needs a client behind the reviewer; give it the shape
+        # _collect_token_usage expects rather than auto-created mocks.
+        llm = MagicMock()
+        llm.token_usage = None
+        llm._model_name = ""
+        reviewer._llm = llm
+        repo = _repo_snapshot()
+        repo.file_index = {"src/app.ts": "code", "empty.ts": ""}
+        ingestion = AsyncMock()
+        ingestion.ingest.return_value = repo
+
+        provider = AsyncMock()
+        provider.authenticate.return_value = MagicMock()
+
+        agent = _agent(
+            endpoints=[DiscoveredEndpoint(url="https://example.com/a")],
+            repo_ingestion_service=ingestion,
+            llm_code_reviewer=reviewer,
+            auth_provider=provider,
+        )
+        scanner = MagicMock()
+        scanner.scan = AsyncMock(return_value=scanner_findings)
+        return agent, scanner
+
+    async def _run(self, agent, scanner, **kwargs):
+        with patch.object(
+            agent, "_run_authenticated_crawl",
+            AsyncMock(return_value=_crawl_result(pages=0)),
+        ), patch.object(
+            agent, "_run_authenticated_scanners", AsyncMock(return_value=([], [])),
+        ), patch(
+            "isitsecure.engine.scanners.llm_business_logic_scanner"
+            ".LLMBusinessLogicScanner",
+            return_value=scanner,
+        ):
+            return await _collect(agent.scan(**kwargs))
+
+    @pytest.mark.asyncio
+    async def test_runs_with_two_sessions_a_repo_and_a_target(self) -> None:
+        agent, scanner = self._agent_with_everything([_finding("price manipulation")])
+        events = await self._run(
+            agent, scanner,
+            target_url="https://example.com",
+            repo_url="https://github.com/o/r",
+            credentials_a=_credentials(),
+            credentials_b=_credentials("b@example.com"),
+            scan_mode=ScanMode.FULL,
+        )
+
+        report = _report(events)
+        assert any(f["title"] == "price manipulation" for f in report["findings"])
+
+    @pytest.mark.asyncio
+    async def test_empty_files_are_not_sent_to_the_model(self) -> None:
+        agent, scanner = self._agent_with_everything([])
+        await self._run(
+            agent, scanner,
+            target_url="https://example.com",
+            repo_url="https://github.com/o/r",
+            credentials_a=_credentials(),
+            credentials_b=_credentials("b@example.com"),
+            scan_mode=ScanMode.FULL,
+        )
+
+        sent = scanner.scan.await_args.kwargs["repo_files"]
+        assert "src/app.ts" in sent and "empty.ts" not in sent
+
+    @pytest.mark.asyncio
+    async def test_skipped_without_a_second_session(self) -> None:
+        """Cross-role attacks need two identities to compare."""
+        agent, scanner = self._agent_with_everything([_finding()])
+        await self._run(
+            agent, scanner,
+            target_url="https://example.com",
+            repo_url="https://github.com/o/r",
+            credentials_a=_credentials(),
+            scan_mode=ScanMode.FULL,
+        )
+        scanner.scan.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_skipped_without_a_repo(self) -> None:
+        agent, scanner = self._agent_with_everything([_finding()])
+        await self._run(
+            agent, scanner,
+            target_url="https://example.com",
+            credentials_a=_credentials(),
+            credentials_b=_credentials("b@example.com"),
+            scan_mode=ScanMode.AUTHENTICATED,
+        )
+        scanner.scan.assert_not_awaited()


### PR DESCRIPTION
Three commits — please **rebase-merge** so they stay distinct. They're a chain: the tests exposed the bugs, and the third fix is the one that changes output.

---

## 1. `test(agent)`: characterize the untested scan phases

`scan()` is 871 lines over 19 phases, and **40% had no coverage at all** — the phases needing an LLM client or authenticated sessions, which no unit test and no `--llm none` live scan ever executed. Eleven of nineteen sat below 70%.

39 tests pin what each currently does. `agent.py` 44% → 62%, **no phase under 73%**:

| | before → after | | before → after |
|---|---|---|---|
| 7.5 lsp-valid | 10% → **100%** | 3 auth-crawl | 29% → 73% |
| 8 llm-review | 18% → **96%** | 5 auth-dast | 29% → 100% |
| 6.5 lsp-init | 20% → **87%** | 9.2 bizlogic | 30% → 100% |
| 9.5 triage | 20% → **97%** | 9.1 guided | 37% → 100% |
| 9.4 adjudicate | 23% → **96%** | 5.5 cross-probe | 62% → 81% |

Mutation-checked: five deliberate breaks in `agent.py` each fail one or two of them. No production code changed.

## 2. `fix(lsp)`: make suppression actually remove findings

Two independent bugs, either alone sufficient:

- **Wrong list.** `validate_with_lsp` drops disproved findings with `continue`, so they never reach the returned list — which phase 7.5 then scanned for `lsp_suppressed`, finding nothing by construction. Now derived from what actually left the list.
- **Wrong id space.** `_code_finding_to_deep_finding` minted a fresh `uuid4` instead of carrying `cf.id`, so a correct set still couldn't match. Safe to carry: `identity.py` derives its cross-scan fingerprint from content and documents that it ignores this id.

Output unchanged, because nothing was being suppressed yet — see below.

## 3. `fix(lsp)`: resolve auth helpers so the tracer can confirm auth at all

The tracer reported **zero** verified-auth routes on every target, including routes that plainly verify it.

**tsserver builds its program asynchronously after the first `didOpen`.** Until it finishes it still answers definition requests — by pointing at the *import statement* in the querying file. Indistinguishable from success unless you check where it landed:

```
wait=0.0s   definition -> src/app/api/settings/route.ts   (the import)
wait=1.0s   definition -> src/lib/auth.ts                 (the real one)
```

Every go-to-definition in every scan has returned that. There's no readiness notification to wait on (typescript-language-server sends only `$/typescriptVersion`), so `_resolve_definition` detects the shape and retries with backoff; a loaded project pays nothing.

**And `_trace_inline_auth` never used the LSP** — it regexed the terminal patterns against the route file and stopped. A route calling its own helper matched nothing, because no pattern list can name `getUserFromRequest`. It now follows called project-local imports one hop.

**That hop needed scoping.** Resolving any symbol into a module exposes the whole module's terminals, and helpers cluster — a login route importing `signToken` from the file that also defines `verifyToken` came out "authenticated". `_trace_definition_body` returns only the resolved symbol's own declaration, dropping that false suppression while keeping the true ones.

## Re-baseline

| Target | Was | Now | |
|---|---:|---:|---|
| **test-app** | 114 | **110** | 4 routes verified, 4 suppressed |
| juice-shop | 198 | 198 | 0 verified auth — unchanged |

The four suppressed — `checkout`, `credits/redeem`, `settings`, `users/profile` — each call `getUserFromRequest(request)` and return **401** when it's falsy. Hand-verified as genuine false positives; nothing was added.

juice-shop is unchanged: its Express routes still yield no verified auth. That may be correct for a deliberately vulnerable app, or a shape we don't cover — **not proven either way**.

## Verification

**2355 tests** (+55) · sast-injection 46/46 with 0 FP · VAmPI 3/3 · both targets diffed finding-by-finding.

## Note

`_trace_express_auth` has the same whole-file weakness commit 3 fixes for the inline path; its curated name list keeps the blast radius small, but it's worth knowing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EZ4QoTqRoYWE25CNoV2Wfy
