### PR TITLE
fix(sast): examine a route's own handler before reporting it unauthenticated

### DIFF
--- a/docs/scanners/route-auth-analyzer.md
+++ b/docs/scanners/route-auth-analyzer.md
@@ -68,6 +68,39 @@ What a guard actually *does* is decided by the auth-flow tracer, which
 resolves it and reads its body. A `False` here is only an absence of evidence
 — the route is still examined either way.
 
+### Auth checked inside the route's own handler
+
+A route often has no named guard on its mount line and checks auth in its
+body instead:
+
+```js
+router.get('/orders', (req, res) => {
+  const session = getServerSession(req)
+  if (!session) return res.status(401).end()
+  ...
+```
+
+The Express mapper answers "no guard" for that, since an anonymous function
+has no name to recognise — but "no known name applied here" is not "no auth",
+so the route's **own handler** is examined before the finding is raised.
+
+Its own, and not the file's: one `server.ts` shares its content with a hundred
+routes, and searching that would let a single guarded neighbour clear all of
+them.
+
+Two things must both be present. Looking up an identity is not authentication
+on its own — it is most of what an IDOR looks like:
+
+```js
+const user = getUser(req.params.id)   // an id from the caller
+res.json(user)                        // and nobody refused
+```
+
+Accepting that would suppress the finding for a route whose whole problem is
+that it never checks who is asking. A handler that authenticates also turns
+someone away, so a refusal — a 401, a 403, an auth error — is required
+alongside.
+
 ## Why It Matters
 
 A single API route without authentication is often enough for a full data breach:

--- a/isitsecure/engine/code_analysis/express_route_mapper.py
+++ b/isitsecure/engine/code_analysis/express_route_mapper.py
@@ -228,6 +228,7 @@ class ExpressRouteMapper:
                     route_pattern=path,
                     has_auth_check=has_auth,
                     content=content,
+                    handler_source=self._call_arguments(content, match.end()),
                 )
             )
 
@@ -255,6 +256,54 @@ class ExpressRouteMapper:
     # ------------------------------------------------------------------
     # Auth middleware detection
     # ------------------------------------------------------------------
