### PR TITLE
fix(sast): examine every route, and answer each method from its own guard

### DIFF
--- a/docs/lsp-setup.md
+++ b/docs/lsp-setup.md
@@ -209,6 +209,26 @@ file would either miss every guard or vouch for every unguarded neighbour —
 and vouching is the dangerous direction, because a suppressed finding is a
 vulnerability the report no longer mentions.
 
+A verdict belongs to one **method**, not to a path, because the same path is
+routinely mounted more than once:
+
+```javascript
+app.get('/api/Recycles', recycles.blockRecycleItems())   // open
+app.post('/api/Recycles', security.isAuthorized())       // guarded
+```
+
+Answering both from the path would either report the guarded POST or clear the
+open GET. A path-wide `app.use('/api/BasketItems', security.isAuthorized())` is
+different again — it stands in front of *every* method on that path, including
+ones with a mount of their own, so it is checked first and settles the route
+when it verifies.
+
+Trailing comments on a mount line are ignored. They are not middleware, and
+reading the last name on the line meant `app.post('/api/Products',
+security.isAuthorized()) // vuln-code-snippet neutral-line
+changeProductChallenge` resolved `changeProductChallenge` while dropping the
+guard beside it.
+
 Middleware that delegates to a library counts as the terminal, because tracing
 deliberately will not follow into `node_modules`: `expressJwt` (express-jwt),
 `requiresAuth` (express-openid-connect), `ensureLoggedIn` (connect-ensure-login),

--- a/docs/scanners/route-auth-analyzer.md
+++ b/docs/scanners/route-auth-analyzer.md
@@ -15,6 +15,26 @@ The analyzer is **framework-aware**:
 - **Express**: Scans `app.get()`, `router.post()` patterns
 - **tRPC**: Checks if procedures use `protectedProcedure` vs `publicProcedure`
 
+### Routes it deliberately stays quiet about
+
+Some routes are meant to be open, and flagging them is noise. The exemption
+list is deliberately short and is about what a route **is**, not about what we
+found on it:
+
+- health and status endpoints (`/health`, `/ping`, `/status`, `/ready`, …)
+- API documentation (`/docs`, `/swagger`, `/openapi`) and the root path
+- webhook receivers (`/webhook`, `/stripe`), which are signature-verified
+  rather than auth-gated
+
+App-specific route names are kept out of it on purpose: a scanned app that
+happens to reuse one would have a real finding silently suppressed.
+
+Not finding a guard is never itself grounds for staying quiet. A rule that
+exempted any GET route the mapper reported no auth on read that backwards —
+it is the exact condition a missing-auth finding exists to report — and
+because the Express mapper always answers true or false and never "unknown",
+no Express GET route could produce a missing-auth finding at all.
+
 ## Why It Matters
 
 A single API route without authentication is often enough for a full data breach:

--- a/isitsecure/engine/code_analysis/lsp/auth_flow_tracer.py
+++ b/isitsecure/engine/code_analysis/lsp/auth_flow_tracer.py
@@ -106,8 +106,13 @@ class AuthFlowTracer:
                     )
                     continue
                 for route in file_routes:
-                    key = f"{route.file_path}:{route.route_pattern}"
-                    results[key] = result.get(route.route_pattern, AuthFlowResult())
+                    for method in route.http_methods:
+                        key = self.result_key(
+                            route.file_path, method, route.route_pattern
+                        )
+                        results[key] = result.get(
+                            (method, route.route_pattern), AuthFlowResult()
+                        )
 
         traced = len(results)
         auth_found = sum(1 for r in results.values() if r.has_verified_auth)
@@ -118,13 +123,23 @@ class AuthFlowTracer:
         )
         return results
 
