### PR TITLE
ci: fail a pull request whose commit message release-please cannot read

### DIFF
--- a/.github/scripts/check-commit-messages.mjs
+++ b/.github/scripts/check-commit-messages.mjs
@@ -1,0 +1,81 @@
+#!/usr/bin/env node
+// Fails when a commit message cannot be parsed as a Conventional Commit.
+//
+// release-please reads every commit on main to build the release. A message
+// it cannot parse is not an error there — it is skipped, silently, and the
+// workflow still reports success. The only trace is a `commit could not be
+// parsed` line in the run log, so the first sign of trouble is a release that
+// never appears. That has cost this repo two releases.
+//
+// The parser here is the one release-please itself uses, pinned to the same
+// version, rather than a rule of thumb about what breaks it: the failure is
+// subtle enough that it was mis-derived twice from examples before anyone
+// tried the parser. A line *beginning* with a token that contains nested
+// parentheses is the shape that bites — indenting it, or putting a word in
+// front of it, is enough — but knowing that is not needed to use this.
+//
+// Usage: node check-commit-messages.mjs <git-range>
+
+import { parser } from '@conventional-commits/parser'
+import { execFileSync } from 'node:child_process'
+
+const range = process.argv[2]
+if (!range) {
+  console.error('usage: check-commit-messages.mjs <git-range>')
+  process.exit(2)
+}
+
+const git = (...args) => execFileSync('git', args, { encoding: 'utf8' })
+// `--no-merges`: on a pull_request event actions/checkout builds a synthetic
+// "Merge <head> into <base>" commit. It is not a Conventional Commit, nobody
+// wrote it, and it cannot be reworded — and it never reaches main, since
+// pull requests here are squashed.
+const shas = git('rev-list', '--no-merges', range).trim().split('\n').filter(Boolean)
+
+if (shas.length === 0) {
+  console.log('No commits in range — nothing to check.')
+  process.exit(0)
+}
+
+let failed = 0
+
+for (const sha of shas) {
+  const message = git('log', '-1', '--format=%B', sha)
+  const subject = message.split('\n', 1)[0]
+
+  try {
+    parser(message)
+    console.log(`  ok    ${sha.slice(0, 8)}  ${subject.slice(0, 72)}`)
+  } catch (error) {
+    failed++
+    const detail = String(error.message).split('\n')[0]
+    console.error(`  FAIL  ${sha.slice(0, 8)}  ${subject.slice(0, 72)}`)
+    console.error(`        ${detail}`)
+
+    // The parser reports "at LINE:COLUMN" against the whole message, so the
+    // offending line can be shown rather than described.
+    const at = detail.match(/at (\d+):(\d+)/)
+    if (at) {
+      const line = message.split('\n')[Number(at[1]) - 1]
+      if (line !== undefined) {
+        const prefix = `        line ${at[1]}: `
+        console.error(`${prefix}${line}`)
+        console.error(`${' '.repeat(prefix.length + Number(at[2]) - 1)}^`)
+      }
+    }
+    console.error(
+      '        Fix: indent the line by four spaces, or put a word before the\n' +
+      '        code. See "Commit messages" in CONTRIBUTING.md.'
+    )
+  }
+}
+
+if (failed) {
+  console.error(
+    `\n${failed} commit message(s) release-please would silently skip.\n` +
+    'Reword with `git commit --amend` or `git rebase -i`, then force-push.'
+  )
+  process.exit(1)
+}
+
+console.log(`\n${shas.length} commit message(s) parse cleanly.`)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,26 @@ jobs:
       - run: pip install -e ".[all,dev]"
       - run: pytest -q
 
+  commit-messages:
+    name: commit messages
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+      # The parser release-please itself uses, pinned to the same version. A
+      # message it cannot read is skipped there *silently* — the workflow
+      # still reports success and no release PR appears — so this is a gate
+      # rather than advisory. It has cost two releases.
+      - run: npm install --no-save @conventional-commits/parser@0.4.1
+      - run: >
+          node .github/scripts/check-commit-messages.mjs
+          ${{ github.event.pull_request.base.sha }}..HEAD
+
   lint:
     name: ruff (advisory)
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,24 +71,35 @@ chokes on silently costs you the release: release-please logs
 `commit could not be parsed`, counts zero commits and opens no PR, so the code
 merges and the changelog entry simply never appears.
 
