### PR TITLE
fix(sast): count a guard that rejects, and stop reading handler names as guards

### DIFF
--- a/docs/lsp-setup.md
+++ b/docs/lsp-setup.md
@@ -229,6 +229,24 @@ security.isAuthorized()) // vuln-code-snippet neutral-line
 changeProductChallenge` resolved `changeProductChallenge` while dropping the
 guard beside it.
 
+**Guards that reject rather than verify:**
+```javascript
+if (decodedToken?.data?.role === roles.accounting) next()
+else res.status(403).json({ error: 'Malicious activity detected' })
+```
+
+A middleware naming no auth library at all still makes an auth decision when
+it refuses the request: a 401 or 403 on the failing branch means an
+unauthenticated caller never reaches the handler. Requiring a library call
+meant role guards like this read as unguarded.
+
+Only what actually *guards* a route counts, though. On `app.get(path, a, b)`
+the last argument is the handler, and every handler has an error path —
+`changePassword` answers 401 to "current password is not correct", which says
+nothing about whether the route is authenticated. So rejection is read from
+the arguments before the handler, and from every argument of a `.use`/`.all`
+mount, which carries no handler.
+
 Middleware that delegates to a library counts as the terminal, because tracing
 deliberately will not follow into `node_modules`: `expressJwt` (express-jwt),
 `requiresAuth` (express-openid-connect), `ensureLoggedIn` (connect-ensure-login),

--- a/docs/scanners/route-auth-analyzer.md
+++ b/docs/scanners/route-auth-analyzer.md
@@ -35,6 +35,25 @@ it is the exact condition a missing-auth finding exists to report — and
 because the Express mapper always answers true or false and never "unknown",
 no Express GET route could produce a missing-auth finding at all.
 
+### How a guard is recognised before the language server runs
+
+The Express mapper answers `has_auth_check` from the mount line, and a `True`
+suppresses the route's missing-auth finding outright — so it is matched
+narrowly: known guard names, on **word boundaries**, against the route's
+**arguments** only, with comments stripped.
+
+Each of those bounds exists because it was once missing. `checkAuth` matched
+inside `checkAuthorEmail`, and `authenticate` inside `authenticatedUsers` —
+the handler that *returns* Juice Shop's user list — so both routes were
+cleared. Scanning the whole line also meant `app.get('/api/authenticate',
+handler)` was guarded by its own URL.
+
+The list cannot name a project's own vocabulary (`isLoggedIn`, `ensureMember`)
+and is not meant to: it is the cheap answer for scans with no language server.
+What a guard actually *does* is decided by the auth-flow tracer, which
+resolves it and reads its body. A `False` here is only an absence of evidence
+— the route is still examined either way.
+
 ## Why It Matters
 
 A single API route without authentication is often enough for a full data breach:

--- a/isitsecure/engine/code_analysis/express_route_mapper.py
+++ b/isitsecure/engine/code_analysis/express_route_mapper.py
@@ -207,14 +207,17 @@ class ExpressRouteMapper:
             method = match.group(1).upper()
             path = match.group(2)
 
-            # Get the full line context for auth detection
-            line_start = content.rfind("\n", 0, match.start()) + 1
+            # Only what is *applied* to the route can guard it: the
+            # arguments after the path. The whole line also holds the path
+            # itself and any trailing comment, and matching those made
+            # `app.get('/api/authenticate', handler)` look guarded by its own
+            # URL.
             line_end = content.find("\n", match.end())
             if line_end == -1:
                 line_end = len(content)
-            line_context = content[line_start:line_end]
+            arguments = content[match.end():line_end]
 
-            has_auth = self._detect_auth_middleware(line_context)
+            has_auth = self._detect_auth_middleware(arguments)
 
             routes.append(
                 RouteEntry(
@@ -253,13 +256,31 @@ class ExpressRouteMapper:
     # Auth middleware detection
     # ------------------------------------------------------------------
 
-    @staticmethod
-    def _detect_auth_middleware(line_context: str) -> bool:
-        """Detect if auth middleware is present in the route definition line."""
-        return any(
-            indicator in line_context
-            for indicator in ExpressRouteMapperConfig.AUTH_MIDDLEWARE_INDICATORS
+    _AUTH_INDICATOR_RE = re.compile(
+        "|".join(
+            rf"\b{re.escape(name)}\b"
+            for name in ExpressRouteMapperConfig.AUTH_MIDDLEWARE_INDICATORS
         )
+    )
+
+    @classmethod
+    def _detect_auth_middleware(cls, arguments: str) -> bool:
+        """Whether an auth guard is applied among a route's arguments.
+
+        Word boundaries, not substrings. `checkAuth` matched inside
+        `checkAuthorEmail` and `authenticate` inside `authenticatedUsers` —
+        the handler that *returns* Juice Shop's user list — and because a
+        True here suppresses the route's missing-auth finding outright, each
+        of those was a vulnerability the report stopped mentioning.
+
+        A False is only ever a missing finding's absence of evidence: the
+        route is still examined, and the tracer still reads what the guard
+        does.
+        """
+        arguments = re.sub(
+            SharedPatterns.JS_COMMENT_PATTERN, "", arguments, flags=re.DOTALL
+        )
+        return bool(cls._AUTH_INDICATOR_RE.search(arguments))
 
     # ------------------------------------------------------------------
     # Mount prefix resolution

--- a/isitsecure/engine/code_analysis/lsp/auth_flow_tracer.py
+++ b/isitsecure/engine/code_analysis/lsp/auth_flow_tracer.py
@@ -33,7 +33,7 @@ from isitsecure.engine.code_analysis.protocols import (
     RepoSnapshot,
     RouteEntry,
 )
-from isitsecure.engine.constants import LSPConfig
+from isitsecure.engine.constants import LSPConfig, SharedPatterns
 
 logger = logging.getLogger(__name__)
 
@@ -210,7 +210,7 @@ class AuthFlowTracer:
         path_wide = mounts.get((LSPConfig.MOUNT_ANY_METHOD, route_pattern))
         if path_wide:
             result = await self._verify_mount_middleware(
-                path_wide, content, abs_path
+                path_wide, content, abs_path, path_wide=True
             )
             if result.has_verified_auth:
                 return result
@@ -265,10 +265,35 @@ class AuthFlowTracer:
         return mounts
 
     async def _verify_mount_middleware(
-        self, middleware: str, content: str, abs_path: str
+        self, middleware: str, content: str, abs_path: str,
+        path_wide: bool = False,
     ) -> AuthFlowResult:
-        """Resolve the middleware on a mount line and look for auth in it."""
-        for name in self._middleware_names(middleware):
+        """Resolve the middleware on a mount line and look for auth in it.
+
+        Two shapes count, the same two the router-wide path accepts. A
+        middleware that calls a *terminal* — `expressJwt`, `jwt.verify` — is
+        verifying a token itself. One that *rejects* — a 401 or 403 on the
+        failing branch — has decided the request may not proceed, which is
+        equally an auth decision though it names no library:
+
+            if (decodedToken?.data?.role === roles.accounting) next()
+            else res.status(403).json({ error: 'Malicious activity detected' })
+
+        Only the terminal was checked here, so role guards like that one read
+        as unguarded and their routes were reported as having no auth at all.
+
+        Rejection only counts for something that actually *guards* the route,
+        which on a method mount means: not the last argument. The last one is
+        the handler, and every handler has an error path — `changePassword`
+        answers 401 to "current password is not correct", which says nothing
+        about whether the route is authenticated. Accepting that suppressed
+        four routes on the strength of their own validation errors.
+
+        `.use` and `.all` mount middleware rather than a handler, so on those
+        every argument is a guard.
+        """
+        names = self._middleware_names(middleware)
+        for index, name in enumerate(names):
             position = self._locate_symbol(content, name)
             if position is None:
                 continue
@@ -282,6 +307,16 @@ class AuthFlowTracer:
                 return AuthFlowResult(
                     has_verified_auth=True,
                     auth_method=auth_method,
+                    middleware_chain=[name],
+                    confidence=LSPConfig.CONFIDENCE_LSP_CONFIRMED,
+                    trace_depth=1,
+                )
+
+            guards_route = path_wide or index < len(names) - 1
+            if guards_route and self._has_enforcement(definition):
+                return AuthFlowResult(
+                    has_verified_auth=True,
+                    auth_method=f"{name} (rejects unauthorized)",
                     middleware_chain=[name],
                     confidence=LSPConfig.CONFIDENCE_LSP_CONFIRMED,
                     trace_depth=1,
@@ -324,7 +359,7 @@ class AuthFlowTracer:
         dropped entirely, so the route read as unguarded.
         """
         middleware = re.sub(
-            LSPConfig.LINE_COMMENT_PATTERN, "", middleware, flags=re.DOTALL
+            SharedPatterns.JS_COMMENT_PATTERN, "", middleware, flags=re.DOTALL
         )
         names: list[str] = []
         for argument in middleware.split(","):

--- a/isitsecure/engine/constants.py
+++ b/isitsecure/engine/constants.py
@@ -16,6 +16,12 @@ class SharedPatterns:
         "site-packages", "coverage", ".terraform",
     })
 
+    # A comment is not code. Both the route mapper and the auth-flow tracer
+    # read a mount line to find the middleware on it, and both were fooled by
+    # what came after a `//` — Juice Shop annotates its mounts, and the
+    # annotation was taken for the guard.
+    JS_COMMENT_PATTERN = r"//.*$|/\*.*?\*/"
+
     UUID_PATTERN = (
         r'[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'
     )