+    @staticmethod
+    def result_key(file_path: str, method: str, route_pattern: str) -> str:
+        """The key one route's verdict is filed under.
+
+        The method is part of it because a verdict is per method: one path is
+        routinely mounted twice with different guards, and a single key let
+        whichever was traced last answer for both.
+        """
+        return f"{file_path}:{method} {route_pattern}"
+
     # ------------------------------------------------------------------
     # Per-file tracing
     # ------------------------------------------------------------------
 
     async def _trace_file(
         self, file_path: str, routes: list[RouteEntry]
-    ) -> dict[str, AuthFlowResult]:
+    ) -> dict[tuple[str, str], AuthFlowResult]:
         """Trace auth flow for one file, per route.
 
         A file that mounts its routes explicitly — the Express shape, where
@@ -151,7 +166,7 @@ class AuthFlowTracer:
         # so it settles the whole file regardless of what the mounts say.
         router_wide = await self._trace_express_auth(content, abs_path)
         if router_wide and router_wide.has_verified_auth:
-            return {route.route_pattern: router_wide for route in routes}
+            return self._for_every_method(routes, router_wide)
 
         mounts = self._route_mounts(content)
         if mounts:
@@ -159,27 +174,94 @@ class AuthFlowTracer:
             # a route with no auth on its mount line has none. Falling back to
             # a file-wide scan here is what would let one guarded route vouch
             # for its unguarded neighbours.
-            per_route: dict[str, AuthFlowResult] = {}
+            per_route: dict[tuple[str, str], AuthFlowResult] = {}
             for route in routes:
-                middleware = mounts.get(route.route_pattern)
-                per_route[route.route_pattern] = (
-                    await self._verify_mount_middleware(middleware, content, abs_path)
-                    if middleware
-                    else AuthFlowResult(confidence=0.5)
-                )
+                for method in route.http_methods:
+                    per_route[(method, route.route_pattern)] = (
+                        await self._verify_route_mount(
+                            mounts, method, route.route_pattern,
+                            content, abs_path,
+                        )
+                    )
             return per_route
 
         result = await self._trace_whole_file(content, abs_path)
-        return {route.route_pattern: result for route in routes}
+        return self._for_every_method(routes, result)
+
+    async def _verify_route_mount(
+        self,
+        mounts: dict[tuple[str, str], str],
+        method: str,
+        route_pattern: str,
+        content: str,
+        abs_path: str,
+    ) -> AuthFlowResult:
+        """The verdict for one method of one route, from its mount lines.
+
+        A path may be mounted twice over: `app.use('/api/BasketItems',
+        security.isAuthorized())` guards every method on that path, and
+        `app.post('/api/BasketItems', handler)` still runs through it. So the
+        path-wide mount is asked first and settles the route when it verifies
+        — treating it as a fallback for methods with no mount of their own had
+        an unguarded handler override the guard standing in front of it.
+
+        The method's own mount answers when the path-wide one does not.
+        """
+        path_wide = mounts.get((LSPConfig.MOUNT_ANY_METHOD, route_pattern))
+        if path_wide:
+            result = await self._verify_mount_middleware(
+                path_wide, content, abs_path
+            )
+            if result.has_verified_auth:
+                return result
+
+        own = mounts.get((method, route_pattern))
+        if own:
+            return await self._verify_mount_middleware(own, content, abs_path)
+
+        return AuthFlowResult(confidence=0.5)
 
     @staticmethod
-    def _route_mounts(content: str) -> dict[str, str]:
-        """Map each mounted route pattern to the middleware named beside it."""
-        mounts: dict[str, str] = {}
+    def _for_every_method(
+        routes: list[RouteEntry], result: AuthFlowResult
+    ) -> dict[tuple[str, str], AuthFlowResult]:
+        """One verdict, filed against every method of every route in it.
+
+        Router-wide middleware and whole-file strategies answer the file, not
+        a mount line, so no method on it is distinguished.
+        """
+        return {
+            (method, route.route_pattern): result
+            for route in routes
+            for method in route.http_methods
+        }
+
+    @staticmethod
+    def _route_mounts(content: str) -> dict[tuple[str, str], str]:
+        """Map each mounted (method, path) to the middleware named beside it.
+
+        Keyed by method as well as path, because one path is routinely mounted
+        several times with different guards::
+
+            app.get('/api/Recycles', recycles.blockRecycleItems())
+            app.post('/api/Recycles', security.isAuthorized())
+
+        Keying by path alone let the first line settle the second, so a guarded
+        POST was reported as unauthenticated. `.use` and `.all` take
+        ``MOUNT_ANY_METHOD``: they apply to every method on that path and
+        answer whichever ones have no mount of their own.
+        """
+        mounts: dict[tuple[str, str], str] = {}
         for match in re.finditer(LSPConfig.ROUTE_MOUNT_PATTERN, content):
-            pattern, middleware = match.group(1), match.group("middleware")
+            verb = match.group("verb").lower()
+            method = (
+                LSPConfig.MOUNT_ANY_METHOD
+                if verb in ("use", "all")
+                else verb.upper()
+            )
+            key = (method, match.group("path"))
             # First mount wins; later ones are usually narrower duplicates.
-            mounts.setdefault(pattern, middleware)
+            mounts.setdefault(key, match.group("middleware"))
         return mounts
 
     async def _verify_mount_middleware(
@@ -234,7 +316,16 @@ class AuthFlowTracer:
         Taking the last identifier of each argument yields the member for a
         qualified call and the name itself for a bare reference. The route
         handler comes along too; it simply contains no auth terminal.
+
+        Comments are stripped first. Juice Shop annotates its mounts, and
+        ``app.post('/api/Products', security.isAuthorized()) //
+        vuln-code-snippet neutral-line changeProductChallenge`` yielded
+        ``changeProductChallenge`` — the annotation, with the guard beside it
+        dropped entirely, so the route read as unguarded.
         """
