### PR TITLE
feat(dast): keep the paths a bundle requests, not the ones with familiar names

### DIFF
--- a/benchmarks/run_benchmarks.py
+++ b/benchmarks/run_benchmarks.py
@@ -71,7 +71,13 @@ class Target:
     expect: list[Expectation] = field(default_factory=list)   # recall
     forbid: list[Expectation] = field(default_factory=list)   # false positives
     ready_timeout: int = 180
-    scan_timeout: int = 1800      # hard cap on the scan itself (seconds)
+    # Hard cap on the scan itself. This is a measurement budget, not a
+    # statement about how long a scan should take: when it trips, the run
+    # yields no report at all, so a target that outgrows it stops being
+    # measured rather than scoring lower. Raised from 1800 when Juice Shop's
+    # authenticated scan crossed it — the url-only leg finishes in a few
+    # minutes, but the authenticated one probes every endpoint as two users.
+    scan_timeout: int = 3600
     down_cmd: list[str] = field(default_factory=list)
     notes: str = ""
     # Authenticated scanning (two-user cross-user IDOR uses -b variants; a

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -279,6 +279,29 @@ looks reachable the graph is uninformative — the entry point may be a `.jsx`
 or a compiled artefact — so the filter stands down rather than dropping the
 whole project.
 
+### Endpoint Discovery
+
+For a single-page app, the served HTML is a shell: the routes and the API
+calls both live in the JavaScript bundle, which `EndpointDiscoveryScanner`
+parses alongside the HTML.
+
+Two kinds of path appear there, and only one is attack surface — the routes
+the app's own router renders are not endpoints, while the paths it calls are.
+They are told apart by **how each is written**, a request-making token
+(`fetch`, `axios`, `url:`, `hostServer`, …) just before the path:
+
+```js
+uploader = new Es({url: Z.hostServer + "/file-upload", ...})   // an endpoint
+{path: "/about", component: AboutComponent}                    // a route
+```
+
+This replaced a list of interesting-looking directory names (`/dashboard`,
+`/api`, `/apps`, `/admin`, `/account`). On Juice Shop that list kept 11 of 55
+paths and discarded `/file-upload`, `/dataerasure`, `/profile` and
+`/data-export` — and a scanner cannot test an endpoint nothing told it about,
+so the four file-upload vulnerabilities behind `/file-upload` were unreachable
+no matter how good the file-upload scanner was.
+
 ## Design Principles
 
 ### Protocol-Based (Dependency Inversion)

--- a/isitsecure/engine/constants.py
+++ b/isitsecure/engine/constants.py
@@ -145,6 +145,22 @@ class EndpointDiscoveryConfig:
     )
 
     # Route path patterns found in minified JS (Next.js, React Router, etc.)
+    # A path is worth probing when the bundle uses it to *make a request*.
+    # The alternative — a list of interesting-looking names — kept
+    # /dashboard, /api, /apps, /admin, /account and discarded 44 of Juice
+    # Shop's 55 paths, /file-upload and /dataerasure among them. A name list
+    # can only recognise vocabulary someone thought of in advance; how a path
+    # is used is visible in the code.
+    REQUEST_CONTEXT_PATTERN = (
+        r"(?:fetch|axios|XMLHttpRequest|\.open|\.get|\.post|\.put|\.patch"
+        r"|\.delete|url\s*:|baseURL|hostServer|apiUrl|endpoint)"
+    )
+
+    # How far back to look for that context. A bundler puts the request call
+    # and its URL close together; widening this starts catching the previous
+    # statement's call instead.
+    REQUEST_CONTEXT_WINDOW = 60
+
     ROUTE_PATH_PATTERN = r'"(/[a-zA-Z][a-zA-Z0-9_/\-]{2,50})"'
 
     # External API base URL pattern (e.g., https://api.example.com)

--- a/isitsecure/engine/scanners/endpoint_discovery.py
+++ b/isitsecure/engine/scanners/endpoint_discovery.py
@@ -115,7 +115,7 @@ class EndpointDiscoveryScanner:
         await self._discover_html_forms(html_content, base_url, raw_endpoints)
 
         # Phase 3: Extract app routes that might be API routes
-        self._extract_app_routes(all_content, base_url, raw_endpoints)
+        self._extract_requested_paths(all_content, base_url, raw_endpoints)
 
         # Post-process: detect params, categorize
         endpoints = list(raw_endpoints.values())
@@ -604,18 +604,36 @@ class EndpointDiscoveryScanner:
 
     # --- Phase 3: App route extraction ---
 
