### PR TITLE
fix(lsp): attribute auth per route so Express apps are traced correctly

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -121,6 +121,10 @@ Route file: app/api/tasks/[id]/route.ts
         → Auth IS genuinely applied → suppress false positive
 ```
 
+Findings the tracer disproves are removed from the report, matched back **per
+route** — a finding carries the route it is about, so one guarded route in a
+file of a hundred cannot vouch for the rest.
+
 This is unique — no commercial SAST tool uses compiler-level definition resolution to verify that auth middleware actually works.
 
 ### Phase 8: LLM Code Review

--- a/docs/lsp-setup.md
+++ b/docs/lsp-setup.md
@@ -148,14 +148,40 @@ router.get('/tasks', requireAuth, async (req, res) => {
 })
 ```
 
-**Next.js inline auth:**
+**Next.js inline auth — including your own helpers:**
 ```typescript
-// Is getServerSession actually called before data access?
-export async function GET() {
-  const session = await getServerSession()
-  // LSP traces: getServerSession → authOptions → providers
+import { getUserFromRequest } from "@/lib/auth"   // your code, not a library
+
+export async function PATCH(request: Request) {
+  const user = getUserFromRequest(request)
+  // LSP traces: getUserFromRequest → lib/auth.ts → verifyToken()
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
 }
 ```
+
+No pattern list can name `getUserFromRequest` — it's your project's invention —
+so the tracer resolves the call and looks for the terminal in **that function's
+own body**, not the whole module. Scoping matters: helpers cluster, so a login
+route importing `signToken` from the file that also defines `verifyToken` would
+otherwise look authenticated.
+
+**Centrally-mounted Express routes, per route:**
+```typescript
+app.use('/api/BasketItems', security.isAuthorized())   // traced → verified
+app.post('/api/Challenges', security.denyAll())        // traced → verified
+app.get('/api/Products', ...)                          // no guard → not verified
+```
+
+A single `server.ts` can mount a hundred routes of which a handful are guarded,
+so each route is answered from **its own mount line**. One verdict for the whole
+file would either miss every guard or vouch for every unguarded neighbour —
+and vouching is the dangerous direction, because a suppressed finding is a
+vulnerability the report no longer mentions.
+
+Middleware that delegates to a library counts as the terminal, because tracing
+deliberately will not follow into `node_modules`: `expressJwt` (express-jwt),
+`requiresAuth` (express-openid-connect), `ensureLoggedIn` (connect-ensure-login),
+alongside the direct `jwt.verify` / `getUser` / `getServerSession` forms.
 
 ### Performance Impact
 

--- a/isitsecure/engine/code_analysis/lsp/auth_flow_tracer.py
+++ b/isitsecure/engine/code_analysis/lsp/auth_flow_tracer.py
@@ -105,10 +105,9 @@ class AuthFlowTracer:
                         )
                     )
                     continue
-                # Assign the file-level result to each route in that file
                 for route in file_routes:
                     key = f"{route.file_path}:{route.route_pattern}"
-                    results[key] = result
+                    results[key] = result.get(route.route_pattern, AuthFlowResult())
 
         traced = len(results)
         auth_found = sum(1 for r in results.values() if r.has_verified_auth)
@@ -125,20 +124,124 @@ class AuthFlowTracer:
 
     async def _trace_file(
         self, file_path: str, routes: list[RouteEntry]
-    ) -> AuthFlowResult:
-        """Trace auth flow for a single file.
+    ) -> dict[str, AuthFlowResult]:
+        """Trace auth flow for one file, per route.
 
-        Strategy (tried in order):
+        A file that mounts its routes explicitly — the Express shape, where
+        one ``server.ts`` can carry a hundred of them — is answered per route
+        from its own mount line. That distinction is the whole point: in Juice
+        Shop 20 of 150 mounts are guarded, so a single verdict for the file
+        would either miss all twenty or vouch for the other hundred and
+        thirty. Vouching is the dangerous direction, because a suppressed
+        finding is a vulnerability the report no longer mentions.
+
+        Files without mounts fall back to whole-file strategies, in order:
         1. Procedure bases: protectedProcedure, tenantProcedure, etc.
         2. Express middleware: requireAuth, verifyAuth, etc.
         3. Auth decorators: @UseGuards, @login_required, @PreAuthorize