@@ -3617,8 +3623,16 @@ class ExpressRouteMapperConfig:
         r"""['"](/[^'"]*?)['"]"""
     )
 
-    # Patterns that indicate auth middleware in route chain.
-    # These are generic names used across Express.js applications.
+    # Names that, applied to a route, indicate an auth guard. Matched on word
+    # boundaries against the *arguments* of the mount — never the path, never
+    # a comment — because a substring anywhere on the line said
+    # `checkAuthorEmail` was `checkAuth` and `authenticatedUsers` was
+    # `authenticate`, and a True here suppresses the route's missing-auth
+    # finding outright.
+    #
+    # It cannot name a project's own vocabulary and is not meant to: this is
+    # the cheap answer for scans with no language server. What a guard
+    # actually does is decided by AuthFlowTracer, which reads its body.
     AUTH_MIDDLEWARE_INDICATORS = (
         "requireAuth",
         "verifyAuth",
@@ -4792,10 +4806,6 @@ class LSPConfig:
     # path, so their verdict answers any method that has no mount of its own.
     MOUNT_ANY_METHOD = "*"
 
-    # A trailing comment is not middleware. Juice Shop annotates its mounts
-    # (`// vuln-code-snippet neutral-line changeProductChallenge`) and the last
-    # identifier on the line was that annotation, not the guard beside it.
-    LINE_COMMENT_PATTERN = r"//.*$|/\*.*?\*/"
 
 
     # Middleware applied without a path — `router.use(requireAuth)` — which

--- a/tests/engine/test_code_analysis/test_auth_flow_tracer.py
+++ b/tests/engine/test_code_analysis/test_auth_flow_tracer.py
@@ -1223,3 +1223,87 @@ class TestAliasFollowing:
         )
         assert body is not None
         assert len(tracer._lsp.queries) <= LSPConfig.MAX_TRACE_DEPTH