-    def _extract_app_routes(
+    def _extract_requested_paths(
         self,
         content: str,
         base_url: str,
         endpoints: dict[str, DiscoveredEndpoint],
     ) -> None:
-        """Extract app routes that might be API-backed pages.
+        """Extract paths the bundle uses as the target of a request.
 
-        Routes like /dashboard/home or /account/settings may have
-        corresponding API calls. We add them as potential endpoints
-        to probe.
+        A single-page app names two kinds of path: the routes its own router
+        renders, and the endpoints it calls. Only the second is attack
+        surface, and the difference is visible in how each is written —
+
+            uploader = new Es({url: Z.hostServer + "/file-upload", ...})
+            {path: "about", component: AboutComponent}
+
+        — so a path is kept when a request-making token sits just before it.
+
+        This used to be a list of interesting-looking names: /dashboard,
+        /api, /apps, /admin, /account. It discarded 44 of Juice Shop's 55
+        paths — /file-upload, /dataerasure, /profile, /data-export among
+        them — because a name list can only recognise vocabulary someone
+        thought of in advance. /file-upload alone gates four vulnerabilities
+        that no scanner could reach, since a scanner cannot test an endpoint
+        nothing told it about.
         """
+        context = re.compile(
+            EndpointDiscoveryConfig.REQUEST_CONTEXT_PATTERN, re.IGNORECASE
+        )
+        window = EndpointDiscoveryConfig.REQUEST_CONTEXT_WINDOW
+
         for match in re.finditer(
             EndpointDiscoveryConfig.ROUTE_PATH_PATTERN, content
         ):
@@ -629,14 +647,11 @@ class EndpointDiscoveryScanner:
             if route.startswith(("/_next", "/ROOT", "/node_modules")):
                 continue
 
-            # Routes with /dashboard, /api, or resource-like segments are interesting
-            if any(
-                seg in route.lower()
-                for seg in ("/dashboard", "/api", "/apps", "/admin", "/account")
-            ):
+            preceding = content[max(0, match.start() - window):match.start()]
+            if context.search(preceding):
                 self._add_endpoint(
                     endpoints, route, base_url,
-                    EndpointMethod.GET, "app_route",
+                    EndpointMethod.GET, "requested_path",
                 )
 
     # --- Helpers ---

--- a/tests/engine/test_endpoint_discovery.py
+++ b/tests/engine/test_endpoint_discovery.py
@@ -532,26 +532,71 @@ class TestEndpointDiscoveryScanner:
         scanner._extract_tables_from_openapi("not json", "https://x.supabase.co", endpoints)
         assert len(endpoints) == 0
 
-    # --- App routes ---
+    # --- Requested paths ---
+    #
+    # A single-page app names two kinds of path: the routes its router
+    # renders, and the endpoints it calls. Only the second is attack surface,
+    # and how each is written tells them apart.
 
     @pytest.mark.asyncio
-    async def test_extract_app_routes(self, scanner: EndpointDiscoveryScanner):
-        """Should extract routes with interesting segments like /dashboard."""
-        content = '"/dashboard/home"'
+    async def test_extracts_a_path_used_as_a_request_target(
+        self, scanner: EndpointDiscoveryScanner
+    ):
+        content = 'uploader = new Es({url: host + "/file-upload", token})'
         endpoints: dict[str, DiscoveredEndpoint] = {}
-        scanner._extract_app_routes(content, BASE_URL, endpoints)
+        scanner._extract_requested_paths(content, BASE_URL, endpoints)
 
         assert len(endpoints) == 1
         ep = list(endpoints.values())[0]
-        assert "/dashboard/home" in ep.url
-        assert ep.source_pattern == "app_route"
+        assert "/file-upload" in ep.url
+        assert ep.source_pattern == "requested_path"
+
+    @pytest.mark.asyncio
+    async def test_extracts_regardless_of_the_name(
+        self, scanner: EndpointDiscoveryScanner
+    ):
+        """The regression this guards: an allowlist of /dashboard, /api,
+        /apps, /admin, /account discarded 44 of Juice Shop's 55 paths."""
+        content = 'fetch("/dataerasure"); axios.post("/erasure-request")'
+        endpoints: dict[str, DiscoveredEndpoint] = {}
+        scanner._extract_requested_paths(content, BASE_URL, endpoints)
+
+        urls = " ".join(e.url for e in endpoints.values())
+        assert "/dataerasure" in urls
+        assert "/erasure-request" in urls
+
+    @pytest.mark.asyncio
+    async def test_a_router_route_is_not_an_endpoint(
+        self, scanner: EndpointDiscoveryScanner
+    ):
+        """`{path: "about"}` renders a view; nothing is requested."""
+        content = '{path: "/about", component: AboutComponent}'
+        endpoints: dict[str, DiscoveredEndpoint] = {}
+        scanner._extract_requested_paths(content, BASE_URL, endpoints)
+
+        assert len(endpoints) == 0
+
+    @pytest.mark.asyncio
+    async def test_a_dashboard_route_still_needs_a_request(
+        self, scanner: EndpointDiscoveryScanner
+    ):
+        """Names no longer earn inclusion on their own — including the ones
+        the old allowlist trusted."""
+        endpoints: dict[str, DiscoveredEndpoint] = {}
+        scanner._extract_requested_paths('"/dashboard/home"', BASE_URL, endpoints)
+        assert len(endpoints) == 0
+
+        scanner._extract_requested_paths(
+            'fetch("/dashboard/home")', BASE_URL, endpoints
+        )
+        assert len(endpoints) == 1
 
     @pytest.mark.asyncio
     async def test_skip_frontend_routes(self, scanner: EndpointDiscoveryScanner):
         """Known frontend-only routes should be skipped."""
-        content = '"/login"'
+        content = 'fetch("/login")'
         endpoints: dict[str, DiscoveredEndpoint] = {}
-        scanner._extract_app_routes(content, BASE_URL, endpoints)
+        scanner._extract_requested_paths(content, BASE_URL, endpoints)
 
         assert len(endpoints) == 0
 
@@ -560,11 +605,23 @@ class TestEndpointDiscoveryScanner:
         self, scanner: EndpointDiscoveryScanner
     ):
         """Internal framework paths like /_next should be skipped."""
