### PR TITLE
fix(sast): count a guard that rejects, and stop reading handler names as guards

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,18 +71,26 @@ chokes on silently costs you the release: release-please logs
 `commit could not be parsed`, counts zero commits and opens no PR, so the code
 merges and the changelog entry simply never appears.
 
-The one that has actually bitten us is a backticked code fragment whose
-parentheses do not balance to the parser's eye:
+What breaks it is **nested parentheses on one line** — an inner `(` opened
+while an outer one is still unclosed. A call inside a call is the usual way in:
 
 ```
-`app.use('/x', security.isAuthorized())` stands in front of every method
-                                    ^^^ Error: unexpected token '(' ... valid tokens [)]
+app.use('/x', security.isAuthorized())     <-- breaks: `isAuthorized(` opens
+                          ^                    inside the open `app.use(`
+Error: unexpected token '(' ... valid tokens [)]
+
+if (a === b) next()                        <-- fine: the parens are sequential,
+app.get('/x', handler)                         never nested
 ```
 
-Describe such code in prose, or trim it to a balanced fragment
-(`security.isAuthorized`). If a release you expected does not appear, read the
-release-please run log before anything else — the workflow reports success
-either way.
+So sequential parens are safe and nesting is not. Write the inner call without
+its parens (`security.isAuthorized`), split the fragment across two lines, or
+describe it in prose. This has cost two releases so far.
+
+If a release you expected does not appear, read the release-please run log
+before anything else: the workflow reports **success** either way, and the
+only evidence is a `commit could not be parsed` line followed by
+`Considering: 0 commits`.
 
 ## Reporting bugs / security issues
 


### PR DESCRIPTION
Restores the changelog entry for `9d19d9f` (#178), and sharpens the rule that was supposed to prevent this.

## Same failure, second time

```
commit could not be parsed: 9d19d9f fix(sast): count a guard that rejects, ...
error message: Error: unexpected token '(' at 52:49, valid tokens [)]
✔ Considering: 0 commits
✔ No commits for path: ., skipping
```

I wrote that commit body *after* adding the CONTRIBUTING guidance, and still tripped it — because the guidance was too vague to act on. It said "unbalanced-looking parentheses".

## The actual rule

**Nested** parentheses on one line: an inner `(` opened while an outer one is still unclosed. Both failures were a call inside a call, and the column each error names is the inner paren:

- `4b8cca2` at 95:51 — `app.use('/x', security.isAuthorized` … the inner paren
- `9d19d9f` at 52:49 — `app.post('/api/Addresss', security.appendUserId` … likewise

Sequential parens are fine, which is why other code fragments in the same bodies passed unharmed. `if (a === b) next()` parses; `foo(bar())` does not.

CONTRIBUTING.md now states that with an example of each, plus the reminder that the workflow reports **success** either way — the only evidence is `commit could not be parsed` followed by `Considering: 0 commits` in the run log.

## Contents

- This commit's subject re-states #178's in a parseable message, so the changelog gets its entry.
- `CONTRIBUTING.md` correction.

No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EZ4QoTqRoYWE25CNoV2Wfy