+        middleware = re.sub(
+            LSPConfig.LINE_COMMENT_PATTERN, "", middleware, flags=re.DOTALL
+        )
         names: list[str] = []
         for argument in middleware.split(","):
             identifiers = re.findall(r"[A-Za-z_]\w*", argument)

--- a/isitsecure/engine/code_analysis/models.py
+++ b/isitsecure/engine/code_analysis/models.py
@@ -36,3 +36,8 @@ class CodeFinding(BaseModel):
     # results are per route, so matching a finding back to them needs it —
     # matching on file alone hands every route in a file one verdict.
     route_pattern: str = ""
+
+    # And the method, for the same reason one level down: one path is
+    # routinely mounted twice with different guards, so a verdict looked up by
+    # path alone can be the other method's.
+    http_methods: list[str] = Field(default_factory=list)

--- a/isitsecure/engine/code_analysis/route_analyzer.py
+++ b/isitsecure/engine/code_analysis/route_analyzer.py
@@ -305,14 +305,17 @@ class RouteAuthAnalyzer:
         if any(ind in pattern for ind in self._PUBLIC_ROUTE_INDICATORS):
             return True
 
-        # Route mapper explicitly marked as public (has_auth_check=False)
-        # AND the route is a read-only GET — likely intentionally public
-        if (
-            route.has_auth_check is False
-            and all(m == "GET" for m in route.http_methods)
-        ):
-            return True
-
+        # Deliberately no rule here for "the mapper found no auth on a GET".
+        # That was read as evidence the route is *intentionally* open, when it
+        # is the exact condition a missing-auth finding exists to report. The
+        # Express mapper always answers True or False, never None, so between
+        # that rule and `has_auth_check is True` no Express GET route could
+        # produce a missing-auth finding at all: 49 of Juice Shop's 104 and 13
+        # of NodeGoat's 19 were skipped here without being looked at.
+        #
+        # A route is public because of what it is — a health check, a webhook
+        # — not because we failed to find a guard on it. Absence of evidence
+        # belongs in the finding, not in the decision to stay quiet.
         return False
 
     def _analyze_server_actions(self, repo: RepoSnapshot) -> list[CodeFinding]:

--- a/isitsecure/engine/code_analysis/route_analyzer.py
+++ b/isitsecure/engine/code_analysis/route_analyzer.py
@@ -462,9 +462,38 @@ class RouteAuthAnalyzer:
         )
 
         if finding.route_pattern:
