### PR TITLE
fix(lsp): find Express middleware by where it is applied, not by name

### DIFF
--- a/docs/lsp-setup.md
+++ b/docs/lsp-setup.md
@@ -165,6 +165,18 @@ own body**, not the whole module. Scoping matters: helpers cluster, so a login
 route importing `signToken` from the file that also defines `verifyToken` would
 otherwise look authenticated.
 
+**Router-wide Express middleware:**
+```typescript
+import { ensureMember } from "../auth/membership"   // your name, not a convention
+router.use(ensureMember)                            // guards every route below
+router.get('/team/:id', handler)
+```
+
+Middleware applied without a path guards the whole router, so it settles every
+route in the file. It's found by **where it's applied** — a path-less `.use()`
+— not by a list of names: a list can only recognise vocabulary someone thought
+of in advance, and `ensureMember` is your project's word.
+
 **Centrally-mounted Express routes, per route:**
 ```typescript
 app.use('/api/BasketItems', security.isAuthorized())   // traced → verified

--- a/isitsecure/engine/code_analysis/lsp/auth_flow_tracer.py
+++ b/isitsecure/engine/code_analysis/lsp/auth_flow_tracer.py
@@ -147,6 +147,12 @@ class AuthFlowTracer:
 
         abs_path = self._resolve_path(file_path)
 
+        # Middleware applied without a path guards every route on the router,
+        # so it settles the whole file regardless of what the mounts say.
+        router_wide = await self._trace_express_auth(content, abs_path)
+        if router_wide and router_wide.has_verified_auth:
+            return {route.route_pattern: router_wide for route in routes}
+
         mounts = self._route_mounts(content)
         if mounts:
             # Authoritative: this file says which middleware guards what, so
@@ -201,6 +207,22 @@ class AuthFlowTracer:
         return AuthFlowResult(confidence=0.5)
 
     @staticmethod
+    def _applied_middleware(content: str) -> list[str]:
+        """Middleware applied to a whole router, in application order.
+
+        Only path-less ``.use(...)`` calls: a ``.use('/admin', guard)`` is a
+        mount and belongs to its route, not to the file.
+        """
+        names: list[str] = []
+        for match in re.finditer(LSPConfig.MIDDLEWARE_USE_PATTERN, content):
+            for name in AuthFlowTracer._middleware_names(
+                match.group("middleware")
+            ):
+                if name not in names:
+                    names.append(name)
+        return names[: LSPConfig.MAX_MOUNT_MIDDLEWARE]
+
+    @staticmethod
     def _middleware_names(middleware: str) -> list[str]:
         """The callables named on a mount line, in order.
 
@@ -245,11 +267,6 @@ class AuthFlowTracer:
 
         # Strategy 1: Procedure base (tRPC, NestJS, etc.)
         result = await self._trace_procedure_auth(content, abs_path)
-        if result and result.has_verified_auth:
-            return result
-
-        # Strategy 2: Express middleware
-        result = await self._trace_express_auth(content, abs_path)
         if result and result.has_verified_auth:
             return result
 
@@ -357,24 +374,20 @@ class AuthFlowTracer:
     ) -> AuthFlowResult | None:
         """Trace Express middleware to confirm auth verification.
 
-        The fallback for files that do not mount their routes explicitly;
-        centrally-mounted routes are attributed per route instead.
+        The fallback for files that do not mount their routes explicitly.
+        Centrally-mounted routes are attributed per route; what reaches here
+        is middleware applied without a path — ``router.use(requireAuth)`` —
+        which guards every route on that router, so one verdict for the file
+        is the right shape.
+
+        Which middleware is found by *where it is applied*, not by a list of
+        names. A list can only recognise vocabulary someone thought of in
+        advance: it had five entries, so a project calling its guard
+        ``ensureMember`` was invisible, while the entry ``authenticate``
+        matched that word anywhere in the file, including inside an import it
+        never used.
         """
-        # Look for auth middleware imports/usage
-        auth_patterns = (
-            r'\brequireAuth\b',
-            r'\bverifyAuth\b',
-            r'\bauthenticate\b',
-            r'\bisAuthenticated\b',
-            r'\bpassport\.authenticate\b',
-        )
-
-        for pattern in auth_patterns:
-            match = re.search(pattern, content)
-            if not match:
-                continue
-
-            middleware_name = match.group(0)
+        for middleware_name in self._applied_middleware(content):
             position = self._locate_symbol(content, middleware_name)
             if position is None:
                 continue

--- a/isitsecure/engine/constants.py
+++ b/isitsecure/engine/constants.py
@@ -4759,6 +4759,12 @@ class LSPConfig:
     )
 
 
+    # Middleware applied without a path — `router.use(requireAuth)` — which
+    # therefore guards every route on that router. The negative lookahead
+    # excludes `.use('/path', mw)`, which is a mount and is attributed to its
+    # own route instead.
+    MIDDLEWARE_USE_PATTERN = r"\.\s*use\s*\(\s*(?!['\"`])(?P<middleware>[^\n]*)"
+
     # How many middlewares on one mount line are worth resolving.
     MAX_MOUNT_MIDDLEWARE = 4
 