+
+    @staticmethod
+    def _call_arguments(content: str, start: int) -> str:
+        """The rest of a route's arguments, to the call's closing paren.
+
+        A route handler is one argument of `app.get(path, ...)`, and it can
+        run for a hundred lines. Delimiting it needs the paren depth, not a
+        line: the mount line alone stops at the arrow, and the whole file
+        belongs to every route in it equally.
+
+        Parens inside strings and comments are skipped: a route body is full
+        of both, and a lone `)` in either would otherwise end the handler
+        early. Returns what it has if the call is never closed — a truncated
+        handler is still that handler's code, where the remainder of the file
+        would be somebody else's.
+        """
+        depth = 1
+        index = start
+        quote = ""
+        limit = min(len(content), start + ExpressRouteMapperConfig.MAX_HANDLER_CHARS)
+
+        while index < limit:
+            char = content[index]
+            if quote:
+                if char == "\\":
+                    index += 2
+                    continue
+                if char == quote:
+                    quote = ""
+            elif content.startswith("//", index):
+                newline = content.find("\n", index)
+                index = limit if newline == -1 else newline
+                continue
+            elif content.startswith("/*", index):
+                close = content.find("*/", index + 2)
+                index = limit if close == -1 else close + 2
+                continue
+            elif char in "\"'`":
+                quote = char
+            elif char == "(":
+                depth += 1
+            elif char == ")":
+                depth -= 1
+                if depth == 0:
+                    return content[start:index]
+            index += 1
+
+        return content[start:limit]
 
     _AUTH_INDICATOR_RE = re.compile(
         "|".join(

--- a/isitsecure/engine/code_analysis/protocols.py
+++ b/isitsecure/engine/code_analysis/protocols.py
@@ -32,6 +32,12 @@ class RouteEntry(BaseModel):
     has_auth_check: bool | None = None
     content: str = ""
 
+    # The route's own arguments — its middleware and handler — where the
+    # mapper could delimit them. `content` is the whole file, which one
+    # `server.ts` shares between a hundred routes; anything judged per route
+    # has to be judged on this instead.
+    handler_source: str = ""
+
 
 class WorkspaceInfo(BaseModel):
     """Metadata for a single workspace inside a monorepo.

--- a/isitsecure/engine/code_analysis/route_analyzer.py
+++ b/isitsecure/engine/code_analysis/route_analyzer.py
@@ -24,7 +24,10 @@ from isitsecure.engine.code_analysis.protocols import (
     RepoSnapshot,
     RouteEntry,
 )
-from isitsecure.engine.constants import RouteAuthAnalyzerConfig
+from isitsecure.engine.constants import (
+    LSPConfig,
+    RouteAuthAnalyzerConfig,
+)
 from isitsecure.engine.shared.code_utils import find_line_number
 from isitsecure.engine.enums import FindingCategory, SeverityLevel
 
@@ -203,11 +206,23 @@ class RouteAuthAnalyzer:
             return findings
 
         # --- Determine auth status ---
-        # Priority 1: Trust route mapper's classification
+        # A mapper's True is a guard named on the mount line. Its False is
+        # narrower than it looks: no *known name* was applied there, which is
+        # not the same as no auth. A route may check inside its handler, and
+        # an anonymous arrow function offers no name to recognise:
+        #
+        #     router.get('/', (req, res, next) => {
+        #       const user = authenticatedUsers.get(req.cookies.token)
+        #       if (!user) { next(new Error('...')); return }
+        #
+        # So a False is re-examined against the route's own handler. Its own:
+        # `content` is the whole file, and one `server.ts` shares that between
+        # a hundred routes, so scanning it would let a single guarded
+        # neighbour clear all of them — the mistake fixed in #168 and #170.
         if route.has_auth_check is True:
             has_auth = True
         elif route.has_auth_check is False:
-            has_auth = False
+            has_auth = self._handler_authenticates(route)
         else:
             # has_auth_check is None (unknown) — fall back to content scan
             has_auth = self._has_auth_check(route.content)
@@ -291,6 +306,36 @@ class RouteAuthAnalyzer:
 
         # Everything else (tRPC routers, Express files) is multi-route
         return False
+
+    def _handler_authenticates(self, route: RouteEntry) -> bool:
+        """Whether a route's own handler both identifies a caller and refuses.
+
+        Both are required, and the conjunction is the whole point. Looking up
+        an identity is not authentication on its own — it is most of what an
+        IDOR looks like::
+
+            app.get('/profile/:id', (req, res) => {
+              const user = getUser(req.params.id)   // no caller involved
+              res.json(user)                        // and nothing refused
+            })
+
+        Accepting `getUser(` there would suppress the finding for a route
+        whose whole problem is that it never checks who is asking. A handler
+        that authenticates also turns someone away, which is the shape
+        `_has_enforcement` recognises.
+        """
+        handler = route.handler_source
+        if not handler:
+            return False
+        return self._has_auth_check(handler) and self._has_enforcement(handler)
+
+    @staticmethod
+    def _has_enforcement(content: str) -> bool:
+        """Whether the code refuses a request — a 401/403 or an auth error."""
+        return any(
+            re.search(pattern, content)
+            for pattern in LSPConfig.AUTH_ENFORCEMENT_PATTERNS
+        )
 
     def _is_intentionally_public(self, route: RouteEntry) -> bool:
         """Check if a route is intentionally public and should not be flagged.

--- a/isitsecure/engine/constants.py
+++ b/isitsecure/engine/constants.py
@@ -3626,6 +3626,10 @@ class ExpressRouteMapperConfig:
     # Files nothing is expected to import, because the process starts there.
     ENTRY_POINT_STEMS = frozenset({"server", "app", "index", "main"})
 
+    # A route handler that runs past this is not going to be understood by
+    # reading further, and an unclosed paren must not walk the whole file.
+    MAX_HANDLER_CHARS = 20_000
+
     # Regex patterns for Express route definitions
     # Captures: (method, path) from app.get('/path', ...) or router.post('/path', ...)
     ROUTE_DEFINITION_PATTERN = (

--- a/tests/engine/test_code_analysis/test_route_analyzer.py
+++ b/tests/engine/test_code_analysis/test_route_analyzer.py
@@ -682,3 +682,89 @@ class TestWebhookRoutesAreJudgedByBehaviour:
         data. A fragment match cannot tell them apart."""
         route = self._route("/api/health-records", "export async function GET() {}\n")
         assert not self.analyzer._is_intentionally_public(route)
+
+
+class TestHandlerScopedAuth:
+    """Auth checked inside a route's own handler (#183).
+
+    The Express mapper answers `has_auth_check=False` when no known guard
+    *name* sits on the mount line — which an anonymous handler never has.
+    That was believed outright, so a route checking auth in its own body was
+    reported as having none.
+    """
+
+    def setup_method(self) -> None:
+        self.analyzer = RouteAuthAnalyzer()
+
+    @staticmethod
+    def _route(handler: str, pattern: str = "/orders") -> RouteEntry:
+        return RouteEntry(
+            file_path="routes/orders.ts",
+            http_methods=["GET"],
+            route_pattern=pattern,
+            has_auth_check=False,
+            content="a hundred other routes live here too\n",
+            handler_source=handler,
+        )
+
+    GUARDED = (
+        ", (req, res) => {\n"
+        "  const session = getServerSession(req)\n"
+        "  if (!session) return res.status(401).end()\n"
+        "  res.json(orders)\n"
+        "}"
+    )
+    # Looks up a user, refuses nobody. This is what an IDOR looks like.
+    LOOKS_UP_A_USER = (
+        ", (req, res) => {\n"
+        "  const user = getUser(req.params.id)\n"
+        "  res.json(user)\n"
+        "}"
+    )
+
+    def test_a_handler_that_identifies_and_refuses_is_authenticated(self) -> None:
+        titles = [f.title for f in self.analyzer._analyze_route(self._route(self.GUARDED))]
+        assert RouteAuthAnalyzerConfig.TITLE_MISSING_AUTH not in titles
+
+    def test_looking_up_a_user_is_not_authenticating(self) -> None:
+        """The conjunction's whole purpose: `getUser(req.params.id)` takes an
+        id from the caller and refuses nobody, which is the vulnerability
+        rather than the defence."""
+        route = self._route(self.LOOKS_UP_A_USER)
+        assert not self.analyzer._handler_authenticates(route)
+        titles = [f.title for f in self.analyzer._analyze_route(route)]
+        assert RouteAuthAnalyzerConfig.TITLE_MISSING_AUTH in titles
+
+    def test_refusing_without_identifying_is_not_authenticating(self) -> None:
+        """A 400-guard on a missing field is not an auth check."""
+        route = self._route(
+            ", (req, res) => {\n"
+            "  if (!req.body.name) return res.status(401).end()\n"
+            "  res.json(ok)\n"
+            "}"
+        )
+        assert not self.analyzer._handler_authenticates(route)
+
+    def test_the_file_is_not_searched_in_the_handler_s_place(self) -> None:
+        """One `server.ts` shares its content with a hundred routes, so a
+        guarded neighbour must not clear an unguarded route."""
+        route = RouteEntry(
+            file_path="server.ts",
+            http_methods=["GET"],
+            route_pattern="/open",
+            has_auth_check=False,
+            content=(
+                "app.get('/guarded', (req, res) => {\n"
+                "  const s = getServerSession(req)\n"
+                "  if (!s) return res.status(401).end()\n"
+                "})\n"
+            ),
+            handler_source=", (req, res) => res.json(everything)",
+        )
+        assert not self.analyzer._handler_authenticates(route)
+
+    def test_a_route_with_no_handler_source_is_unchanged(self) -> None:
+        """Mappers for other frameworks do not set it; they must keep their
+        existing behaviour."""
+        route = self._route("", pattern="/legacy")
+        assert not self.analyzer._handler_authenticates(route)


### PR DESCRIPTION
Closes #183.

## The bug

The Express mapper answers `has_auth_check=False` when no known guard *name* sits on the mount line — and an anonymous handler never has one. The analyzer believed that outright:

```python
elif route.has_auth_check is False:
    has_auth = False          # believed, though it means only "no known name here"
else:
    has_auth = self._has_auth_check(route.content)   # unreachable for Express
```

So a route that checks auth in its own body was reported as having none. Same conflation as the GET exemption fixed in #175: *no evidence of a guard* read as *evidence of no guard*.

## The fix

The route's **own handler** is examined before the finding is raised — its own, not the file's. `content` is the whole file, which one `server.ts` shares between a hundred routes; searching that would let a single guarded neighbour clear all of them, which is the mistake fixed in #168 and #170. `ExpressRouteMapper` delimits each route's arguments by paren depth, skipping strings and comments, and records them on the `RouteEntry`.

**Two signals are required together**, and that conjunction is the point. My first cut accepted an auth call alone, which would have suppressed exactly this:

```js
const user = getUser(req.params.id)   // an id from the caller
res.json(user)                        // and nobody refused
```

`getUser(` matches — and that route's whole problem is that it never checks who is asking. A handler that authenticates also turns someone away, so a refusal (401/403/auth error) is required alongside the lookup.

## This changes nothing on any target

| | main | branch |
|---|---|---|
| Juice Shop | 63 | 63 |
| NodeGoat | 18 | 18 |
| test-app | 13 | 13 |

The case that motivated the issue isn't among them. `/dataerasure` authenticates through `security.authenticatedUsers.get(...)` — this project's own vocabulary, which no pattern list should name and none does. Naming it would be exactly the overfitting worth avoiding.

So what ships is the structural fix: a mapper's `False` gets re-examined rather than believed. A handler using a recognised form is now seen, demonstrated by test and by mutation — reverting either half of the rule fails one.

If you'd rather not carry a change with no measured effect, that's a reasonable call and I'd close it; the counter-argument is that it's a real reported bug whose invisibility today is luck (the `/` exemption happens to cover the one known case).

Suite 2436 passed. Injection benchmark 46/46, 0 FP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EZ4QoTqRoYWE25CNoV2Wfy