### PR TITLE
fix(lsp): judge Express middleware on its own body, not its module

### DIFF
--- a/isitsecure/engine/code_analysis/lsp/auth_flow_tracer.py
+++ b/isitsecure/engine/code_analysis/lsp/auth_flow_tracer.py
@@ -355,7 +355,11 @@ class AuthFlowTracer:
     async def _trace_express_auth(
         self, content: str, abs_path: str
     ) -> AuthFlowResult | None:
-        """Trace Express middleware to confirm auth verification."""
+        """Trace Express middleware to confirm auth verification.
+
+        The fallback for files that do not mount their routes explicitly;
+        centrally-mounted routes are attributed per route instead.
+        """
         # Look for auth middleware imports/usage
         auth_patterns = (
             r'\brequireAuth\b',
@@ -371,11 +375,17 @@ class AuthFlowTracer:
                 continue
 
             middleware_name = match.group(0)
-            line, char = self._offset_to_position(content, match.start())
+            position = self._locate_symbol(content, middleware_name)
+            if position is None:
+                continue
+            line, char = position
             chain = [middleware_name]
 
-            # Trace to the middleware definition
-            definition_content = await self._trace_definition(
+            # Only the middleware's own body counts. Auth helpers cluster in
+            # one module, so searching the whole definition file would let a
+            # sibling's terminal vouch for this middleware — the same way a
+            # login route importing `signToken` once looked authenticated.
+            definition_content = await self._trace_definition_body(
                 abs_path, line, char
             )
 

--- a/tests/engine/test_code_analysis/test_auth_flow_tracer.py
+++ b/tests/engine/test_code_analysis/test_auth_flow_tracer.py
@@ -802,3 +802,83 @@ class TestLocateSymbol:
 
     def test_absent_symbol_returns_none(self) -> None:
         assert AuthFlowTracer._locate_symbol("const a = 1\n", "nope") is None
+
+
+# ---------------------------------------------------------------------------
+# Express middleware is judged on its own body, not its module
+# ---------------------------------------------------------------------------
+
+
+# `requireAuth` does nothing but call next(); `checkToken`, further down the
+# same module, is the one that verifies. Auth helpers cluster like this.
+MIDDLEWARE_MODULE = """export function requireAuth(req, res, next) {
+  next()
+}
+
+export function checkToken(req, res, next) {
+  const user = jwt.verify(req.headers.authorization, SECRET)
+  if (!user) return res.status(401).json({ error: 'Unauthorized' })
+  next()
+}
+"""
+
+ROUTE_USING_IT = (
+    "import { requireAuth } from '../middleware/auth'\n"
+    "router.get('/profile', requireAuth, handler)\n"
+)
+
+
+class TestExpressMiddlewareScoping:
+    @staticmethod
+    def _tracer():
+        repo = _make_repo(
+            file_index={
+                "src/routes/profile.ts": ROUTE_USING_IT,
+                "src/middleware/auth.ts": MIDDLEWARE_MODULE,
+            }
+        )
+        lsp = _make_lsp()
+        lsp.get_definition.return_value = [
+            LSPLocation(
+                file_path="/tmp/test/src/middleware/auth.ts",
+                line=0,          # requireAuth's own declaration
+                character=0,
+            )
+        ]
+        return AuthFlowTracer(lsp, repo)
+
+    @pytest.mark.asyncio
+    async def test_a_sibling_function_does_not_vouch_for_the_middleware(
+        self,
+    ) -> None:
+        """`requireAuth` only calls next(). The `jwt.verify` further down its
+        module belongs to `checkToken`, and searching the whole file — which
+        is what this replaced — reported the route as authenticated."""
+        result = await self._tracer()._trace_express_auth(
+            ROUTE_USING_IT, "/tmp/test/src/routes/profile.ts"
+        )
+        assert result is None or result.has_verified_auth is False
+
+    @pytest.mark.asyncio
+    async def test_middleware_that_does_verify_is_still_confirmed(self) -> None:
+        """The scoping must not cost a true positive: point the definition at
+        `checkToken` and the terminal is found in its own body."""
+        repo = _make_repo(
+            file_index={
+                "src/routes/profile.ts": ROUTE_USING_IT,
+                "src/middleware/auth.ts": MIDDLEWARE_MODULE,
+            }
+        )
+        lsp = _make_lsp()
+        lsp.get_definition.return_value = [
+            LSPLocation(
+                file_path="/tmp/test/src/middleware/auth.ts",
+                line=4,          # checkToken's declaration
+                character=0,
+            )
+        ]
+        result = await AuthFlowTracer(lsp, repo)._trace_express_auth(
+            ROUTE_USING_IT, "/tmp/test/src/routes/profile.ts"
+        )
+        assert result is not None and result.has_verified_auth is True
+        assert "jwt.verify" in result.auth_method


### PR DESCRIPTION
The last instance of a weakness fixed twice already elsewhere.

## The bug

`_trace_express_auth` resolved a middleware to its definition and then searched the whole definition **file** for an auth terminal. Auth helpers cluster in one module, so any middleware resolving into that module inherited its siblings' terminals:

```ts
export function requireAuth(req, res, next) {
  next()                                    // ← verifies nothing
}

export function checkToken(req, res, next) {
  const user = jwt.verify(req.headers.authorization, SECRET)   // ← but this is in the same file
}
```

A route guarded only by `requireAuth` was reported as authenticated — and a route reported as authenticated has its missing-auth finding suppressed, so the failure direction is *hiding a vulnerability*.

Same shape as the inline path (a login route importing `signToken` from the module that defines `verifyToken`). `_trace_definition_body` returns only the resolved symbol's own declaration, and both `_find_auth_terminal` and `_has_enforcement` now see just that.

## Also: resolving from the import line

`re.search` found the middleware's first occurrence in the file — usually its **import**. Asking for the definition of an import specifier is answered with the import itself, which is exactly the shape the project-load retry waits on, so these traces were spending retries before failing. `_locate_symbol` prefers a use site.

## Scope

This path is narrower than it was: centrally-mounted routes are attributed per route since #163, so it now serves files applying middleware inline. Its hardcoded list of five middleware names is **untouched** — it still can't name a project's own vocabulary, which is worth generalising but is a change of behaviour rather than a correction.

## Verification

| | |
|---|---|
| Unit suite | **2368 passed** (+2) |
| sast-injection | 46/46, 0 FP |
| VAmPI | 3/3 |
| test-app | 110 — 4 routes verified, 4 suppressed |
| juice-shop | 183 — 17 routes verified, 15 suppressed |

Findings unchanged everywhere, as expected: neither target reaches this path any more. The two new tests **fail if the whole-file scan is put back** — verified by reverting it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EZ4QoTqRoYWE25CNoV2Wfy