-        4. Inline auth calls: getUser, getSession, jwt.verify, etc.
+        4. Inline auth calls, following project-local helpers one hop.
         """
         content = self._get_file_content(file_path)
         if not content:
-            return AuthFlowResult()
+            return {}
 
         abs_path = self._resolve_path(file_path)
+
+        mounts = self._route_mounts(content)
+        if mounts:
+            # Authoritative: this file says which middleware guards what, so
+            # a route with no auth on its mount line has none. Falling back to
+            # a file-wide scan here is what would let one guarded route vouch
+            # for its unguarded neighbours.
+            per_route: dict[str, AuthFlowResult] = {}
+            for route in routes:
+                middleware = mounts.get(route.route_pattern)
+                per_route[route.route_pattern] = (
+                    await self._verify_mount_middleware(middleware, content, abs_path)
+                    if middleware
+                    else AuthFlowResult(confidence=0.5)
+                )
+            return per_route
+
+        result = await self._trace_whole_file(content, abs_path)
+        return {route.route_pattern: result for route in routes}
+
+    @staticmethod
+    def _route_mounts(content: str) -> dict[str, str]:
+        """Map each mounted route pattern to the middleware named beside it."""
+        mounts: dict[str, str] = {}
+        for match in re.finditer(LSPConfig.ROUTE_MOUNT_PATTERN, content):
+            pattern, middleware = match.group(1), match.group("middleware")
+            # First mount wins; later ones are usually narrower duplicates.
+            mounts.setdefault(pattern, middleware)
+        return mounts
+
+    async def _verify_mount_middleware(
+        self, middleware: str, content: str, abs_path: str
+    ) -> AuthFlowResult:
+        """Resolve the middleware on a mount line and look for auth in it."""
+        for name in self._middleware_names(middleware):
+            position = self._locate_symbol(content, name)
+            if position is None:
+                continue
+            line, char = position
+            definition = await self._trace_definition_body(abs_path, line, char)
+            if not definition:
+                continue
+
+            auth_method = self._find_auth_terminal(definition)
+            if auth_method:
+                return AuthFlowResult(
+                    has_verified_auth=True,
+                    auth_method=auth_method,
+                    middleware_chain=[name],
+                    confidence=LSPConfig.CONFIDENCE_LSP_CONFIRMED,
+                    trace_depth=1,
+                )
+        return AuthFlowResult(confidence=0.5)
+
+    @staticmethod
+    def _middleware_names(middleware: str) -> list[str]:
+        """The callables named on a mount line, in order.
+
+        Both shapes are common and both must resolve::
+
+            app.use('/x', security.isAuthorized())   -> isAuthorized
+            router.get('/x', requireAuth, handler)   -> requireAuth, handler
+
+        Taking the last identifier of each argument yields the member for a
+        qualified call and the name itself for a bare reference. The route
+        handler comes along too; it simply contains no auth terminal.
+        """
+        names: list[str] = []
+        for argument in middleware.split(","):
+            identifiers = re.findall(r"[A-Za-z_]\w*", argument)
+            if identifiers and identifiers[-1] not in names:
+                names.append(identifiers[-1])
+        return names[: LSPConfig.MAX_MOUNT_MIDDLEWARE]
+
+    @staticmethod
+    def _locate_symbol(content: str, name: str) -> tuple[int, int] | None:
+        """Position of ``name`` at a use site, preferring not the import line.
+
+        Asking for the definition of an import specifier is answered with the
+        import itself, which is the shape ``_is_unresolved`` waits on — so
+        query where the symbol is used instead.
+        """
+        fallback: tuple[int, int] | None = None
+        for line_number, line in enumerate(content.split("\n")):
+            for match in re.finditer(rf"\b{re.escape(name)}\b", line):
+                position = (line_number, match.start())
+                if line.lstrip().startswith("import"):
+                    fallback = fallback or position
+                    continue
+                return position
+        return fallback
+
+    async def _trace_whole_file(
+        self, content: str, abs_path: str
+    ) -> AuthFlowResult:
+        """Whole-file strategies, for files that do not mount routes."""
 
         # Strategy 1: Procedure base (tRPC, NestJS, etc.)
         result = await self._trace_procedure_auth(content, abs_path)

--- a/isitsecure/engine/code_analysis/models.py
+++ b/isitsecure/engine/code_analysis/models.py
@@ -31,3 +31,8 @@ class CodeFinding(BaseModel):
     # LSP validation (backward-compatible defaults)
     lsp_validated: bool = False
     lsp_suppressed: bool = False
+
+    # The route this finding is about, when it is about one. LSP auth-flow
+    # results are per route, so matching a finding back to them needs it —
+    # matching on file alone hands every route in a file one verdict.
+    route_pattern: str = ""

--- a/isitsecure/engine/code_analysis/route_analyzer.py
+++ b/isitsecure/engine/code_analysis/route_analyzer.py
@@ -458,16 +458,24 @@ class RouteAuthAnalyzer:
             AuthFlowResult,
         )
 
-        # Try exact match: file_path:route_pattern
-        for key, result in auth_flow_results.items():
-            if key.startswith(finding.file_path + ":"):
-                return result
+        if finding.route_pattern:
+            return auth_flow_results.get(
+                f"{finding.file_path}:{finding.route_pattern}"
+            )
 
-        # Try file-only match
-        for key, result in auth_flow_results.items():
-            if key.startswith(finding.file_path):
-                return result
-
+        # No route on the finding: only answer from the file when every route
+        # in it agrees. One `server.ts` can mount a hundred routes of which a
+        # handful are guarded, and picking any one of their verdicts would
+        # suppress findings on the rest — hiding real vulnerabilities.
+        in_file = [
+            result
+            for key, result in auth_flow_results.items()
+            if key.startswith(finding.file_path + ":")
+        ]
+        if in_file and all(
+            r.has_verified_auth == in_file[0].has_verified_auth for r in in_file
+        ):
+            return in_file[0]
         return None
 
     def _has_auth_check(self, content: str) -> bool:
@@ -539,6 +547,7 @@ class RouteAuthAnalyzer:
             title=title,
             description=description,
             file_path=route.file_path,
+            route_pattern=route.route_pattern,
             line_number=line_number,
             code_snippet=CodeContextExtractor.extract(
                 route.content, line_number

--- a/isitsecure/engine/constants.py
+++ b/isitsecure/engine/constants.py
@@ -4752,6 +4752,16 @@ class LSPConfig:
         "exclude": ["node_modules", "dist", "build", ".next"],
     }
 
+    # Express-style mounts: `app.use('/path', mw)`, `router.get('/path', mw)`.
+    ROUTE_MOUNT_PATTERN = (
+        r"\.\s*(?:use|all|get|post|put|patch|delete|head|options)\s*\(\s*"
+        r"['\"`]([^'\"`]+)['\"`]\s*,(?P<middleware>[^\n]*)"
+    )
+
+
+    # How many middlewares on one mount line are worth resolving.
+    MAX_MOUNT_MIDDLEWARE = 4
+
     # tsserver loads a project asynchronously after the first didOpen, and
     # answers definition requests in the meantime by pointing at the import
     # statement rather than the real declaration. These bound the wait for it
@@ -4795,6 +4805,12 @@ class LSPConfig:
         r'createServerClient\s*\(',
         # Passport
         r'passport\.authenticate\s*\(',
+        # Express auth middleware that verifies for you. The terminal is then
+        # inside the package, which tracing deliberately will not enter, so
+        # the middleware itself has to count as the terminal.
+        r'expressJwt\s*\(',        # express-jwt
+        r'requiresAuth\s*\(',      # express-openid-connect (Auth0)
+        r'ensureLoggedIn\s*\(',    # connect-ensure-login
         # Firebase
         r'admin\.auth\(\)\.verifyIdToken\s*\(',
         r'getAuth\(\)\.verifyIdToken\s*\(',

--- a/tests/engine/test_code_analysis/test_auth_flow_tracer.py
+++ b/tests/engine/test_code_analysis/test_auth_flow_tracer.py
@@ -725,3 +725,80 @@ class TestIsUnresolved:
     def test_unknown_content_is_treated_as_resolved(self) -> None:
         tracer = self._tracer("")
         assert tracer._is_unresolved([_Loc("/r.ts", 0)], "/r.ts") is False
+
+
+# ---------------------------------------------------------------------------
+# Per-route attribution for centrally-mounted (Express) routes
+# ---------------------------------------------------------------------------
+
+
+SERVER = """
+app.use('/api/BasketItems', security.isAuthorized())
+app.post('/api/Challenges', security.denyAll())
+app.get('/api/Products', productController())
+router.get('/profile', requireAuth, handler)
+"""
+
+
+class TestRouteMounts:
+    def test_each_mounted_route_maps_to_its_own_middleware(self) -> None:
+        mounts = AuthFlowTracer._route_mounts(SERVER)
+        assert "isAuthorized" in mounts["/api/BasketItems"]
+        assert "denyAll" in mounts["/api/Challenges"]
+
+    def test_an_unguarded_route_is_still_recorded(self) -> None:
+        """It has to appear, so it can be answered "no auth" rather than
+        falling through to a file-wide scan that a neighbour would pass."""
+        assert "/api/Products" in AuthFlowTracer._route_mounts(SERVER)
+
+    def test_a_file_that_mounts_nothing_yields_nothing(self) -> None:
+        assert AuthFlowTracer._route_mounts("const x = 1\n") == {}
+
+    def test_the_first_mount_wins(self) -> None:
+        src = "app.use('/x', authGuard())\napp.use('/x', other())\n"
+        assert "authGuard" in AuthFlowTracer._route_mounts(src)["/x"]
+
+
+class TestMiddlewareNames:
+    def test_a_qualified_call_yields_the_member(self) -> None:
+        assert AuthFlowTracer._middleware_names(" security.isAuthorized())") == [
+            "isAuthorized"
+        ]
+
+    def test_a_bare_reference_yields_the_name(self) -> None:
+        """Express middleware is as often passed by reference as called."""
+        assert AuthFlowTracer._middleware_names(" requireAuth, handler)") == [
+            "requireAuth",
+            "handler",
+        ]
+
+    def test_several_middlewares_keep_their_order(self) -> None:
+        names = AuthFlowTracer._middleware_names(
+            " security.isAuthorized(), security.appendUserId())"
+        )
+        assert names == ["isAuthorized", "appendUserId"]
+
+    def test_the_count_is_bounded(self) -> None:
+        from isitsecure.engine.constants import LSPConfig
+
+        args = ", ".join(f"mw{i}()" for i in range(10))
+        assert (
+            len(AuthFlowTracer._middleware_names(args))
+            == LSPConfig.MAX_MOUNT_MIDDLEWARE
+        )
+
+
+class TestLocateSymbol:
+    def test_prefers_a_use_site_over_the_import(self) -> None:
+        """Asking for the definition of an import specifier is answered with
+        the import itself, which is the shape the retry waits on."""
+        src = "import { requireAuth } from './auth'\nrouter.get('/x', requireAuth)\n"
+        line, _char = AuthFlowTracer._locate_symbol(src, "requireAuth")
+        assert line == 1
+
+    def test_falls_back_to_the_import_when_that_is_all_there_is(self) -> None:
+        src = "import { requireAuth } from './auth'\n"
+        assert AuthFlowTracer._locate_symbol(src, "requireAuth") == (0, 9)
+
+    def test_absent_symbol_returns_none(self) -> None:
+        assert AuthFlowTracer._locate_symbol("const a = 1\n", "nope") is None


### PR DESCRIPTION
Follow-up to #161. The tracer reported **zero** verified-auth routes on Juice Shop — and that wasn't a property of a deliberately vulnerable app: **20 of its 150 mounts are guarded**.

## Three things in the way, and the middle one made the obvious fix dangerous

**1. A hardcoded name list.** `_trace_express_auth` matched five names; `security.isAuthorized` isn't one. Same failure already fixed for the inline path — a name list can't anticipate a project's own vocabulary.

**2. But adding the name would have been worse than the bug.** Results were computed per *file* and assigned to every route in it:

```python
# Assign the file-level result to each route in that file
```

Juice Shop mounts **102 routes from one `server.ts`**. One verdict there would have marked all 102 authenticated on the strength of the 20 that are guarded — suppressing missing-auth findings on the other 82. In a security scanner a suppressed finding is a vulnerability the report no longer mentions, so **vouching is far worse than missing**.

Routes are now answered from their own mount line, and a file that mounts explicitly is authoritative for all of them: no guard on the line means no auth, rather than falling through to a file-wide scan a neighbour would pass. Files that mount nothing keep the whole-file strategies.

**3. The verdict then had to survive matching back.** `_find_lsp_result` searched on file path alone and returned the *first* result for that file — arbitrary once verdicts differ per route. Findings now carry their route, and the file-only path answers only when every route in the file agrees; otherwise it declines, because the safe direction is to report.

## Library middleware counts as the terminal

Juice Shop's `isAuthorized` is a one-liner around `express-jwt`, whose terminal lives in `node_modules` — which tracing deliberately won't enter. Added `expressJwt`, `requiresAuth` (express-openid-connect), `ensureLoggedIn` (connect-ensure-login).

Scoping earns its keep here: `lib/insecurity.ts` contains `jwt.verify` in a **different** function, which the whole-file search this replaces would have matched.

## Re-baseline

| Target | Was | Now | |
|---|---:|---:|---|
| **juice-shop** | 198 | **183** | 17 routes verified — its first suppression ever |
| test-app | 110 | 110 | unchanged |

**All 15 suppressed were hand-checked against `server.ts`:**

```
8 guarded by isAuthorized   (BasketItems, BasketItems/:id, Complaints,
                             Feedbacks/:id, PrivacyRequests, Users,
                             rest/products/reviews ×2)
7 guarded by denyAll        (Cards/:id ×2, Challenges, Hints,
                             Quantitys, Quantitys/:id, SecurityQuestions)
0 unguarded · 0 findings added
```

`denyAll()` is `expressJwt` with a random secret — it rejects everyone, so it's *stronger* than auth and a "missing authentication" finding on it is equally a false positive.

I initially scored 7 of these as wrong because I only checked for `isAuthorized`; the verification was too narrow, not the code.

## Verification

**2366 tests** (+11) · sast-injection 46/46 with 0 FP · VAmPI 3/3 · both targets diffed finding-by-finding. Disabling the per-route match makes juice-shop fall back to 198 — the conservative direction — confirming the matching is load-bearing.

## Docs

`lsp-setup.md`: the per-route mount rule, the local-helper hop, and the library terminals. `architecture.md`: suppression matches per route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EZ4QoTqRoYWE25CNoV2Wfy