+
+
+@pytest.mark.asyncio
+class TestRejectionCountsAsAuth:
+    """A guard that rejects is a guard, but a handler that errors is not.
+
+    `isAccounting` names no auth library — it compares a role and answers 403
+    otherwise. Requiring a *terminal* call meant role guards read as unguarded
+    and their routes were reported as having no auth at all.
+    """
+
+    ROOT = "/tmp/test"
+    SERVER = "server.ts"
+    SERVER_ABS = f"{ROOT}/{SERVER}"
+    GUARDS = "guards.ts"
+    GUARDS_ABS = f"{ROOT}/{GUARDS}"
+
+    GUARD_SRC = (
+        "export const isAccounting = () => {\n"
+        "  return (req, res, next) => {\n"
+        "    if (decoded?.data?.role === roles.accounting) next()\n"
+        "    else res.status(403).json({ error: 'Malicious activity' })\n"
+        "  }\n"
+        "}\n"
+    )
+    # A handler, not a guard: its 401 is about the password being wrong.
+    HANDLER_SRC = (
+        "export const changePassword = () => {\n"
+        "  return (req, res, next) => {\n"
+        "    if (!req.query.new) return res.status(401).send('empty')\n"
+        "    res.json({ ok: true })\n"
+        "  }\n"
+        "}\n"
+    )
+
+    def _tracer(self, mount_line: str):
+        server = f"const app = express()\n{mount_line}\n"
+        files = {
+            self.SERVER: server,
+            self.GUARDS: self.GUARD_SRC + "\n" + self.HANDLER_SRC,
+        }
+        guard_line = (self.GUARD_SRC + "\n" + self.HANDLER_SRC).split("\n")
+        definitions = {}
+        for symbol, line in (("isAccounting", 0), ("changePassword", 7)):
+            for index, text in enumerate(server.split("\n")):
+                column = text.find(symbol)
+                if column != -1:
+                    definitions[(self.SERVER_ABS, index, column)] = (
+                        self.GUARDS_ABS, line
+                    )
+        assert guard_line[7].startswith("export const changePassword")
+        lsp = _ScriptedLSP(definitions, files)
+        return AuthFlowTracer(lsp, _make_repo(file_index=files))
+
+    async def _verdict(self, mount_line: str, method: str, pattern: str):
+        tracer = self._tracer(mount_line)
+        results = await tracer.trace_routes(
+            [_make_route(self.SERVER, pattern, method=method)]
+        )
+        return results[f"{self.SERVER}:{method} {pattern}"]
+
+    async def test_a_role_guard_that_rejects_is_verified(self) -> None:
+        verdict = await self._verdict(
+            "app.get('/orders', security.isAccounting(), allOrders())",
+            "GET", "/orders",
+        )
+        assert verdict.has_verified_auth
+        assert "isAccounting" in verdict.auth_method
+
+    async def test_a_handlers_own_error_path_is_not_auth(self) -> None:
+        """The last argument is the handler, and every handler has an error
+        path — accepting it cleared routes on their own validation errors."""
+        verdict = await self._verdict(
+            "app.get('/change-password', changePassword())",
+            "GET", "/change-password",
+        )
+        assert not verdict.has_verified_auth
+
+    async def test_a_path_wide_mount_is_all_middleware(self) -> None:
+        """`.use` mounts no handler, so its last argument guards too."""
+        verdict = await self._verdict(
+            "app.use('/orders', security.isAccounting())", "GET", "/orders"
+        )
+        assert verdict.has_verified_auth

