### PR TITLE
fix(sast): judge a webhook route by what it verifies, not by its path

### DIFF
--- a/docs/scanners/route-auth-analyzer.md
+++ b/docs/scanners/route-auth-analyzer.md
@@ -21,13 +21,27 @@ Some routes are meant to be open, and flagging them is noise. The exemption
 list is deliberately short and is about what a route **is**, not about what we
 found on it:
 
-- health and status endpoints (`/health`, `/ping`, `/status`, `/ready`, …)
+- health and liveness probes (`/health`, `/ping`, `/status`, `/ready`,
+  `/livez`, `/readyz`)
 - API documentation (`/docs`, `/swagger`, `/openapi`) and the root path
-- webhook receivers (`/webhook`, `/stripe`), which are signature-verified
-  rather than auth-gated
 
-App-specific route names are kept out of it on purpose: a scanned app that
-happens to reuse one would have a real finding silently suppressed.
+Every one is a name standardised outside your project, and matching is
+**exact** — `/health` is a liveness probe, `/api/health-records` is patient
+data, and a fragment match cannot tell them apart. App-specific names are kept
+out on purpose: a scanned app that happens to reuse one would have a real
+finding silently suppressed. For a route of your own that is public by design,
+suppress the finding by fingerprint (`--suppress`), which is visible and
+reversible where this list is neither.
+
+**Webhook receivers are not on it.** They do authenticate — by verifying the
+sender's signature, the sender having no session to present — so exempting
+them by path was the right idea checked the wrong way. A path is not evidence:
+an endpoint with "webhook" in its name may equally be one that *sends* them,
+which is an SSRF sink, and the test app's `/api/webhooks/test` is exactly that.
+Signature verification is now detected directly — `constructEvent`,
+`timingSafeEqual`, a `stripe-signature` / `x-hub-signature` / `svix-signature`
+header read — so a receiver that checks its signature counts as authenticated
+wherever it lives, and one that does not is reported.
 
 Not finding a guard is never itself grounds for staying quiet. A rule that
 exempted any GET route the mapper reported no auth on read that backwards —

--- a/isitsecure/engine/code_analysis/express_route_mapper.py
+++ b/isitsecure/engine/code_analysis/express_route_mapper.py
@@ -204,8 +204,8 @@ class ExpressRouteMapper:
         for match in re.finditer(
             ExpressRouteMapperConfig.ROUTE_DEFINITION_PATTERN, content
         ):
-            method = match.group(1).upper()
-            path = match.group(2)
+            method = match.group("method").upper()
+            path = match.group("path")
 
             # Only what is *applied* to the route can guard it: the
             # arguments after the path. The whole line also holds the path

--- a/isitsecure/engine/code_analysis/route_analyzer.py
+++ b/isitsecure/engine/code_analysis/route_analyzer.py
@@ -161,20 +161,26 @@ class RouteAuthAnalyzer:
 
         return findings
 
-    # Routes that are intentionally public — never flag for missing auth
+    # Routes that are public by definition, exempt from the missing-auth
+    # check. Every entry is a name standardised outside this project —
+    # Kubernetes probe endpoints and the conventional API-documentation paths
+    # — and matching is exact, never a substring.
+    #
+    # Nothing app-specific belongs here, and neither does anything matched by
+    # a fragment: a scanned app that happens to reuse the word gets a real
+    # finding silently suppressed, and silence is indistinguishable from
+    # having looked. A project with its own public route suppresses that
+    # finding by fingerprint (`--suppress`), which is visible and reversible.
+    #
+    # "/" stays: a site's home page is public by convention, and removing it
+    # was measured to cost three false positives and buy nothing. The case
+    # that seemed to justify removing it — Juice Shop's /dataerasure, which
+    # declares `router.get('/')` — turned out to authenticate inside its
+    # handler, so the exemption was hiding no vulnerability there.
     _PUBLIC_ROUTE_PATTERNS = frozenset({
         "/health", "/ping", "/status", "/ready", "/livez", "/readyz",
         "/", "/docs", "/swagger", "/openapi",
     })