-            return auth_flow_results.get(
-                f"{finding.file_path}:{finding.route_pattern}"
+            from isitsecure.engine.code_analysis.lsp.auth_flow_tracer import (
+                AuthFlowTracer,
             )
+
+            # A verdict is per method: `GET /api/Recycles` is open where
+            # `POST /api/Recycles` is guarded, so a finding about one must not
+            # be answered with the other's result.
+            for method in finding.http_methods:
+                result = auth_flow_results.get(
+                    AuthFlowTracer.result_key(
+                        finding.file_path, method, finding.route_pattern
+                    )
+                )
+                if result is not None:
+                    return result
+
+            # A finding that names no method is answered from the route only
+            # when every method on it agrees — same reason as the file-level
+            # case below.
+            suffix = f":{finding.route_pattern}"
+            on_route = [
+                result
+                for key, result in auth_flow_results.items()
+                if key.startswith(finding.file_path + ":")
+                and key.endswith(suffix)
+            ]
+            if on_route and all(
+                r.has_verified_auth == on_route[0].has_verified_auth
+                for r in on_route
+            ):
+                return on_route[0]
+            return None
 
         # No route on the finding: only answer from the file when every route
         # in it agrees. One `server.ts` can mount a hundred routes of which a
@@ -551,6 +580,7 @@ class RouteAuthAnalyzer:
             description=description,
             file_path=route.file_path,
             route_pattern=route.route_pattern,
+            http_methods=list(route.http_methods),
             line_number=line_number,
             code_snippet=CodeContextExtractor.extract(
                 route.content, line_number

--- a/isitsecure/engine/constants.py
+++ b/isitsecure/engine/constants.py
@@ -4780,10 +4780,22 @@ class LSPConfig:
     }
 
     # Express-style mounts: `app.use('/path', mw)`, `router.get('/path', mw)`.
+    # The verb is captured because one path is routinely mounted several times
+    # with different guards — Juice Shop leaves `GET /api/Recycles` open and
+    # guards `POST /api/Recycles` on the next line.
     ROUTE_MOUNT_PATTERN = (
-        r"\.\s*(?:use|all|get|post|put|patch|delete|head|options)\s*\(\s*"
-        r"['\"`]([^'\"`]+)['\"`]\s*,(?P<middleware>[^\n]*)"
+        r"\.\s*(?P<verb>use|all|get|post|put|patch|delete|head|options)\s*\(\s*"
+        r"['\"`](?P<path>[^'\"`]+)['\"`]\s*,(?P<middleware>[^\n]*)"
     )
+
+    # `.use('/path', mw)` and `.all('/path', mw)` apply to every method on that
+    # path, so their verdict answers any method that has no mount of its own.
+    MOUNT_ANY_METHOD = "*"
+
+    # A trailing comment is not middleware. Juice Shop annotates its mounts
+    # (`// vuln-code-snippet neutral-line changeProductChallenge`) and the last
+    # identifier on the line was that annotation, not the guard beside it.
+    LINE_COMMENT_PATTERN = r"//.*$|/\*.*?\*/"
 
 
     # Middleware applied without a path — `router.use(requireAuth)` — which

--- a/tests/engine/test_code_analysis/test_auth_flow_tracer.py
+++ b/tests/engine/test_code_analysis/test_auth_flow_tracer.py
@@ -41,10 +41,12 @@ def _make_repo(
     )
 
 
-def _make_route(file_path: str, pattern: str = "/api/test") -> RouteEntry:
+def _make_route(
+    file_path: str, pattern: str = "/api/test", method: str = "GET"
+) -> RouteEntry:
     return RouteEntry(
         file_path=file_path,
-        http_methods=["GET"],
+        http_methods=[method],
         route_pattern=pattern,
     )
 
@@ -94,12 +96,12 @@ class TestAuthFlowTracerBasic:
 
         # Both routes should have results (mapped from the single file trace)
         assert len(results) == 2
-        assert "src/routes/api.ts:/api/users" in results
-        assert "src/routes/api.ts:/api/posts" in results
+        assert "src/routes/api.ts:GET /api/users" in results
+        assert "src/routes/api.ts:GET /api/posts" in results
 
         # Both should share the same result (same file traced once)
-        r1 = results["src/routes/api.ts:/api/users"]
-        r2 = results["src/routes/api.ts:/api/posts"]
+        r1 = results["src/routes/api.ts:GET /api/users"]
+        r2 = results["src/routes/api.ts:GET /api/posts"]
         assert r1.confidence == r2.confidence
 
 
@@ -149,7 +151,7 @@ class TestTRPCTracing:
         routes = [_make_route("src/server/routers/user.ts", "/api/user.getProfile")]
 
         results = await tracer.trace_routes(routes)
-        result = results["src/server/routers/user.ts:/api/user.getProfile"]
+        result = results["src/server/routers/user.ts:GET /api/user.getProfile"]
 
         assert result.has_verified_auth is True
         assert result.confidence == 0.95
@@ -175,7 +177,7 @@ class TestTRPCTracing:
 
         routes = [_make_route("src/server/routers/health.ts", "/api/health.check")]
         results = await tracer.trace_routes(routes)
-        result = results["src/server/routers/health.ts:/api/health.check"]
+        result = results["src/server/routers/health.ts:GET /api/health.check"]
 
         # Public procedures have no verified auth -- the tracer's _trace_file
         # only keeps results where has_verified_auth is True, so this falls
@@ -214,7 +216,7 @@ class TestTRPCTracing:
         tracer = AuthFlowTracer(lsp, repo)
         routes = [_make_route("src/router.ts")]
         results = await tracer.trace_routes(routes)
-        result = results["src/router.ts:/api/test"]
+        result = results["src/router.ts:GET /api/test"]
 
         assert result.has_verified_auth is True
         assert "getUser" in result.auth_method
@@ -260,7 +262,7 @@ class TestExpressTracing:
         tracer = AuthFlowTracer(lsp, repo)
         routes = [_make_route("src/routes/profile.ts", "/profile")]
         results = await tracer.trace_routes(routes)
-        result = results["src/routes/profile.ts:/profile"]
+        result = results["src/routes/profile.ts:GET /profile"]
 
         assert result.has_verified_auth is True
         assert "requireAuth" in result.middleware_chain
@@ -298,9 +300,9 @@ class TestExpressTracing:
         ]
 
         tracer = AuthFlowTracer(lsp, repo)
-        routes = [_make_route("src/routes/data.ts", "/data")]
+        routes = [_make_route("src/routes/data.ts", "/data", method="POST")]
         results = await tracer.trace_routes(routes)
-        result = results["src/routes/data.ts:/data"]
+        result = results["src/routes/data.ts:POST /data"]
 
         assert result.has_verified_auth is True
         assert "verifyAuth" in result.middleware_chain
@@ -320,7 +322,7 @@ class TestExpressTracing:
 
         routes = [_make_route("src/routes/health.ts", "/health")]
         results = await tracer.trace_routes(routes)
-        result = results["src/routes/health.ts:/health"]
+        result = results["src/routes/health.ts:GET /health"]
 
         assert result.has_verified_auth is False
         assert result.confidence == 0.5  # fallback confidence
