### PR TITLE
fix: map the routes a project actually has, and follow aliases to the guard

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -259,6 +259,26 @@ The repo ingestion phase uses framework-specific route mappers:
 
 All mappers implement `RouteMapperProtocol` and are registered in `factory.py`. Adding a new language requires implementing one mapper — no changes to existing code.
 
+`ExpressRouteMapper` searches the whole repository rather than a list of
+directory names, because Express projects put routes wherever they like — a
+list of `src`, `routes`, `api` mapped **zero** routes for a project keeping
+them in `app/routes`, and downstream nothing can tell "no routes" apart from
+"did not look". Vendored and generated directories (`node_modules`, `dist`,
+`.git`, …) are pruned, and the walk is capped at
+`ExpressRouteMapperConfig.MAX_FILES_SCANNED`.
+
+Searching everywhere then raises a second question, since a repo also holds
+route-shaped code that never runs — Juice Shop ships 135 route definitions
+under `data/static/codefixes` as fixtures for its own coding challenges. A
+candidate is kept only if it is **reachable**: imported by another file
+(per `ImportGraphBuilder`), or an entry point nothing imports because it *is*
+the start (a top-level script, or `server`/`app`/`index`/`main`). Route files
+are often loaded by globbing a directory, which leaves no import to find, so
+one reachable route file keeps every route file beside it; and if *nothing*
+looks reachable the graph is uninformative — the entry point may be a `.jsx`
+or a compiled artefact — so the filter stands down rather than dropping the
+whole project.
+
 ## Design Principles
 
 ### Protocol-Based (Dependency Inversion)

--- a/docs/lsp-setup.md
+++ b/docs/lsp-setup.md
@@ -177,6 +177,25 @@ route in the file. It's found by **where it's applied** — a path-less `.use()`
 — not by a list of names: a list can only recognise vocabulary someone thought
 of in advance, and `ensureMember` is your project's word.
 