-
-    # Generic substrings that indicate intentionally public endpoints. Kept
-    # deliberately minimal — app-specific route names must NOT live here, or a
-    # scanned app that happens to reuse the name gets its missing-auth finding
-    # silently suppressed. Make this configurable per project instead.
-    _PUBLIC_ROUTE_INDICATORS = (
-        "/webhook",
-        "/stripe",  # Stripe webhooks are signature-verified, not auth-gated
-    )
 
     def _analyze_route(self, route: RouteEntry) -> list[CodeFinding]:
         """Analyze a single API route for security issues.
@@ -301,9 +307,13 @@ class RouteAuthAnalyzer:
         if pattern in self._PUBLIC_ROUTE_PATTERNS:
             return True
 
-        # Substring matches
-        if any(ind in pattern for ind in self._PUBLIC_ROUTE_INDICATORS):
-            return True
+        # No substring matching, and in particular no exemption for a path
+        # containing "webhook". Webhook receivers authenticate by verifying
+        # the sender's signature rather than a session, so they are answered
+        # where every other route is: by what the handler does. The path
+        # cannot tell a receiver from an endpoint that *sends* a webhook —
+        # which is an SSRF sink, and was being silenced as though it were
+        # signature-verified.
 
         # Deliberately no rule here for "the mapper found no auth on a GET".
         # That was read as evidence the route is *intentionally* open, when it

--- a/isitsecure/engine/constants.py
+++ b/isitsecure/engine/constants.py
@@ -22,6 +22,23 @@ class SharedPatterns:
     # annotation was taken for the guard.
     JS_COMMENT_PATTERN = r"//.*$|/\*.*?\*/"
 
+    # Verifying a request signature authenticates the caller as surely as a
+    # session does — it is how a webhook receiver is *meant* to authenticate,
+    # the sender holding no session to present. Detected by what the handler
+    # does, because the path says nothing: an endpoint with "webhook" in its
+    # name may equally be one that *sends* them, which is an SSRF sink rather
+    # than a receiver.
+    SIGNATURE_VERIFICATION_PATTERNS = (
+        r"constructEvent\s*\(",        # stripe.webhooks.constructEvent
+        r"timingSafeEqual\s*\(",       # constant-time digest comparison
+        r"verifySignature\s*\(",
+        r"verify_signature\s*\(",
+        r"(?i)x-hub-signature",         # GitHub, Meta
+        r"(?i)stripe-signature",
+        r"(?i)svix-signature",          # Svix, Clerk
+        r"(?i)x-signature-ed25519",     # Discord
+    )
+
     UUID_PATTERN = (
         r'[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'
     )
@@ -1010,7 +1027,7 @@ class RouteAuthAnalyzerConfig:
         r'requireAuth\s*\(',
         r'withAuth\s*\(',
         r'isAuthenticated',
-    )
+    ) + SharedPatterns.SIGNATURE_VERIFICATION_PATTERNS
 
     # Patterns indicating authorization/ownership check
     OWNERSHIP_CHECK_PATTERNS = (
@@ -3612,8 +3629,9 @@ class ExpressRouteMapperConfig:
     # Regex patterns for Express route definitions
     # Captures: (method, path) from app.get('/path', ...) or router.post('/path', ...)
     ROUTE_DEFINITION_PATTERN = (
-        r'(?:app|router)\s*\.\s*(get|post|put|patch|delete|all)\s*\(\s*'
-        r"""['"](/[^'"]*?)['"]"""
+        r'(?:app|router)\s*\.\s*'
+        r'(?P<method>get|post|put|patch|delete|all)\s*\(\s*'
+        r"""['"](?P<path>/[^'"]*?)['"]"""
     )
 
     # Regex pattern for app.use mount points
@@ -4877,7 +4895,7 @@ class LSPConfig:
         # bcrypt/argon (password verification)
         r'bcrypt\.compare\s*\(',
         r'argon2\.verify\s*\(',
-    )
+    ) + SharedPatterns.SIGNATURE_VERIFICATION_PATTERNS
 
     # Patterns that confirm auth enforcement (throws/returns on failure).
     # Generic across frameworks — matches status codes and error types.

--- a/tests/engine/test_code_analysis/test_route_analyzer.py
+++ b/tests/engine/test_code_analysis/test_route_analyzer.py
@@ -509,8 +509,11 @@ class TestIntentionallyPublic:
     def test_a_health_check_is_public(self) -> None:
         assert self.analyzer._is_intentionally_public(self._route("/health"))
 
-    def test_a_webhook_is_public(self) -> None:
-        assert self.analyzer._is_intentionally_public(
+    def test_a_webhook_path_is_not_public_on_its_name(self) -> None:
+        """Receivers authenticate by verifying a signature, which is checked
+        for directly — see TestWebhookRoutesAreJudgedByBehaviour. The path
+        cannot tell a receiver from an endpoint that sends one."""
+        assert not self.analyzer._is_intentionally_public(
             self._route("/api/webhook/stripe", "POST")
         )
 
@@ -614,3 +617,68 @@ class TestLSPSuppressionIsPerMethod:
         finding.http_methods = []
         kept = self.analyzer.validate_with_lsp([finding], self._results())
         assert len(kept) == 1
+
+
+class TestWebhookRoutesAreJudgedByBehaviour:
+    """A path containing "webhook" used to exempt a route outright.
+
+    Webhook receivers do authenticate — by verifying the sender's signature,
+    the sender holding no session to present — so the *rationale* was sound.
+    The path is not evidence of it, though: an endpoint with "webhook" in its
+    name may equally be one that **sends** them, which is an SSRF sink. The
+    test app's `/api/webhooks/test` is exactly that, and was silenced.
+    """
+
+    def setup_method(self) -> None:
+        self.analyzer = RouteAuthAnalyzer()
+
+    @staticmethod
+    def _route(pattern: str, content: str) -> RouteEntry:
+        return RouteEntry(
+            file_path="route.ts",
+            http_methods=["POST"],
+            route_pattern=pattern,
+            content=content,
+        )
+
+    SENDS_A_WEBHOOK = (
+        "export async function POST(request) {\n"
+        "  const { webhook_url } = await request.json()\n"
+        "  await fetch(webhook_url, { method: 'POST' })\n"
+        "}\n"
+    )
+    VERIFIES_A_SIGNATURE = (
+        "export async function POST(request) {\n"
+        "  const sig = request.headers.get('stripe-signature')\n"
+        "  const event = stripe.webhooks.constructEvent(body, sig, secret)\n"
+        "}\n"
+    )
+
+    def test_a_webhook_path_alone_no_longer_exempts(self) -> None:
+        route = self._route("/api/webhooks/test", self.SENDS_A_WEBHOOK)
+        assert not self.analyzer._is_intentionally_public(route)
+        titles = [f.title for f in self.analyzer._analyze_route(route)]
+        assert RouteAuthAnalyzerConfig.TITLE_MISSING_AUTH in titles
+
+    def test_verifying_a_signature_counts_as_authentication(self) -> None:
+        """A receiver that checks the signature is authenticated, whatever
+        its path is called."""
+        route = self._route("/api/hooks/incoming", self.VERIFIES_A_SIGNATURE)
+        titles = [f.title for f in self.analyzer._analyze_route(route)]
+        assert RouteAuthAnalyzerConfig.TITLE_MISSING_AUTH not in titles
+
+    def test_a_stripe_path_alone_no_longer_exempts(self) -> None:
+        route = self._route("/api/stripe/hook", self.SENDS_A_WEBHOOK)
+        assert not self.analyzer._is_intentionally_public(route)
+
+    def test_conventional_public_endpoints_are_still_exempt(self) -> None:
+        for pattern in ("/health", "/livez", "/readyz", "/", "/openapi"):
+            assert self.analyzer._is_intentionally_public(
+                self._route(pattern, "export async function GET() {}\n")
+            ), pattern
+
+    def test_exemption_is_exact_not_a_substring(self) -> None:
+        """`/health` is a liveness probe; `/api/health-records` is patient
+        data. A fragment match cannot tell them apart."""
+        route = self._route("/api/health-records", "export async function GET() {}\n")
+        assert not self.analyzer._is_intentionally_public(route)


### PR DESCRIPTION
Your overfitting question, followed up. Short version: the hardcoded values in the *logic* were fine, one of the two suspect entries was genuinely wrong, and the other turned out to be right — which the measurement told me, not my reasoning.

## What was there

```python
_PUBLIC_ROUTE_PATTERNS = {"/health", "/ping", "/status", "/ready",
                          "/livez", "/readyz", "/", "/docs", "/swagger", "/openapi"}
_PUBLIC_ROUTE_INDICATORS = ("/webhook", "/stripe")
```

From `acc1bcf`, the initial extraction. The comment above it warned that app-specific names must not live there — then listed `/stripe`.

## Fixed: webhook paths

The rationale was sound — receivers authenticate by verifying the sender's signature, the sender having no session to present. The path is not evidence of it. A path cannot tell a receiver from an endpoint that **sends** a webhook, which is an SSRF sink.

Your test app ships exactly that. `test-app/src/app/api/webhooks/test/route.ts` is labelled `VULNERABILITY: Blind SSRF`, takes a caller-supplied URL, has no auth — and `route_auth_analyzer` said nothing, because of the word in its path.

Signature verification is now detected directly (`SharedPatterns.SIGNATURE_VERIFICATION_PATTERNS`): `constructEvent`, `timingSafeEqual`, `verifySignature`, and reads of `stripe-signature` / `x-hub-signature` / `svix-signature` / `x-signature-ed25519`. Wired into both the content fallback and the tracer's terminal patterns, so a receiver that checks its signature is authenticated wherever it lives — and one that doesn't is reported.

## Not fixed: `"/"` — I was wrong

I told you `"/"` was indefensible. I removed it, found what looked like proof (Juice Shop's `/dataerasure` declares `router.get('/')`, so a router-relative `/` was being exempted as though it were a home page), built the machinery to distinguish the two — and then read the handler:

```ts
const loggedInUser = security.authenticatedUsers.get(req.cookies.token)
if (!loggedInUser) { next(new Error('Blocked illegal activity by ' + ...)); return }
```

It authenticates. The exemption was hiding nothing there. Measured, removing `"/"` cost **three false positives** across the targets and found nothing, so it is back and the machinery is reverted.

### What that case does expose

A real blind spot, deliberately left alone: an Express route whose auth check sits **inline in an anonymous handler** is invisible — the mapper's `has_auth_check=False` short-circuits the content fallback, and the tracer has no symbol to resolve. It costs nothing today only because the `"/"` exemption happens to cover it. Worth its own issue.

## Kept

`/health`, `/ping`, `/status`, `/ready`, `/livez`, `/readyz`, `/`, `/docs`, `/swagger`, `/openapi` — every one a name standardised outside this project, matched **exactly**, never as a substring (`/health` is a liveness probe; `/api/health-records` is patient data). For a project's own public route there's `--suppress` by fingerprint, which is visible and reversible where this list is neither.

## Measurements

| | main | branch |
|---|---|---|
| test-app | 12 | **13** — the blind-SSRF webhook, nothing newly suppressed |
| Juice Shop | 63 | 63 |
| NodeGoat | 18 | 18 |

Suite 2431 passed. Injection benchmark 46/46 recall, 0 FP. Restoring the path exemption, or dropping the signature patterns, each fails a test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EZ4QoTqRoYWE25CNoV2Wfy