-        content = '"/_next/data/abc123"'
+        content = 'fetch("/_next/data/abc123")'
         endpoints: dict[str, DiscoveredEndpoint] = {}
-        scanner._extract_app_routes(content, BASE_URL, endpoints)
+        scanner._extract_requested_paths(content, BASE_URL, endpoints)
 
         assert len(endpoints) == 0
+
+    @pytest.mark.asyncio
+    async def test_the_context_window_is_bounded(
+        self, scanner: EndpointDiscoveryScanner
+    ):
+        """A fetch call far above must not vouch for an unrelated path."""
+        content = 'fetch("/a");' + " " * 200 + '"/unrelated"'
+        endpoints: dict[str, DiscoveredEndpoint] = {}
+        scanner._extract_requested_paths(content, BASE_URL, endpoints)
+
+        urls = " ".join(e.url for e in endpoints.values())
+        assert "/unrelated" not in urls
 
     # --- Integration ---
 


### PR DESCRIPTION
First recall improvement of the day. Juice Shop **url-only 44% → 53%**, **authenticated 51% → 60%**.

## The cause was one layer deeper than "no bundle parsing"

Discovery already parsed the JS bundle, and `ROUTE_PATH_PATTERN` already matched `/file-upload`. `_extract_app_routes` then threw it away:

```python
if any(seg in route.lower() for seg in ("/dashboard", "/api", "/apps", "/admin", "/account")):
```

That allowlist discarded **44 of Juice Shop's 55 paths** — `/file-upload`, `/dataerasure`, `/profile`, `/data-export`, `/erasure-request` among them. A scanner cannot test an endpoint nothing told it about, so `FileUploadScanner` logged *"no upload endpoints detected"* and returned, while `/file-upload` sat there accepting `.html`, `.svg` and a traversal filename.

Isolated before writing any code: injecting the endpoint into the inventory by hand produced three findings immediately, which proved the scanners were fine and discovery was the whole blockage.

## The rule

A path is kept when the bundle uses it to **make a request** — a `fetch`, `axios`, `XMLHttpRequest`, `url:`, `baseURL` or `hostServer` token within 60 chars before it. That separates the two kinds of path an SPA names, by how each is written rather than what it's called:

```js
uploader = new Es({url: Z.hostServer + "/file-upload", ...})   // endpoint  → kept
{path: "/about", component: AboutComponent}                    // route     → dropped
```

On Juice Shop: keeps 30, drops 25, and the 25 are router routes (`/about`, `/contact`, `/chatbot`, `/login`).

## Results

| Juice Shop | before | after |
|---|---|---|
| url-only | 20/45 (44%) | **24/45 (53%)** |
| authenticated | 23/45 (51%) | **27/45 (60%)** |
| file_upload | 0/4 | **4/4** |
| inventory (url-only) | 59 | 77 |

No regressions: vampi-vulnerable 3/3, vampi-secure unchanged (its 2 IDOR false positives are pre-existing, confirmed on main earlier today), sast-injection 46/46 with 0 FP. Suite 2440 passed.

## The timeout change is not incidental

The authenticated scan grew with the inventory and came in at **1825s** against an 1800s cap — 25 seconds over. A scan over budget produces *no report at all*, so the target stops being measured rather than scoring lower; the first run of this change reported `juiceshop-auth (0 findings) ERROR`.

Pruning the `/1` id-variants would have bought those seconds back, but `/basket/1` and `/rest/basket/1` are real endpoints — that trades recall away for a limit that was only ever a measurement artifact. Raising the budget measures the true cost instead.

## Still open

`xxe 0/2` at the same endpoint, untouched here: XXE is only ever probed as a raw XML body, and Juice Shop's `/file-upload` takes multipart with an `.xml` attachment (returns 400 for a raw body — verified). Filed as #188.

Also unchanged: `ssrf 0/2`, `xss 2/7`, `mass_assignment 0/2`, and 19 of 49 authenticated findings still unclassified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EZ4QoTqRoYWE25CNoV2Wfy