--- a/tests/engine/test_code_analysis/test_express_route_mapper.py
+++ b/tests/engine/test_code_analysis/test_express_route_mapper.py
@@ -387,3 +387,59 @@ class TestUnreachableRouteFiles:
         read — and pruning on no evidence would drop the whole project."""
         self._write(tmp_path, "src/http/widgets.js", self.ROUTE)
         assert "/widgets" in self._patterns(tmp_path)
+
+
+class TestAuthMiddlewareDetection:
+    """Whether a guard is applied to a route, from its mount line alone.
+
+    This runs before any language server, and a True suppresses the route's
+    missing-auth finding outright — so a wrong True is a vulnerability the
+    report stops mentioning. A wrong False only costs a finding that is
+    examined anyway.
+    """
+
+    def test_a_guard_among_the_arguments_is_found(self) -> None:
+        assert ExpressRouteMapper._detect_auth_middleware(", requireAuth, handler)")
+
+    def test_a_qualified_guard_is_found(self) -> None:
+        assert ExpressRouteMapper._detect_auth_middleware(
+            ", passport.authenticate('jwt'), handler)"
+        )
+
+    def test_a_handler_that_merely_contains_a_guard_name_is_not_one(self) -> None:
+        """`checkAuthorEmail` is not `checkAuth`. Substring matching read it
+        as one and cleared the route."""
+        assert not ExpressRouteMapper._detect_auth_middleware(", checkAuthorEmail)")
+
+    def test_a_handler_named_for_authenticated_things_is_not_a_guard(self) -> None:
+        """Juice Shop's `authenticatedUsers` *returns* the user list; it
+        matched `authenticate` and cleared the route that exposes it."""
+        assert not ExpressRouteMapper._detect_auth_middleware(
+            ", utils.asyncHandler(authenticatedUsers()))"
+        )
+
+    def test_requireauthorrole_is_not_requireauth(self) -> None:
+        assert not ExpressRouteMapper._detect_auth_middleware(", requireAuthorRole)")
+
+    def test_a_guard_named_only_in_a_comment_does_not_count(self) -> None:
+        assert not ExpressRouteMapper._detect_auth_middleware(
+            ", handler) // TODO: add requireAuth here"
+        )
+
+    def test_the_route_path_is_not_scanned(self, tmp_path: Path) -> None:
+        """The path is not applied to the route, it *is* the route — so an
+        endpoint named /authenticate must not clear itself."""
+        (tmp_path / "server.js").write_text(
+            "const app = require('express')();\n"
+            "app.get('/api/authenticate', handler);\n"
+        )
+        routes = ExpressRouteMapper().map_routes(str(tmp_path))
+        assert [r.has_auth_check for r in routes] == [False]
+
+    def test_a_genuinely_guarded_route_is_still_marked(self, tmp_path: Path) -> None:
+        (tmp_path / "server.js").write_text(
+            "const app = require('express')();\n"
+            "app.get('/api/things', requireAuth, handler);\n"
+        )
+        routes = ExpressRouteMapper().map_routes(str(tmp_path))
+        assert [r.has_auth_check for r in routes] == [True]


### PR DESCRIPTION
The two causes left standing after #173. Between them they account for every remaining false positive on Juice Shop.

## 1. A guard that rejects is a guard

`_verify_mount_middleware` accepted only an auth *terminal* — a call to `expressJwt`, `jwt.verify` and friends. A guard that names no library still makes an auth decision when it refuses the request:

```js
if (decodedToken?.data?.role === roles.accounting) next()
else res.status(403).json({ error: 'Malicious activity detected' })
```

The router-wide path has always accepted that shape; only the per-route path didn't, so role guards read as unguarded.

**But rejection is weaker evidence than a terminal**, so it counts only for something that actually guards the route. My first attempt accepted it anywhere and suppressed 20 routes — of which only 2 were guards. Four were cleared by their own *handlers*' error paths (`changePassword` answers 401 to "current password is not correct").

On a method mount the last argument is the handler; everything before it is middleware. `.use`/`.all` carry no handler, so every argument there is a guard. Shape doesn't separate the two — the handlers take `next` and call `next(error)` exactly as guards do — but position does.

## 2. The mount-line name list matched substrings

`_detect_auth_middleware` tested 14 guard names with `in` against the whole line:

| line | matched | reality |
|---|---|---|
| `, checkAuthorEmail)` | `checkAuth` | not a guard |
| `, utils.asyncHandler(authenticatedUsers()))` | `authenticate` | the handler that *returns* the user list |
| `, requireAuthorRole)` | `requireAuth` | not a guard |
| `app.get('/api/authenticate', handler)` | `authenticate` | the route guarding itself with its own URL |

A `True` suppresses the route's missing-auth finding outright, so each of those was a vulnerability the report stopped mentioning. Matching is now on **word boundaries**, against the route's **arguments** rather than the whole line, with **comments stripped** (via a `SharedPatterns.JS_COMMENT_PATTERN` the tracer now shares).

The list still can't name a project's own vocabulary (`isLoggedIn`, `ensureMember`) and isn't meant to — it's the cheap answer for scans with no language server, and what a guard *does* is decided by the tracer, which reads its body. A `False` here is only an absence of evidence.

## Result

Scored against every mount that stops an unauthenticated request reaching the handler:

| Juice Shop | main | branch |
|---|---|---|
| missing-auth findings | 74 | **61** |
| landing on a guarded route | 16 | **3** |

The 3 are single-argument method mounts like `app.post('/api/Addresss', security.appendUserId())`, where position can't tell guard from handler and the rule declines to guess — erring toward reporting.

### Correction to #173

That PR reported 8 false positives, scoring `appendUserId` as gating nothing. It doesn't gate **ownership** — the IDOR findings on those routes stand — but it does gate **authentication**: it reads the caller's id from the token map and answers 401 when there is none. Under the corrected ground truth, main has 16, not 8.

NodeGoat unchanged at 18, test-app unchanged at 12. Suite 2426 passed. Injection benchmark 46/46, 0 FP.

Reverting any of the three rules — word boundaries, argument scoping, the handler exclusion — fails a test (checked by mutation).

Docs: `docs/lsp-setup.md` on rejection-as-auth and why the handler is excluded; `docs/scanners/route-auth-analyzer.md` on how the pre-LSP name match is bounded and why.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EZ4QoTqRoYWE25CNoV2Wfy