+**Middleware reached through a local alias:**
+```javascript
+const isLoggedIn = sessionHandler.isLoggedInMiddleware   // just another name
+app.get('/dashboard', isLoggedIn, handler.show)
+```
+
+Go-to-definition on `isLoggedIn` lands on the alias, not the implementation.
+Stopping there reads an assignment with no auth in it and calls the route
+unguarded — the dangerous direction, since the route *is* guarded. A
+declaration whose whole right-hand side is a name gets followed to what it
+names, up to `MAX_TRACE_DEPTH` hops; anything with a call or a function body
+is the implementation and is read where it stands.
+
+Whether the next hop resolves is the language server's call. In untyped
+CommonJS — a property assigned as `this.x = …` inside a constructor, reached
+through `new Handler(db)` — tsserver returns no definition at all, and the
+trace stops at the alias. That route stays *unverified* rather than falsely
+cleared, so its findings are reported, not suppressed.
+
 **Centrally-mounted Express routes, per route:**
 ```typescript
 app.use('/api/BasketItems', security.isAuthorized())   // traced → verified

--- a/isitsecure/engine/code_analysis/express_route_mapper.py
+++ b/isitsecure/engine/code_analysis/express_route_mapper.py
@@ -14,11 +14,17 @@ DIP: Depends on ``RouteMapperProtocol`` (abstraction), not on any
 from __future__ import annotations
 
 import logging
+import os
+import posixpath
 import re
 from pathlib import Path
 
+from isitsecure.engine.code_analysis.import_graph import ImportGraphBuilder
 from isitsecure.engine.code_analysis.protocols import RouteEntry
-from isitsecure.engine.constants import ExpressRouteMapperConfig
+from isitsecure.engine.constants import (
+    ExpressRouteMapperConfig,
+    SharedPatterns,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -84,37 +90,98 @@ class ExpressRouteMapper:
     # ------------------------------------------------------------------
 
     def _find_route_files(self, root: Path) -> list[Path]:
-        """Find files that contain Express route definitions."""
-        candidates: list[Path] = []
+        """Find the files that define this application's Express routes.
 
-        # Search in standard source directories
-        for source_dir_name in ExpressRouteMapperConfig.SOURCE_DIRS:
-            source_dir = root / source_dir_name
-            if not source_dir.is_dir():
-                continue
+        The whole tree is walked, minus vendored and generated directories.
+        Guessing at directory names — src, routes, api — meant a project that
+        keeps its routes anywhere else had none of them mapped, and nothing
+        downstream could tell the difference between "no routes" and "did not
+        look": NodeGoat, whose routes live in app/routes, mapped zero.
 
-            for ext in ExpressRouteMapperConfig.CODE_EXTENSIONS:
-                for file_path in source_dir.rglob(f"*{ext}"):
-                    candidates.append(file_path)
+        Walking everything then needs a second question, because a repo holds
+        code that is never wired into the running app: Juice Shop ships 135
+        route definitions under data/static/codefixes as fixtures for its own
+        coding challenges. They look exactly like routes, and reporting
+        missing auth on them is 84 findings about code that does not run.
+        So a candidate has to be reachable — imported by something, or an
+        entry point nothing imports because it *is* the start.
 
-        # Also check root-level entry files (main.js, app.js, server.js, index.js)
-        for name in ("main", "app", "server", "index"):
-            for ext in ExpressRouteMapperConfig.CODE_EXTENSIONS:
-                entry = root / f"{name}{ext}"
-                if entry.is_file() and entry not in candidates:
-                    candidates.append(entry)
+        Files loaded dynamically (``readdirSync('./routes').forEach(require)``)
+        have no import to find, so a directory that holds one reachable route
+        file keeps all of them. Erring that way costs noise; erring the other
+        way drops real routes, and a route nobody maps is a route nobody
+        checks.
+        """
+        code_files = self._read_code_files(root)
+        candidates = [
+            path for path, content in code_files.items()
+            if self._is_express_file(content)
+        ]
+        if not candidates:
+            return []
 
-        # Filter to only files that actually contain Express patterns
-        route_files: list[Path] = []
-        for file_path in candidates:
-            try:
-                content = file_path.read_text(encoding="utf-8", errors="replace")
-                if self._is_express_file(content):
-                    route_files.append(file_path)
-            except OSError:
-                continue
+        fan_in = ImportGraphBuilder().build_fan_in_map(code_files)
+        reachable = {
+            path for path in candidates
+            if fan_in.get(path) or self._is_entry_point(path)
+        }
+        if not reachable:
+            # Nothing looks wired, which says more about the graph than the
+            # code: the entry point may be a .jsx, a .cjs or a compiled
+            # artefact this walk never read. Pruning on no evidence at all
+            # would drop every route in the project.
+            return [root / path for path in candidates]
 
-        return route_files
+        reachable_dirs = {posixpath.dirname(path) for path in reachable}
+
+        return [
+            root / path for path in candidates
+            if path in reachable or posixpath.dirname(path) in reachable_dirs
+        ]
+
+    @staticmethod
+    def _read_code_files(root: Path) -> dict[str, str]:
+        """Every source file under ``root``, keyed by repo-relative path.
+
+        The import graph needs the whole picture, not just the route files:
+        what makes a route file reachable is being imported by a file that is
+        itself no route file at all.
+        """
+        code_files: dict[str, str] = {}
+
+        for dirpath, dirnames, filenames in os.walk(root):
+            dirnames[:] = [
+                d for d in dirnames
+                if d not in SharedPatterns.VENDOR_DIRS and not d.startswith(".")
+            ]
+            for name in filenames:
+                if not name.endswith(ExpressRouteMapperConfig.CODE_EXTENSIONS):
+                    continue
+                file_path = Path(dirpath) / name
+                try:
+                    content = file_path.read_text(
+                        encoding="utf-8", errors="replace"
+                    )
+                except OSError:
+                    continue
+                relative = file_path.relative_to(root).as_posix()
+                code_files[relative] = content
+            if len(code_files) >= ExpressRouteMapperConfig.MAX_FILES_SCANNED:
+                break
+
+        return code_files
+
+    @staticmethod
+    def _is_entry_point(relative_path: str) -> bool:
+        """Whether nothing importing this file is expected.
+
+        The process starts somewhere, and that file is imported by no other:
+        a top-level script, or one of the conventional entry names.
+        """
+        if "/" not in relative_path:
+            return True
+        stem = posixpath.basename(relative_path).rsplit(".", 1)[0]
+        return stem in ExpressRouteMapperConfig.ENTRY_POINT_STEMS
 
     @staticmethod
     def _is_express_file(content: str) -> bool:

--- a/isitsecure/engine/code_analysis/lsp/auth_flow_tracer.py
+++ b/isitsecure/engine/code_analysis/lsp/auth_flow_tracer.py
@@ -560,15 +560,20 @@ class AuthFlowTracer:
         content = self._get_file_content_absolute(file_path)
         if not content:
             return False
-        lines = content.split("\n")
         for loc in locations:
             if loc.file_path != file_path:
                 return False
-            if not (0 <= loc.line < len(lines)):
-                return False
-            if not lines[loc.line].lstrip().startswith(("import ", "import{")):
+            if not self._is_import_line(content, loc.line):
                 return False
         return True
+
+    @staticmethod
+    def _is_import_line(content: str, line: int) -> bool:
+        """True when ``line`` is an import statement rather than a body."""
+        lines = content.split("\n")
+        if not (0 <= line < len(lines)):
+            return False
+        return lines[line].lstrip().startswith(("import ", "import{"))
 
     async def _trace_definition(
         self,
@@ -605,7 +610,12 @@ class AuthFlowTracer:
         return None
 
     async def _trace_definition_body(
-        self, file_path: str, line: int, character: int
+        self,
+        file_path: str,
+        line: int,
+        character: int,
+        depth: int = 0,
+        seen: frozenset[tuple[str, int, int]] = frozenset(),
     ) -> str | None:
         """Go-to-definition, returning only the resolved symbol's own body.
 
@@ -614,38 +624,108 @@ class AuthFlowTracer:
         terminals belonging to its siblings. Searching the whole file made a
         login route — which imports ``signToken`` from the same module that
         defines ``verifyToken`` — look authenticated.
+
+        A declaration that is only another name for something else is
+        followed, up to ``MAX_TRACE_DEPTH`` hops. One hop lands on the
+        alias, not the implementation::
+
+            const isLoggedIn = sessionHandler.isLoggedInMiddleware;
+
+        Stopping there reads an assignment with no auth in it and concludes
+        the route is unguarded — the dangerous direction, since the route
+        *is* guarded. Local aliases like this are how a project shortens a
+        name it uses twenty times, so they sit directly between the route
+        and every guard it applies. ``seen`` closes the cycle a
+        self-referential alias would otherwise open.
         """
+        key = (file_path, line, character)
+        if key in seen or depth >= LSPConfig.MAX_TRACE_DEPTH:
+            return None
+        seen = seen | {key}
+
         locations = await self._resolve_definition(file_path, line, character)
         if not locations:
             return None
 
         for loc in locations:
-            if loc.file_path == file_path and loc.line == line:
-                continue
             if "node_modules" in loc.file_path:
                 continue
             content = self._get_file_content_absolute(loc.file_path)
-            if content:
-                return self._enclosing_block(content, loc.line)
+            if not content:
+                continue
+            # A location on an import line in the file we asked from is the
+            # unresolved answer, not a declaration; its "body" would be
+            # whatever happens to follow the import. A location that lands
+            # back on the query itself is not: that is a symbol declared
+            # right there, and reading it is the whole point.
+            if loc.file_path == file_path and self._is_import_line(
+                content, loc.line
+            ):
+                continue
+
+            block = self._enclosing_block(content, loc.line)
+            alias_column = self._alias_target_column(block)
+            if alias_column is not None:
+                followed = await self._trace_definition_body(
+                    loc.file_path, loc.line, alias_column, depth + 1, seen
+                )
+                if followed:
+                    return followed
+            return block
         return None
+
+    @staticmethod
+    def _alias_target_column(block: str) -> int | None:
+        """Column of the symbol an alias declaration points at, if it is one.
+
+        An alias is a declaration whose whole right-hand side is a name —
+        ``const isLoggedIn = sessionHandler.isLoggedInMiddleware;``. Anything
+        with a call or a function body is the implementation itself and is
+        answered where it stands.
+
+        The column returned is the *last* segment of a dotted path, because
+        that is the member whose definition is wanted:
+        ``sessionHandler.isLoggedInMiddleware`` resolves to the assignment in
+        the session module, while ``sessionHandler`` resolves only to the
+        local variable holding the object.
+        """
+        first_line = block.split("\n", 1)[0]
+        match = re.match(LSPConfig.ALIAS_DECLARATION_PATTERN, first_line)
+        if not match:
+            return None
+        target = match.group("target")
+        return match.start("target") + target.rfind(".") + 1
 
     @staticmethod
     def _enclosing_block(content: str, line: int) -> str:
         """The declaration starting at ``line``, up to its closing brace.
 
         Ends at the first closing brace in the declaration's own column, so a
-        top-level function stops before its neighbours. Falls back to the
-        remainder of the file if no such brace is found.
+        top-level function stops before its neighbours. Trailing punctuation
+        is ignored, so an assigned function — which closes on ``};`` or
+        ``});`` rather than a bare brace — ends where it actually ends
+        instead of running to the end of the file and picking up whatever
+        its neighbours do.
+
+        Falls back to the remainder of the file if no such brace is found.
         """
         lines = content.split("\n")
         if not (0 <= line < len(lines)):
             return content
 
         start = lines[line]
+        # A statement that opens no block is the whole declaration. Scanning
+        # on for a closing brace it never opened runs into the *next*
+        # declaration's brace and returns a block that includes neighbours —
+        # which is how an alias to something unguarded could be vouched for
+        # by a guard defined twenty lines below it.
+        if start.count("{") <= start.count("}"):
+            return start
+
         indent = len(start) - len(start.lstrip())
         closing = (" " * indent) + "}"
         for end in range(line + 1, len(lines)):
-            if lines[end].rstrip() == closing:
+            if lines[end].rstrip().rstrip(";,)") == closing:
                 return "\n".join(lines[line : end + 1])
         return "\n".join(lines[line:])
 

--- a/isitsecure/engine/constants.py
+++ b/isitsecure/engine/constants.py
@@ -4741,6 +4741,16 @@ class LSPConfig:
     # --- Performance guards ---
     MAX_FILES_TO_OPEN = 100
     MAX_TRACE_DEPTH = 5  # prevent infinite recursion in go-to-definition chains
+
+    # A declaration that is nothing but another name for something else:
+    # `const isLoggedIn = sessionHandler.isLoggedInMiddleware;`. The right-hand
+    # side must be a bare (possibly dotted) name — a call or an arrow body
+    # means this *is* the implementation, so tracing stops here.
+    ALIAS_DECLARATION_PATTERN = (
+        r"^\s*(?:const|let|var|this\.[\w$]+|exports\.[\w$]+"
+        r"|module\.exports\.[\w$]+)?\s*[\w$.]+\s*=\s*"
+        r"(?P<target>[\w$]+(?:\.[\w$]+)*)\s*;?\s*$"
+    )
     MAX_CONCURRENT_REQUESTS = 10
 
     # --- tsserver command detection ---

--- a/isitsecure/engine/constants.py
+++ b/isitsecure/engine/constants.py
@@ -6,6 +6,16 @@ from isitsecure.engine.enums import FindingCategory, SeverityLevel
 class SharedPatterns:
     """Shared regex patterns and constants used across multiple scanners."""
 
+    # Directories that hold someone else's code or build output. Several
+    # scanners walk a repo and every one of them needs this list; keeping one
+    # copy is why it lives here rather than beside each walker.
+    VENDOR_DIRS = frozenset({
+        "node_modules", ".git", ".venv", "venv", "env", "__pycache__",
+        "dist", "build", "out", "target", ".next", ".nuxt", ".output",
+        ".mypy_cache", ".pytest_cache", ".ruff_cache", "vendor",
+        "site-packages", "coverage", ".terraform",
+    })
+
     UUID_PATTERN = (
         r'[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'
     )
@@ -3580,11 +3590,18 @@ class ExpressRouteMapperConfig:
 
     SCANNER_NAME = "express_route_mapper"
 
-    # Directories to search for Express route files
-    SOURCE_DIRS = ("src", "routes", "src/routes", "api", "src/api")
-
     # File extensions to scan
     CODE_EXTENSIONS = (".js", ".ts", ".mjs")
+
+    # No list of source directory names. Express projects put routes wherever
+    # they like — NodeGoat uses app/routes, which a list of src/routes/api
+    # never reached, so its routes were not mapped at all and every later
+    # stage silently had nothing to work on. The whole tree is walked instead,
+    # minus vendored code, and this caps what that can cost.
+    MAX_FILES_SCANNED = 20_000
+
+    # Files nothing is expected to import, because the process starts there.
+    ENTRY_POINT_STEMS = frozenset({"server", "app", "index", "main"})
 
     # Regex patterns for Express route definitions
     # Captures: (method, path) from app.get('/path', ...) or router.post('/path', ...)
@@ -4927,11 +4944,7 @@ class LSPConfig:
     # Directories that say nothing about what a project is written in, and can
     # be enormous. Ingestion strips most of these already; belt and braces for
     # callers that point us at a working tree.
-    LANGUAGE_SCAN_SKIP_DIRS = frozenset({
-        "node_modules", ".git", ".venv", "venv", "env", "__pycache__",
-        "dist", "build", "out", "target", ".next", ".mypy_cache",
-        ".pytest_cache", ".ruff_cache", "vendor", "site-packages",
-    })
+    LANGUAGE_SCAN_SKIP_DIRS = SharedPatterns.VENDOR_DIRS
 
     # Stop counting once a project's language is obvious — a monorepo should
     # not cost a full-tree walk.

--- a/tests/engine/test_code_analysis/test_auth_flow_tracer.py
+++ b/tests/engine/test_code_analysis/test_auth_flow_tracer.py
@@ -669,6 +669,35 @@ class TestEnclosingBlock:
         assert "jwt.verify" in block
         assert "signToken" not in block
 
+    def test_a_statement_that_opens_no_block_is_just_that_line(self) -> None:
+        """An alias opens no block, so there is none to scan for. Scanning
+        anyway runs into the *next* declaration's closing brace and returns a
+        body containing neighbours — which is how an alias to something
+        unguarded gets vouched for by a guard defined below it."""
+        src = (
+            "const isLoggedIn = handler.isLoggedInMiddleware;\n"
+            "app.get('/x', (req, res) => {\n"
+            "  jwt.verify(req.token);\n"
+            "});\n"
+        )
+        block = AuthFlowTracer._enclosing_block(src, 0)
+        assert block == "const isLoggedIn = handler.isLoggedInMiddleware;"
+        assert "jwt.verify" not in block
+
+    def test_an_assigned_function_ends_at_its_closing_brace(self) -> None:
+        """`};` closes a function expression just as `}` closes a
+        declaration; not accepting it ran the body to the end of the file."""
+        src = (
+            "this.requireUser = (req, res, next) => {\n"
+            "  if (!req.user) return res.status(401).end();\n"
+            "  next();\n"
+            "};\n"
+            "this.other = () => { getUser(); };\n"
+        )
+        block = AuthFlowTracer._enclosing_block(src, 0)
+        assert "status(401)" in block
+        assert "getUser" not in block
+
     def test_out_of_range_line_returns_everything(self) -> None:
         assert AuthFlowTracer._enclosing_block(MODULE, 999) == MODULE
 
@@ -987,3 +1016,188 @@ class TestRouterWideMiddlewareWins:
         result = results["src/routes/team.ts:/team/:id"]
         assert result.has_verified_auth is True
         assert result.middleware_chain == ["ensureMember"]
+
+
+# ---------------------------------------------------------------------------
+# Definition-body extraction and alias following
+# ---------------------------------------------------------------------------
+
+
+class TestAliasTargetColumn:
+    """Which declarations are only another name for something else."""
+
+    def test_a_dotted_alias_points_at_its_last_segment(self) -> None:
+        """`sessionHandler` resolves to the local variable; only
+        `isLoggedInMiddleware` resolves to the middleware itself."""
+        line = "    const isLoggedIn = sessionHandler.isLoggedInMiddleware;"
+        column = AuthFlowTracer._alias_target_column(line)
+        assert line[column:] == "isLoggedInMiddleware;"
+
+    def test_a_bare_alias_points_at_the_name(self) -> None:
+        line = "const guard = requireAuth;"
+        column = AuthFlowTracer._alias_target_column(line)
+        assert line[column:] == "requireAuth;"
+
+    def test_an_export_assignment_is_an_alias(self) -> None:
+        line = "module.exports.guard = internal.guard"
+        assert AuthFlowTracer._alias_target_column(line) is not None
+
+    def test_a_function_body_is_not_an_alias(self) -> None:
+        """This is the implementation — tracing stops here, not one hop on."""
+        line = "this.isLoggedInMiddleware = (req, res, next) => {"
+        assert AuthFlowTracer._alias_target_column(line) is None
+
+    def test_a_call_is_not_an_alias(self) -> None:
+        line = 'const ErrorHandler = require("./error").errorHandler;'
+        assert AuthFlowTracer._alias_target_column(line) is None
+
+    def test_a_construction_is_not_an_alias(self) -> None:
+        line = "const sessionHandler = new SessionHandler(db);"
+        assert AuthFlowTracer._alias_target_column(line) is None
+
+
+class _ScriptedLSP:
+    """An LSP that answers each symbol honestly, from its own position.
+
+    A mock that returns one file for every query proves nothing: a route can
+    then come out verified through a symbol that has no auth in it at all.
+    Definitions are keyed by the exact (file, line, column) asked about.
+    """
+
+    def __init__(self, definitions: dict, files: dict[str, str]) -> None:
+        self._definitions = definitions
+        self._files = files
+        self.queries: list[tuple[str, int, int]] = []
+
+    @property
+    def is_available(self) -> bool:
+        return True
+
+    async def initialize(self, path: str) -> bool:
+        return True
+
+    async def get_definition(self, file_path: str, line: int, character: int):
+        self.queries.append((file_path, line, character))
+        target = self._definitions.get((file_path, line, character))
+        return [LSPLocation(file_path=target[0], line=target[1], character=0)] if target else []
+
+    async def get_references(self, *a, **k):
+        return None
+
+    async def get_hover(self, *a, **k):
+        return None
+
+    async def shutdown(self) -> None:
+        return None
+
+
+@pytest.mark.asyncio
+class TestAliasFollowing:
+    """Following a local alias to the middleware it names.
+
+    `const isLoggedIn = sessionHandler.isLoggedInMiddleware` is how a project
+    shortens a name it applies to twenty routes. Stopping at the alias reads
+    an assignment with no auth in it and calls every one of those routes
+    unguarded.
+    """
+
+    ROOT = "/tmp/test"
+    ROUTES = "routes.js"
+    SESSION = "session.js"
+    ROUTES_ABS = f"{ROOT}/{ROUTES}"
+    SESSION_ABS = f"{ROOT}/{SESSION}"
+
+    ROUTES_SRC = (
+        "const sessionHandler = new SessionHandler(db);\n"
+        "const isLoggedIn = sessionHandler.isLoggedInMiddleware;\n"
+        "app.get('/dashboard', isLoggedIn, handler.show);\n"
+    )
+    SESSION_SRC = (
+        "this.isLoggedInMiddleware = (req, res, next) => {\n"
+        "  if (!jwt.verify(req.token)) return res.status(401).end();\n"
+        "  next();\n"
+        "};\n"
+    )
+
+    def _column(self, src: str, line: int, needle: str, occurrence: int = 0) -> int:
+        text = src.split("\n")[line]
+        index = -1
+        for _ in range(occurrence + 1):
+            index = text.index(needle, index + 1)
+        return index
+
+    def _tracer(self, *, resolve_alias: bool = True):
+        files = {self.ROUTES: self.ROUTES_SRC, self.SESSION: self.SESSION_SRC}
+        mount_col = self._column(self.ROUTES_SRC, 2, "isLoggedIn")
+        decl_col = self._column(self.ROUTES_SRC, 1, "isLoggedIn")
+        alias_col = self._column(self.ROUTES_SRC, 1, "isLoggedInMiddleware")
+        definitions = {
+            (self.ROUTES_ABS, 2, mount_col): (self.ROUTES_ABS, 1),
+            (self.ROUTES_ABS, 1, decl_col): (self.ROUTES_ABS, 1),
+        }
+        if resolve_alias:
+            definitions[(self.ROUTES_ABS, 1, alias_col)] = (self.SESSION_ABS, 0)
+        lsp = _ScriptedLSP(definitions, files)
+        repo = _make_repo(file_index=files)
+        return AuthFlowTracer(lsp, repo), lsp
+
+    async def test_an_alias_resolves_to_the_middleware_it_names(self) -> None:
+        tracer, _ = self._tracer()
+        body = await tracer._trace_definition_body(
+            self.ROUTES_ABS, 2, self._column(self.ROUTES_SRC, 2, "isLoggedIn")
+        )
+        assert "jwt.verify" in body
+
+    async def test_a_guarded_route_is_verified_through_its_alias(self) -> None:
+        tracer, _ = self._tracer()
+        results = await tracer.trace_routes([_make_route(self.ROUTES, "/dashboard")])
+        result = results[f"{self.ROUTES}:/dashboard"]
+        assert result.has_verified_auth
+        assert "jwt.verify" in result.auth_method
+
+    async def test_an_unresolvable_second_hop_does_not_verify(self) -> None:
+        """When the alias target cannot be resolved — an untyped property on
+        a constructed object, say — the alias line is the honest answer, and
+        it has no auth in it, so the route stays unverified rather than
+        falsely cleared."""
+        tracer, _ = self._tracer(resolve_alias=False)
+        results = await tracer.trace_routes([_make_route(self.ROUTES, "/dashboard")])
+        assert not results[f"{self.ROUTES}:/dashboard"].has_verified_auth
+
+    async def test_a_self_referential_alias_terminates(self) -> None:
+        """A cycle must end in an answer, not a hang."""
+        src = "const guard = guard;\napp.get('/x', guard, h);\n"
+        files = {"a.js": src}
+        abs_path = f"{self.ROOT}/a.js"
+        definitions = {
+            (abs_path, 1, self._column(src, 1, "guard")): (abs_path, 0),
+            (abs_path, 0, self._column(src, 0, "guard")): (abs_path, 0),
+            (abs_path, 0, self._column(src, 0, "guard", 1)): (abs_path, 0),
+        }
+        tracer = AuthFlowTracer(
+            _ScriptedLSP(definitions, files), _make_repo(file_index=files)
+        )
+        results = await tracer.trace_routes([_make_route("a.js", "/x")])
+        assert not results["a.js:/x"].has_verified_auth
+
+    async def test_the_hop_count_is_bounded(self) -> None:
+        """Aliases chained past MAX_TRACE_DEPTH stop rather than recurse on,
+        and the last body reached is still returned."""
+        from isitsecure.engine.constants import LSPConfig
+
+        depth = LSPConfig.MAX_TRACE_DEPTH + 3
+        src = "\n".join(f"const a{i} = a{i + 1};" for i in range(depth))
+        files = {"chain.js": src}
+        abs_path = f"{self.ROOT}/chain.js"
+        definitions = {
+            (abs_path, i, self._column(src, i, f"a{i + 1}")): (abs_path, i + 1)
+            for i in range(depth)
+        }
+        tracer = AuthFlowTracer(
+            _ScriptedLSP(definitions, files), _make_repo(file_index=files)
+        )
+        body = await tracer._trace_definition_body(
+            abs_path, 0, self._column(src, 0, "a1")
+        )
+        assert body is not None
+        assert len(tracer._lsp.queries) <= LSPConfig.MAX_TRACE_DEPTH

--- a/tests/engine/test_code_analysis/test_express_route_mapper.py
+++ b/tests/engine/test_code_analysis/test_express_route_mapper.py
@@ -25,7 +25,7 @@ class TestExpressRouteMapperBasic:
         self, tmp_path: Path
     ) -> None:
         """Scanner returns empty list when JS files contain no Express patterns."""
-        src_dir = tmp_path / ExpressRouteMapperConfig.SOURCE_DIRS[0]
+        src_dir = tmp_path / "src"
         src_dir.mkdir(parents=True)
         plain_file = src_dir / "utils.js"
         plain_file.write_text(
@@ -240,3 +240,150 @@ class TestMountPoints:
         routes = self.mapper.map_routes(str(tmp_path))
         assert len(routes) == 1
         assert routes[0].content == content
+
+
+class TestRouteFileDiscovery:
+    """Which files the mapper treats as this application's routes.
+
+    Two questions, both of which used to be answered wrong. Where to look:
+    a fixed list of directory names — src, routes, api — reported zero routes
+    for any project that names its own, and "zero routes" is indistinguishable
+    from "no Express here" for every stage downstream. And what counts: a repo
+    also holds route-shaped code that never runs, and reporting missing auth
+    on a fixture is a finding about nothing.
+    """
+
+    def setup_method(self) -> None:
+        self.mapper = ExpressRouteMapper()
+
+    ROUTE = (
+        "const express = require('express');\n"
+        "const router = express.Router();\n"
+        "router.get('/widgets', (req, res) => res.json([]));\n"
+        "module.exports = router;\n"
+    )
+
+    def _write(self, root: Path, rel: str, body: str) -> None:
+        target = root / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(body)
+
+    def _app(self, root: Path, *requires: str) -> None:
+        """A root entry point that requires the given route modules."""
+        body = "const express = require('express');\nconst app = express();\n"
+        body += "".join(f"app.use(require('./{r}'));\n" for r in requires)
+        self._write(root, "server.js", body)
+
+    def _patterns(self, root: Path) -> list[str]:
+        return [r.route_pattern for r in self.mapper.map_routes(str(root))]
+
+    def test_finds_routes_outside_the_conventional_directories(
+        self, tmp_path: Path
+    ) -> None:
+        """NodeGoat's shape: routes under app/routes, which no list reached."""
+        self._write(tmp_path, "app/routes/widgets.js", self.ROUTE)
+        self._app(tmp_path, "app/routes/widgets")
+        assert "/widgets" in self._patterns(tmp_path)
+
+    def test_finds_routes_at_any_depth(self, tmp_path: Path) -> None:
+        self._write(tmp_path, "services/billing/http/v2/handlers.js", self.ROUTE)
+        self._app(tmp_path, "services/billing/http/v2/handlers")
+        assert "/widgets" in self._patterns(tmp_path)
+
+    def test_still_finds_routes_in_the_conventional_directories(
+        self, tmp_path: Path
+    ) -> None:
+        """Widening the search must not lose what the old list did find."""
+        self._write(tmp_path, "src/routes/widgets.js", self.ROUTE)
+        self._app(tmp_path, "src/routes/widgets")
+        assert "/widgets" in self._patterns(tmp_path)
+
+    def test_vendored_code_is_not_scanned(self, tmp_path: Path) -> None:
+        """A dependency's routes are not this project's attack surface, and
+        node_modules is where a whole-tree walk would otherwise drown."""
+        self._write(tmp_path, "node_modules/express-thing/lib/routes.js", self.ROUTE)
+        assert self.mapper.map_routes(str(tmp_path)) == []
+
+    def test_hidden_directories_are_not_scanned(self, tmp_path: Path) -> None:
+        self._write(tmp_path, ".git/hooks/routes.js", self.ROUTE)
+        assert self.mapper.map_routes(str(tmp_path)) == []
+
+    def test_build_output_is_not_scanned(self, tmp_path: Path) -> None:
+        """dist/ is a copy of src/, so scanning it doubles every finding."""
+        self._write(tmp_path, "dist/routes.js", self.ROUTE)
+        assert self.mapper.map_routes(str(tmp_path)) == []
+
+    def test_non_code_files_are_ignored(self, tmp_path: Path) -> None:
+        self._write(tmp_path, "app/routes/widgets.md", self.ROUTE)
+        assert self.mapper.map_routes(str(tmp_path)) == []
+
+    def test_the_walk_is_bounded(self, tmp_path: Path, monkeypatch) -> None:
+        """A pathological tree must not make the scan unbounded."""
+        from isitsecure.engine.constants import ExpressRouteMapperConfig
+
+        monkeypatch.setattr(ExpressRouteMapperConfig, "MAX_FILES_SCANNED", 2)
+        for i in range(50):
+            self._write(tmp_path, f"pkg{i}/routes.js", self.ROUTE)
+        assert len(self.mapper.map_routes(str(tmp_path))) < 50
+
+
+class TestUnreachableRouteFiles:
+    """Route-shaped code that the application never loads.
+
+    Juice Shop ships 135 of these under data/static/codefixes — fixtures for
+    its own coding challenges. Mapping them produced 84 findings about
+    missing auth on code that does not run.
+    """
+
+    def setup_method(self) -> None:
+        self.mapper = ExpressRouteMapper()
+
+    ROUTE = TestRouteFileDiscovery.ROUTE
+    _write = TestRouteFileDiscovery._write
+    _app = TestRouteFileDiscovery._app
+    _patterns = TestRouteFileDiscovery._patterns
+
+    def _snippet(self, root: Path, rel: str) -> None:
+        self._write(
+            root,
+            rel,
+            "const router = require('express').Router();\n"
+            "router.get('/snippet', (req, res) => res.json([]));\n",
+        )
+
+    def test_a_file_nothing_imports_is_not_a_route(self, tmp_path: Path) -> None:
+        self._write(tmp_path, "src/routes/widgets.js", self.ROUTE)
+        self._app(tmp_path, "src/routes/widgets")
+        self._snippet(tmp_path, "data/static/codefixes/challenge_1.js")
+        patterns = self._patterns(tmp_path)
+        assert "/widgets" in patterns
+        assert "/snippet" not in patterns
+
+    def test_a_neighbour_of_a_reachable_route_is_kept(
+        self, tmp_path: Path
+    ) -> None:
+        """Route files are often loaded by globbing a directory, which leaves
+        no import to find. Missing a real route is the worse mistake, so one
+        reachable file vouches for its directory."""
+        self._write(tmp_path, "src/routes/widgets.js", self.ROUTE)
+        self._app(tmp_path, "src/routes/widgets")
+        self._snippet(tmp_path, "src/routes/gadgets.js")
+        assert "/snippet" in self._patterns(tmp_path)
+
+    def test_an_entry_point_needs_no_importer(self, tmp_path: Path) -> None:
+        """Nothing imports the file the process starts from."""
+        self._write(tmp_path, "server.js", self.ROUTE)
+        assert "/widgets" in self._patterns(tmp_path)
+
+    def test_a_conventional_entry_name_needs_no_importer(
+        self, tmp_path: Path
+    ) -> None:
+        self._write(tmp_path, "app/routes/index.js", self.ROUTE)
+        assert "/widgets" in self._patterns(tmp_path)
+
+    def test_nothing_reachable_keeps_everything(self, tmp_path: Path) -> None:
+        """When no candidate looks wired the graph is uninformative — the
+        entry point may be a .jsx or a compiled artefact this walk never
+        read — and pruning on no evidence would drop the whole project."""
+        self._write(tmp_path, "src/http/widgets.js", self.ROUTE)
+        assert "/widgets" in self._patterns(tmp_path)


### PR DESCRIPTION
Two defects surfaced by benchmarking the middleware-name generalisation (#170), both pre-existing.

## 1. Route discovery guessed at directory names

`ExpressRouteMapper` searched `src`, `routes`, `src/routes`, `api`, `src/api`. NodeGoat keeps its routes in `app/routes`, so it mapped **zero** — and nothing downstream can tell "no routes" apart from "did not look".

The whole tree is walked now, minus vendored/generated directories and capped at `MAX_FILES_SCANNED`.

That alone **regressed Juice Shop by 84 false positives**: the wider walk picked up 135 route definitions under `data/static/codefixes`, fixtures for Juice Shop's own coding challenges, and the route auth analyzer reported missing auth on code that never runs. So a candidate is kept only if it is *reachable* — imported by another file (reusing the existing `ImportGraphBuilder`), or an entry point nothing imports because it is the start.

Two relaxations, both erring toward keeping routes, because a route nobody maps is a route nobody checks: one reachable file vouches for its directory (glob-loaded routers leave no import to find), and if nothing looks reachable the filter stands down rather than dropping the project.

## 2. The tracer stopped at a local alias

```js
const isLoggedIn = sessionHandler.isLoggedInMiddleware;
app.get("/dashboard", isLoggedIn, handler.show);
```

`_trace_definition_body` read the assignment, found no auth in it, and called the route unguarded. A declaration whose whole right-hand side is a name is now followed to what it names, up to `MAX_TRACE_DEPTH`, with a `seen` set closing alias cycles.

Two `_enclosing_block` bugs surfaced while testing it, both returning more than the symbol's own body — `};`/`});` not recognised as closing, and a statement that opens no block still scanned for a brace, finding the *next* declaration's. Both widen what a body contains, which is the direction that falsely clears a route.

NodeGoat still shows `verified: 0`, and not because of the hop count: tsserver returns no definition at all for a `this.x = …` property reached through `new SessionHandler(db)` in untyped CommonJS. The route stays unverified rather than falsely cleared. Documented as a limit.

## Verification

Deterministic surface only — the LLM code reviewer rewrites ~52 of test-app's findings each run, so raw scan counts are noise.

| | main | branch |
|---|---|---|
| NodeGoat routes mapped | 0 | **19** |
| NodeGoat `route_auth` findings | 0 | 6 — see correction below |
| Juice Shop routes / findings | 104 / 53 | 104 / 53 |
| test-app routes / findings | 15 / 16 | 15 / 16 |
| LSP-verified routes | 4 / 17 / 0 | 4 / 17 / 0 — same sets |

SAST injection benchmark 46/46 recall, 0 FP. Suite 2403 passed, 1 xfailed.

Docs updated in the same commits: `architecture.md` (route discovery + reachability), `lsp-setup.md` (alias following and its tsserver limit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EZ4QoTqRoYWE25CNoV2Wfy

---

## Correction (added after merge)

This PR originally claimed NodeGoat's 6 findings were "exactly its 6 public routes, with no false positive on any of the 13 guarded ones." **That is wrong.**

They are its 6 **POST** routes, and 4 are false positives: `/profile`, `/contributions`, `/benefits` and `/memos` are all `isLoggedIn`-guarded in `app/routes/index.js`. Only `POST /login` and `POST /signup` are genuinely public.

Every GET route — guarded or not — produced no finding, for an unrelated reason found afterwards: `_is_intentionally_public` exempted any GET the mapper reported no auth on, which skipped 13 of NodeGoat's 19 routes and 49 of Juice Shop's 104 without examining them. That is fixed in #173.

I checked findings-per-file counts against main and saw 0 → 6 where main had nothing; I did not check which routes they were.

What this PR actually delivers is unaffected: 0 → 19 routes mapped on NodeGoat, Juice Shop and test-app byte-identical, LSP-verified sets unchanged. The finding *quality* on NodeGoat was worse than reported here, and #173 is where that gets addressed.