-What breaks it is **nested parentheses on one line** — an inner `(` opened
-while an outer one is still unclosed. A call inside a call is the usual way in:
+CI checks this on every pull request (the **commit messages** job), running
+the same parser release-please uses. You should not have to think about the
+rule below — but when the job fails, this is what it is telling you.
+
+What breaks it is a line that **begins** with a token containing nested
+parentheses:
 
 ```
-app.use('/x', security.isAuthorized())     <-- breaks: `isAuthorized(` opens
-                          ^                    inside the open `app.use(`
-Error: unexpected token '(' ... valid tokens [)]
-
-if (a === b) next()                        <-- fine: the parens are sequential,
-app.get('/x', handler)                         never nested
+`app.post('/x', security.appendUserId())`, where position cannot   <-- breaks
+    `app.post('/x', security.appendUserId())` indented four spaces <-- fine
+the call `app.post('/x', security.appendUserId())` mid-sentence    <-- fine
+`security.isAuthorized()` at the start, only one level             <-- fine
 ```
 
-So sequential parens are safe and nesting is not. Write the inner call without
-its parens (`security.isAuthorized`), split the fragment across two lines, or
-describe it in prose. This has cost two releases so far.
+So indent code fragments by four spaces, or put a word in front of them.
+Position in the line is what matters, not the parens themselves.
 
-If a release you expected does not appear, read the release-please run log
-before anything else: the workflow reports **success** either way, and the
+(This rule was mis-derived twice from examples before anyone ran the parser,
+which is why CI runs the parser rather than the rule.)
+
+To check before you push:
+
+```bash
+npm install --no-save @conventional-commits/parser@0.4.1
+node .github/scripts/check-commit-messages.mjs origin/main..HEAD
+```
+
+If a release you expected does not appear anyway, read the release-please run
+log before anything else: the workflow reports **success** either way, and the
 only evidence is a `commit could not be parsed` line followed by
 `Considering: 0 commits`.
 


### PR DESCRIPTION
release-please skips a commit it cannot parse — not with an error. It counts zero commits, opens no release PR, and **the workflow reports success**. The only trace is one line in the run log:

```
commit could not be parsed: 9d19d9f fix(sast): count a guard that rejects, ...
✔ Considering: 0 commits
✔ No commits for path: ., skipping
```

That has happened twice today, on `4b8cca2` and `9d19d9f`, each costing a follow-up PR to restore the changelog entry.

## What this adds

A `commit messages` job on pull requests that parses every commit message and fails if one would be skipped.

It runs **the parser release-please itself uses** (`@conventional-commits/parser`, pinned to 0.4.1), not a rule about what breaks it. That distinction is the whole point:

| attempt | rule I wrote | verdict |
|---|---|---|
| 1 | "unbalanced-looking parentheses" | too vague to act on — I tripped it myself the next commit |
| 2 | "nested parentheses on one line" | wrong — nesting mid-sentence parses fine |
| 3 | ran the parser | a line that *begins* with a token containing nested parens |

A check encoding guess #2 would have passed `9d19d9f`, the message that broke the last release. Hence: run the parser.

## Output

```
  FAIL  9d19d9f4  fix(sast): count a guard that rejects, and stop reading handler names...
        unexpected token '(' at 52:49, valid tokens [)]
        line 52: `app.post('/api/Addresss', security.appendUserId())`, where position cannot
                                                                 ^
        Fix: indent the line by four spaces, or put a word before the
        code. See "Commit messages" in CONTRIBUTING.md.
```

Verified against real history: `9d19d9f` fails with the same message CI produced, every other commit from 0.23.7 through 0.23.10 passes, an empty range is a no-op, and exit codes are 1 / 0 / 0.

## A gate, not advisory

Unlike `ruff`, this blocks. A silent failure that has cost two releases is worth stopping for, and the remedy is always to reword — `git commit --amend`, force-push.

`CONTRIBUTING.md` now describes the shape, with examples of what breaks and what doesn't, plus the two commands to check locally before pushing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EZ4QoTqRoYWE25CNoV2Wfy