@@ -357,7 +359,7 @@ class TestDecoratorTracing:
 
         routes = [_make_route("src/users/users.controller.ts", "/users")]
         results = await tracer.trace_routes(routes)
-        result = results["src/users/users.controller.ts:/users"]
+        result = results["src/users/users.controller.ts:GET /users"]
 
         assert result.has_verified_auth is True
         assert "UseGuards" in result.auth_method
@@ -382,7 +384,7 @@ class TestDecoratorTracing:
 
         routes = [_make_route("views/profile.py", "/profile")]
         results = await tracer.trace_routes(routes)
-        result = results["views/profile.py:/profile"]
+        result = results["views/profile.py:GET /profile"]
 
         assert result.has_verified_auth is True
         assert "login_required" in result.auth_method
@@ -409,7 +411,7 @@ class TestDecoratorTracing:
 
         routes = [_make_route("src/controllers/UserController.java", "/admin")]
         results = await tracer.trace_routes(routes)
-        result = results["src/controllers/UserController.java:/admin"]
+        result = results["src/controllers/UserController.java:GET /admin"]
 
         assert result.has_verified_auth is True
         assert "PreAuthorize" in result.auth_method
@@ -431,7 +433,7 @@ class TestDecoratorTracing:
 
         routes = [_make_route("src/handlers/health.ts", "/health")]
         results = await tracer.trace_routes(routes)
-        result = results["src/handlers/health.ts:/health"]
+        result = results["src/handlers/health.ts:GET /health"]
 
         assert result.has_verified_auth is False
         assert result.confidence == 0.5
@@ -462,7 +464,7 @@ class TestCJSImportFallback:
 
         routes = [_make_route("src/routers/user.js", "/api/user.getProfile")]
         results = await tracer.trace_routes(routes)
-        result = results["src/routers/user.js:/api/user.getProfile"]
+        result = results["src/routers/user.js:GET /api/user.getProfile"]
 
         assert result.has_verified_auth is True
         assert "protectedProcedure" in result.auth_method
@@ -489,7 +491,7 @@ class TestCJSImportFallback:
 
         routes = [_make_route("src/app/api/me/route.ts", "/api/me")]
         results = await tracer.trace_routes(routes)
-        result = results["src/app/api/me/route.ts:/api/me"]
+        result = results["src/app/api/me/route.ts:GET /api/me"]
 
         assert result.has_verified_auth is True
         assert "getUser" in result.auth_method
@@ -513,7 +515,7 @@ class TestCJSImportFallback:
 
         routes = [_make_route("src/app/api/items/route.ts", "/api/items")]
         results = await tracer.trace_routes(routes)
-        result = results["src/app/api/items/route.ts:/api/items"]
+        result = results["src/app/api/items/route.ts:GET /api/items"]
 
         assert result.has_verified_auth is False
         assert result.confidence == 0.5
@@ -544,7 +546,7 @@ class TestTraceFallback:
         tracer = AuthFlowTracer(lsp, repo)
         routes = [_make_route("src/routes/secret.ts", "/secret")]
         results = await tracer.trace_routes(routes)
-        result = results["src/routes/secret.ts:/secret"]
+        result = results["src/routes/secret.ts:GET /secret"]
 
         # Without LSP tracing the definition, requireAuth can't be confirmed
         # unless the definition is in the file_index. Since we didn't include
@@ -567,7 +569,7 @@ class TestTraceFallback:
         tracer = AuthFlowTracer(lsp, repo)
         routes = [_make_route("src/routes/items.ts", "/items")]
         results = await tracer.trace_routes(routes)
-        result = results["src/routes/items.ts:/items"]
+        result = results["src/routes/items.ts:GET /items"]
 
         # authenticate is detected as an auth pattern, but LSP can't
         # trace it, so the tracer can't confirm it — falls to fallback
@@ -772,20 +774,40 @@ router.get('/profile', requireAuth, handler)
 class TestRouteMounts:
     def test_each_mounted_route_maps_to_its_own_middleware(self) -> None:
         mounts = AuthFlowTracer._route_mounts(SERVER)
-        assert "isAuthorized" in mounts["/api/BasketItems"]
-        assert "denyAll" in mounts["/api/Challenges"]
+        assert "isAuthorized" in mounts[("*", "/api/BasketItems")]
+        assert "denyAll" in mounts[("POST", "/api/Challenges")]
 
     def test_an_unguarded_route_is_still_recorded(self) -> None:
         """It has to appear, so it can be answered "no auth" rather than
         falling through to a file-wide scan that a neighbour would pass."""
-        assert "/api/Products" in AuthFlowTracer._route_mounts(SERVER)
+        assert ("GET", "/api/Products") in AuthFlowTracer._route_mounts(SERVER)
 
     def test_a_file_that_mounts_nothing_yields_nothing(self) -> None:
         assert AuthFlowTracer._route_mounts("const x = 1\n") == {}
 
     def test_the_first_mount_wins(self) -> None:
         src = "app.use('/x', authGuard())\napp.use('/x', other())\n"