--- a/tests/engine/test_code_analysis/test_auth_flow_tracer.py
+++ b/tests/engine/test_code_analysis/test_auth_flow_tracer.py
@@ -822,9 +822,13 @@ export function checkToken(req, res, next) {
 }
 """
 
+# Applied without a path, so it guards every route on this router — the shape
+# `_trace_express_auth` serves. A `.use('/admin', guard)` would be a mount and
+# is attributed to its own route instead.
 ROUTE_USING_IT = (
     "import { requireAuth } from '../middleware/auth'\n"
-    "router.get('/profile', requireAuth, handler)\n"
+    "router.use(requireAuth)\n"
+    "router.get('/profile', handler)\n"
 )
 
 
@@ -882,3 +886,104 @@ class TestExpressMiddlewareScoping:
         )
         assert result is not None and result.has_verified_auth is True
         assert "jwt.verify" in result.auth_method
+
+
+class TestAppliedMiddlewareDiscovery:
+    """Middleware is found by where it is applied, not by a list of names.
+
+    The list this replaced had five entries, so it could only recognise
+    vocabulary someone had thought of in advance.
+    """
+
+    def test_a_project_specific_guard_is_found(self) -> None:
+        """`ensureMember` is nobody's convention — it is this app's word."""
+        src = "router.use(ensureMember)\nrouter.get('/x', handler)\n"
+        assert AuthFlowTracer._applied_middleware(src) == ["ensureMember"]
+
+    def test_a_qualified_call_yields_the_member(self) -> None:
+        src = "app.use(security.isAuthorized())\n"
+        assert AuthFlowTracer._applied_middleware(src) == ["isAuthorized"]
+
+    def test_mounted_middleware_is_left_to_its_route(self) -> None:
+        """`.use('/admin', guard)` guards one path, not the whole router, and
+        is attributed per route — counting it here would let it vouch for
+        every other route in the file."""
+        src = "app.use('/admin', requireAdmin)\n"
+        assert AuthFlowTracer._applied_middleware(src) == []
+
+    def test_both_forms_in_one_file_are_kept_apart(self) -> None:
+        src = (
+            "app.use(requestLogger)\n"
+            "app.use('/admin', requireAdmin)\n"
+            "app.use(sessionGuard)\n"
+        )
+        assert AuthFlowTracer._applied_middleware(src) == [
+            "requestLogger",
+            "sessionGuard",
+        ]
+
+    def test_several_middlewares_in_one_call_keep_their_order(self) -> None:
+        src = "app.use(cors(), sessionGuard, auditLog)\n"
+        assert AuthFlowTracer._applied_middleware(src) == [
+            "cors",
+            "sessionGuard",
+            "auditLog",
+        ]
+
+    def test_a_name_mentioned_but_never_applied_is_not_middleware(self) -> None:
+        """The old list matched `authenticate` anywhere in the file — an
+        unused import was enough to claim a route was guarded."""
+        src = "import { authenticate } from 'passport'\nconst x = 1\n"
+        assert AuthFlowTracer._applied_middleware(src) == []
+
+    def test_duplicates_collapse(self) -> None:
+        src = "app.use(guard)\nrouter.use(guard)\n"
+        assert AuthFlowTracer._applied_middleware(src) == ["guard"]
+
+    def test_the_count_is_bounded(self) -> None:
+        from isitsecure.engine.constants import LSPConfig
+
+        src = "".join(f"app.use(mw{i})\n" for i in range(12))
+        assert (
+            len(AuthFlowTracer._applied_middleware(src))
+            == LSPConfig.MAX_MOUNT_MIDDLEWARE
+        )
+
+
+class TestRouterWideMiddlewareWins:
+    """`router.use(guard)` guards every route on the router, including ones
+    whose own mount line names no middleware."""
+
+    @pytest.mark.asyncio
+    async def test_a_router_wide_guard_covers_a_mounted_route(self) -> None:
+        routes_src = (
+            "import { ensureMember } from '../auth/membership'\n"
+            "router.use(ensureMember)\n"
+            "router.get('/team/:id', handler)\n"
+        )
+        guard = (
+            "export function ensureMember(req, res, next) {\n"
+            "  const user = verifyToken(req.headers.authorization)\n"
+            "  if (!user) return res.status(401).json({ error: 'no' })\n"
+            "  next()\n"
+            "}\n"
+        )
+        repo = _make_repo(
+            file_index={
+                "src/routes/team.ts": routes_src,
+                "src/auth/membership.ts": guard,
+            },
+        )
+        lsp = _make_lsp()
+        lsp.get_definition.return_value = [
+            LSPLocation(
+                file_path="/tmp/test/src/auth/membership.ts", line=0, character=0
+            )
+        ]
+        route = _make_route("src/routes/team.ts", "/team/:id")
+
+        results = await AuthFlowTracer(lsp, repo).trace_routes([route])
+
+        result = results["src/routes/team.ts:/team/:id"]
+        assert result.has_verified_auth is True
+        assert result.middleware_chain == ["ensureMember"]


### PR DESCRIPTION
The last name list in the tracer.

## The bug

`_trace_express_auth` looked for five hardcoded names — `requireAuth`, `verifyAuth`, `authenticate`, `isAuthenticated`, `passport.authenticate` — **anywhere in the file**. Two failures from one design:

- A list only recognises vocabulary someone thought of in advance. A project whose guard is called `ensureMember` was invisible.
- Matching anywhere meant an *unused import* of `authenticate` was enough to claim a route was guarded.

Middleware is now found **positionally**: a path-less `.use(...)` call, which is exactly what this path serves. `.use('/admin', guard)` is a mount and stays attributed to its own route, so it can't vouch for the rest of the file.

## A gap this exposed

A file with **both** `router.use(ensureMember)` and `router.get('/team/:id', handler)` has mounts, so per-route attribution ran and looked only at the mount line — **missing the router-wide guard that covers every route on it**. Path-less middleware is now checked first and settles the whole file when it verifies.

That direction was a false *negative*: it reported a false positive rather than hiding a vulnerability. Wrong, but the safe kind of wrong.

**It took an honest mock to see.** My first end-to-end probe returned every symbol's definition from one file, so the route came out verified via `handler` — right answer, wrong reason. Resolving each symbol to its own file showed `has_verified_auth: False`.

## Verification

| | |
|---|---|
| Unit suite | **2377 passed** (+9) |
| sast-injection | 46/46, 0 FP |
| VAmPI | 3/3 |
| test-app | 110 — 4 verified, 4 suppressed |
| juice-shop | 183 — 17 verified, 15 suppressed |

Unchanged on both targets, since neither uses path-less middleware — so the new tests carry the weight here, including that a mounted `.use('/admin', …)` is *not* counted as router-wide, and that a name mentioned but never applied isn't middleware.

## Docs

`lsp-setup.md` gains the router-wide middleware shape and the where-it's-applied rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EZ4QoTqRoYWE25CNoV2Wfy