### PR TITLE
chore(agent): let ScanContext own the phase defaults

### DIFF
--- a/isitsecure/engine/agent.py
+++ b/isitsecure/engine/agent.py
@@ -47,7 +47,6 @@ if TYPE_CHECKING:
         AuthSession,
     )
     from isitsecure.engine.code_analysis.lsp.protocols import (
-        AuthFlowResult,
         LSPClientProtocol,
     )
     from isitsecure.engine.code_analysis.protocols import (
@@ -464,7 +463,6 @@ class DeepSecurityScanAgent:
         # ==============================================================
         # Phase 3: Authenticated Crawl (browser login + BFS discovery)
         # ==============================================================
-        ctx.crawl_result = None
         if (
             ctx.credentials_a
             and ctx.target_url
@@ -613,7 +611,6 @@ class DeepSecurityScanAgent:
         # ==============================================================
         # Phase 3.5: OOB Callback Registration (non-blocking)
         # ==============================================================
-        ctx.oob_service = None
         if ctx.target_url and ctx.mode in (
             ScanMode.URL_ONLY, ScanMode.AUTHENTICATED, ScanMode.FULL,
         ):
@@ -853,8 +850,6 @@ class DeepSecurityScanAgent:
         # ==============================================================
         # Phase 6.5: LSP Initialization (optional — graceful degradation)
         # ==============================================================
-        ctx.lsp_initialized = False
-        ctx.auth_flow_results: dict[str, AuthFlowResult] = {}
         if (
             ctx.repo_snapshot
             and self._lsp_client
@@ -920,7 +915,6 @@ class DeepSecurityScanAgent:
         # ==============================================================
         # Phase 7: SAST Scanners (parallel)
         # ==============================================================
-        ctx.sast_code_findings: list[CodeFinding] = []
         if ctx.repo_snapshot and ctx.mode in (ScanMode.CODE_ONLY, ScanMode.FULL):
             yield DeepScanEvent(
                 DeepScanPhase.SAST_SCANNING,
@@ -1177,8 +1171,6 @@ class DeepSecurityScanAgent:
         # ==============================================================
         # Phase 9.5: LLM Triage (deduplicate, enrich, prioritize)
         # ==============================================================
-        ctx.owner_summary = None
-        ctx.themes = []
         if self._llm_triage and ctx.all_findings:
             from isitsecure.engine.constants import TriageConfig
 


### PR DESCRIPTION
Seven phases opened by re-initialising their own outputs — `ctx.crawl_result = None`, `ctx.themes = []` and so on — which `ScanContext` already supplies.

**Two lines that look identical are kept deliberately:** the ones inside `except` blocks reset state *after a failure*, which is a decision rather than a default.

I argued in #165 that removing these was churn for no functional gain. That was about not widening a large refactor mid-flight; as its own small change, having one source of truth for a default is worth having — and the annotated re-init turned out to be the last user of an import.

**Also the vehicle for cutting 0.23.4.** The `scan()` decomposition is a `refactor`, which release-please doesn't bump on its own, and mislabelling it a `fix` to force a release would put a lie in the changelog. `Release-As: 0.23.4` in the footer instead.

## Verification

2366 tests · sast-injection 46/46 with 0 FP · VAmPI 3/3 · test-app 110 · juice-shop 183 — all unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EZ4QoTqRoYWE25CNoV2Wfy