-        assert "authGuard" in AuthFlowTracer._route_mounts(src)["/x"]
+        assert "authGuard" in AuthFlowTracer._route_mounts(src)[("*", "/x")]
+
+    def test_the_same_path_keeps_a_verdict_per_method(self) -> None:
+        """Juice Shop leaves `GET /api/Recycles` open and guards the POST on
+        the very next line. Keyed by path alone, the first settled both."""
+        src = (
+            "app.get('/api/Recycles', recycles.blockRecycleItems())\n"
+            "app.post('/api/Recycles', security.isAuthorized())\n"
+        )
+        mounts = AuthFlowTracer._route_mounts(src)
+        assert "blockRecycleItems" in mounts[("GET", "/api/Recycles")]
+        assert "isAuthorized" in mounts[("POST", "/api/Recycles")]
+
+    def test_use_and_all_apply_to_any_method(self) -> None:
+        """They mount a path, not a method, so they answer whichever methods
+        have no mount of their own."""
+        mounts = AuthFlowTracer._route_mounts(
+            "app.use('/x', guard())\napp.all('/y', other())\n"
+        )
+        assert ("*", "/x") in mounts
+        assert ("*", "/y") in mounts
 
 
 class TestMiddlewareNames:
@@ -1013,7 +1035,7 @@ class TestRouterWideMiddlewareWins:
 
         results = await AuthFlowTracer(lsp, repo).trace_routes([route])
 
-        result = results["src/routes/team.ts:/team/:id"]
+        result = results["src/routes/team.ts:GET /team/:id"]
         assert result.has_verified_auth is True
         assert result.middleware_chain == ["ensureMember"]
 
@@ -1151,7 +1173,7 @@ class TestAliasFollowing:
     async def test_a_guarded_route_is_verified_through_its_alias(self) -> None:
         tracer, _ = self._tracer()
         results = await tracer.trace_routes([_make_route(self.ROUTES, "/dashboard")])
-        result = results[f"{self.ROUTES}:/dashboard"]
+        result = results[f"{self.ROUTES}:GET /dashboard"]
         assert result.has_verified_auth
         assert "jwt.verify" in result.auth_method
 
@@ -1162,7 +1184,7 @@ class TestAliasFollowing:
         falsely cleared."""
         tracer, _ = self._tracer(resolve_alias=False)
         results = await tracer.trace_routes([_make_route(self.ROUTES, "/dashboard")])
-        assert not results[f"{self.ROUTES}:/dashboard"].has_verified_auth
+        assert not results[f"{self.ROUTES}:GET /dashboard"].has_verified_auth
 
     async def test_a_self_referential_alias_terminates(self) -> None:
         """A cycle must end in an answer, not a hang."""
@@ -1178,7 +1200,7 @@ class TestAliasFollowing:
             _ScriptedLSP(definitions, files), _make_repo(file_index=files)
         )
         results = await tracer.trace_routes([_make_route("a.js", "/x")])
-        assert not results["a.js:/x"].has_verified_auth
+        assert not results["a.js:GET /x"].has_verified_auth
 
     async def test_the_hop_count_is_bounded(self) -> None:
         """Aliases chained past MAX_TRACE_DEPTH stop rather than recurse on,

--- a/tests/engine/test_code_analysis/test_route_analyzer.py
+++ b/tests/engine/test_code_analysis/test_route_analyzer.py
@@ -544,3 +544,73 @@ class TestIntentionallyPublic:
         assert self.analyzer._is_intentionally_public(
             self._route("/", "GET", has_auth=False)
         )
+
+
+# ---------------------------------------------------------------------------
+# LSP suppression is per method
+# ---------------------------------------------------------------------------
+
+
+class TestLSPSuppressionIsPerMethod:
+    """A verdict belongs to one method, not to a path.
+
+    Juice Shop leaves `GET /api/Recycles` open and guards
+    `POST /api/Recycles` on the very next line. Answering a finding from the
+    path alone hands one of them the other's verdict — and in the direction
+    that suppresses, that hides a live vulnerability.
+    """
+
+    def setup_method(self) -> None:
+        self.analyzer = RouteAuthAnalyzer()
+
+    @staticmethod
+    def _finding(analyzer, method: str) -> object:
+        route = RouteEntry(
+            file_path="server.ts",
+            http_methods=[method],
+            route_pattern="/api/Recycles",
+            has_auth_check=False,
+            content="app.get('/api/Recycles', open)\n",
+        )
+        return analyzer._create_finding(
+            route=route,
+            title=RouteAuthAnalyzerConfig.TITLE_MISSING_AUTH,
+            description="no auth",
+            severity=SeverityLevel(RouteAuthAnalyzerConfig.SEVERITY_MISSING_AUTH),
+            category=FindingCategory.AUTH_WEAKNESS,
+        )
+
+    @staticmethod
+    def _results():
+        from isitsecure.engine.code_analysis.lsp.auth_flow_tracer import (
+            AuthFlowTracer,
+        )
+        from isitsecure.engine.code_analysis.lsp.protocols import AuthFlowResult
+
+        return {
+            AuthFlowTracer.result_key("server.ts", "GET", "/api/Recycles"):
+                AuthFlowResult(has_verified_auth=False, confidence=0.5),
+            AuthFlowTracer.result_key("server.ts", "POST", "/api/Recycles"):
+                AuthFlowResult(has_verified_auth=True, auth_method="isAuthorized"),
+        }
+
+    def test_the_guarded_method_is_suppressed(self) -> None:
+        kept = self.analyzer.validate_with_lsp(
+            [self._finding(self.analyzer, "POST")], self._results()
+        )
+        assert kept == []
+
+    def test_the_open_method_is_not(self) -> None:
+        """The bug: the POST's guard used to answer for the GET too."""
+        kept = self.analyzer.validate_with_lsp(
+            [self._finding(self.analyzer, "GET")], self._results()
+        )
+        assert len(kept) == 1
+
+    def test_a_finding_with_no_method_needs_agreement(self) -> None:
+        """Nothing identifies which mount it came from, so a verdict is only
+        safe to apply when every method on the route agrees."""
+        finding = self._finding(self.analyzer, "GET")
+        finding.http_methods = []
+        kept = self.analyzer.validate_with_lsp([finding], self._results())
+        assert len(kept) == 1

--- a/tests/engine/test_code_analysis/test_route_analyzer.py
+++ b/tests/engine/test_code_analysis/test_route_analyzer.py
@@ -477,3 +477,70 @@ class TestRouteAuthAnalyzer:
         route = _make_route("", http_methods=["GET"])
         line = self.analyzer._find_relevant_line("", route)
         assert line is None
+
+
+# ---------------------------------------------------------------------------
+# _is_intentionally_public
+# ---------------------------------------------------------------------------
+
+
+class TestIntentionallyPublic:
+    """Which routes are exempt from the missing-auth check.
+
+    A route is public because of what it *is* — a health check, a webhook —
+    never because we looked for a guard and did not find one. Treating the
+    second as the first is how 49 of Juice Shop's 104 routes and 13 of
+    NodeGoat's 19 were skipped without being examined.
+    """
+
+    def setup_method(self) -> None:
+        self.analyzer = RouteAuthAnalyzer()
+
+    @staticmethod
+    def _route(pattern: str, method: str = "GET", has_auth=None) -> RouteEntry:
+        return RouteEntry(
+            file_path="server.ts",
+            http_methods=[method],
+            route_pattern=pattern,
+            has_auth_check=has_auth,
+            content=f"app.get('{pattern}', handler)",
+        )
+
+    def test_a_health_check_is_public(self) -> None:
+        assert self.analyzer._is_intentionally_public(self._route("/health"))
+
+    def test_a_webhook_is_public(self) -> None:
+        assert self.analyzer._is_intentionally_public(
+            self._route("/api/webhook/stripe", "POST")
+        )
+
+    def test_an_unguarded_get_is_not_public(self) -> None:
+        """The regression this guards: `has_auth_check is False` on a GET was
+        read as "deliberately open" when it is the exact condition a
+        missing-auth finding exists to report."""
+        route = self._route("/api/Products", "GET", has_auth=False)
+        assert not self.analyzer._is_intentionally_public(route)
+
+    def test_an_unguarded_get_produces_a_finding(self) -> None:
+        route = self._route("/rest/wallet/balance", "GET", has_auth=False)
+        titles = [f.title for f in self.analyzer._analyze_route(route)]
+        assert RouteAuthAnalyzerConfig.TITLE_MISSING_AUTH in titles
+
+    def test_a_guarded_get_still_produces_no_finding(self) -> None:
+        """Removing the exemption must not start flagging routes the mapper
+        did find a guard on."""
+        route = self._route("/api/BasketItems", "GET", has_auth=True)
+        titles = [f.title for f in self.analyzer._analyze_route(route)]
+        assert RouteAuthAnalyzerConfig.TITLE_MISSING_AUTH not in titles
+
+    def test_an_unguarded_post_still_produces_a_finding(self) -> None:
+        """POST was never exempt; it must stay that way."""
+        route = self._route("/api/Recycles", "POST", has_auth=False)
+        titles = [f.title for f in self.analyzer._analyze_route(route)]
+        assert RouteAuthAnalyzerConfig.TITLE_MISSING_AUTH in titles
+
+    def test_a_root_path_is_still_public(self) -> None:
+        """`/` is exempt by name, not by method, and stays so."""
+        assert self.analyzer._is_intentionally_public(
+            self._route("/", "GET", has_auth=False)
+        )


### PR DESCRIPTION
Found while answering a question about the `AUTH_MIDDLEWARE_INDICATORS` name list. The list has its own problems, but this is much larger and sits one layer above it.

## The rule

`route_analyzer.py:_is_intentionally_public`:

```python
if route.has_auth_check is False and all(m == "GET" for m in route.http_methods):
    return True   # skip the route entirely
```

`has_auth_check is False` is the exact condition a missing-auth finding exists to report. Here it was read as evidence the route is *deliberately* open.

The Express mapper always answers `True` or `False`, never `None`. So between this rule and the `has_auth_check is True` branch, **no Express GET route could produce a missing-auth finding at all** — a match made it authenticated, a non-match made it public.

| | Express routes | GETs skipped here without being examined |
|---|---|---|
| Juice Shop | 104 | **49** |
| NodeGoat | 19 | **13** |
| test-app | 15 | 0 — Next.js mapper leaves `None`, so the content fallback ran |

Present since `acc1bcf`, the initial extraction.

## The fix

The rule is removed. A route is exempt for what it *is* — a health check, a webhook, the root path — not because we looked for a guard and did not find one. The remaining exemptions (`_PUBLIC_ROUTE_PATTERNS`, `_PUBLIC_ROUTE_INDICATORS`) are unchanged.

## What it costs and what it buys

Juice Shop `route_auth` findings: **53 → 101**, and **79** after the LSP tracer's suppression.

Verified by hand against `server.ts`, counting only real authorization gates (`isAuthorized`, `denyAll`, `isAccounting`, `isDeluxe` — `appendUserId` attaches a user id and gates nothing):

- **69** of the 77 method/path pairs are routes that genuinely have no guard and were never reported before
- **8** land on a gated route

Those 8 had three pre-existing causes, all *exposed* by this change rather than created by it. **Two are now fixed in this PR** (second commit); the third is left alone.

NodeGoat goes 7 → 18. Its guards are `isLoggedIn`, which the tracer cannot resolve there (a `this.x = …` property reached through `new SessionHandler(db)` in untyped CommonJS — tsserver returns no definition), so they are not suppressed.

Reporting a guarded route is a false positive; staying silent about an unguarded one is a missed vulnerability. This trades in the safer direction.

## Second commit: the two causes, fixed

**Comments are not middleware.** `_middleware_names` took the last identifier of each argument, and a mount line does not end at the closing paren — `app.post('/api/Products', security.isAuthorized()) // vuln-code-snippet neutral-line changeProductChallenge` yielded `['changeProductChallenge']`, dropping `isAuthorized` entirely. Comments are stripped first now.

**A verdict belongs to a method, not a path.** `_route_mounts` keyed by pattern with `setdefault`, so the open `app.get('/api/Recycles', …)` settled the guarded `app.post('/api/Recycles', security.isAuthorized())` on the next line. This is the per-file→per-route attribution problem one level down, and it ran the length of the pipeline — the mounts collapsed, `_trace_file` returned one result per pattern, and `trace_routes` filed both methods under `file:pattern` so whichever traced last won again. Mounts are now keyed by `(method, pattern)`, results by `file:METHOD pattern`, and `CodeFinding` carries `http_methods` so `_find_lsp_result` asks for its own method's verdict — the same reason `route_pattern` was added to it.

`.use`/`.all` mount a path rather than a method and are checked **first**: `app.use('/api/BasketItems', security.isAuthorized())` stands in front of every method on that path, including ones with a mount of their own. Treating it as a fallback for methods without their own mount — which is what I wrote first — let an unguarded handler override the guard in front of it and turned three correctly-suppressed routes into false positives. The measurement caught that; the reasoning had not.

Third cause left alone: `isAccounting` checks a role rather than calling an auth terminal, so `/rest/order-history/*` traces without verifying. It accounts for both remaining false positives.

## Net result

| Juice Shop | before this PR | after commit 1 | after commit 2 |
|---|---|---|---|
| `route_auth` findings | 53 | 101 → 79 post-LSP | 101 → **76** post-LSP |
| landing on a gated route | — | 8 | **2** |
| GET routes never examined | 49 | 0 | 0 |

NodeGoat 7 → 18, unsuppressed (its `isLoggedIn` guards are unresolvable by tsserver). test-app unchanged at 12.

Suite 2415 passed. Injection benchmark 46/46 recall, 0 FP.

Docs: `docs/scanners/route-auth-analyzer.md` on what the exemption list covers and why absence of evidence is not on it; `docs/lsp-setup.md` on per-method verdicts, path-wide `.use` precedence, and comment stripping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EZ4QoTqRoYWE25CNoV2Wfy
