### PR TITLE
fix(dast): deliver the XXE payload as an uploaded file, not only as a body

### DIFF
--- a/docs/scanners/active-injection-scanner.md
+++ b/docs/scanners/active-injection-scanner.md
@@ -14,7 +14,12 @@ Tests for server-side injection vulnerabilities by sending payloads to API endpo
 
 4. **NoSQL Injection** — Sends MongoDB operator payloads (`[$ne]=null`) and checks for response size inflation, indicating the query returned more data than intended.
 
-5. **XXE (XML External Entity)** — For endpoints accepting XML, injects `<!ENTITY xx SYSTEM "/etc/passwd">` and checks for file content indicators in the response.
+5. **XXE (XML External Entity)** — Injects `<!ENTITY xx SYSTEM "/etc/passwd">` and checks for file content indicators in the response. Delivered **two ways**, because an endpoint that accepts XML as a *file* rejects it as a request body:
+
+   - as the request body, on endpoints that advertise an XML content type or are POST;
+   - as an **uploaded file** (`.xml`, `.svg`) on upload-shaped paths — SVG, DOCX and XLSX are zipped XML, and SAML assertions and sitemap imports arrive as attachments, so an XXE probe that only posts raw bodies misses the whole class.
+
+   The upload delivery is not gated on the recorded HTTP method: discovery records most endpoints as GET, and an upload endpoint is worth probing either way.
 
 6. **SSTI (Server-Side Template Injection)** — Sends `{{7*7}}` and checks if `49` appears in the response, indicating template evaluation.
 

--- a/isitsecure/engine/constants.py
+++ b/isitsecure/engine/constants.py
@@ -39,6 +39,14 @@ class SharedPatterns:
         r"(?i)x-signature-ed25519",     # Discord
     )
 
+    # Paths that take an uploaded file. Matched as substrings of the path,
+    # which is deliberately loose: the cost of probing a non-upload endpoint
+    # with a multipart body is one request that 400s.
+    UPLOAD_PATH_INDICATORS = (
+        "/upload", "/file", "/media", "/attachment",
+        "/image", "/avatar", "/document", "/import",
+    )
+
     UUID_PATTERN = (
         r'[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'
     )
@@ -1517,6 +1525,17 @@ class InjectionConfig:
 
     XXE_CONTENT_TYPES = ("application/xml", "text/xml")
 
+    # An endpoint that accepts XML *as a file* rejects it as a body. Juice
+    # Shop's /file-upload answers 400 to a raw XML post and parses the same
+    # payload happily when it arrives as an attachment, and both of its XXE
+    # challenges live there. Real ones look the same: SVG, DOCX and XLSX are
+    # zipped XML, SAML assertions and sitemap imports are XML uploads.
+    #
+    # Extensions, because servers route on them. The field name is the one
+    # nearly every upload form uses; a wrong guess costs one 400.
+    XXE_UPLOAD_FILENAMES = ("xxe.xml", "xxe.svg")
+    XXE_UPLOAD_FIELD = "file"
+
     XXE_PAYLOAD = (
         '<?xml version="1.0"?>'
         '<!DOCTYPE foo [<!ENTITY xxe SYSTEM "file:///etc/passwd">]>'
@@ -2817,11 +2836,11 @@ class FileUploadConfig:
     CONFIDENCE_UNRESTRICTED = 0.85
     CONFIDENCE_PATH_TRAVERSAL = 0.90
 
-    # Endpoint indicators for file upload
-    UPLOAD_PATH_INDICATORS = (
-        "/upload", "/file", "/media", "/attachment",
-        "/image", "/avatar", "/document", "/import",
-    )
+    # Endpoint indicators for file upload. Shared, because an upload is a
+    # delivery mechanism rather than a vulnerability class: the injection
+    # scanner needs to know an endpoint takes files so it can post its XML
+    # payload as one.
+    UPLOAD_PATH_INDICATORS = SharedPatterns.UPLOAD_PATH_INDICATORS
     UPLOAD_CONTENT_TYPES = ("multipart/form-data",)
 
     # Dangerous file types to test: (extension, content_type, payload)

--- a/isitsecure/engine/scanners/active_injection_scanner.py
+++ b/isitsecure/engine/scanners/active_injection_scanner.py
@@ -25,6 +25,7 @@ import httpx
 from isitsecure.engine.constants import (
     DeepScanConfig,
     InjectionConfig,
+    SharedPatterns,
     TemplateInjectionConfig,
 )
 from isitsecure.engine.models import (
@@ -683,24 +684,80 @@ class ActiveInjectionScanner(AuthAwareScanner):
         client: RateLimitedClient,
         endpoint: DiscoveredEndpoint,
     ) -> DeepFinding | None:
-        """Test if an endpoint accepting XML is vulnerable to XXE injection.
+        """Test if an endpoint is vulnerable to XXE injection.
 
-        Only tests endpoints that accept XML content types. Sends a payload
-        with an external entity referencing /etc/passwd and checks the
-        response for file-system content indicators.
+        The payload carries an external entity referencing /etc/passwd; a
+        response echoing file-system content is the proof.
+
+        It is delivered two ways, because an endpoint that accepts XML as a
+        *file* rejects it as a body. Juice Shop's /file-upload answers 400 to
+        a raw XML post and parses the very same payload when it arrives as an
+        attachment — and both of its XXE challenges live there. That shape is
+        not a quirk: SVG, DOCX and XLSX are zipped XML, and SAML assertions
+        and sitemap imports arrive as uploads too, so an XXE probe that only
+        posts raw bodies misses the class.
         """
-        # Pre-check: probe with OPTIONS or HEAD to see if XML is accepted
-        accepts_xml = await self._endpoint_accepts_xml(client, endpoint)
-        if not accepts_xml:
+        # The body probe keeps its existing gate: an endpoint that advertises
+        # no XML and is not a POST is not worth a raw XML body.
+        if await self._endpoint_accepts_xml(client, endpoint):
+            finding = await self._probe_xxe(
+                client, endpoint, self._xxe_bodies(), "raw XML body"
+            )
+            if finding:
+                return finding
+
+        return await self._probe_xxe(
+            client, endpoint, self._xxe_uploads(endpoint), "uploaded file"
+        )
+
+    @staticmethod
+    def _xxe_bodies() -> list[dict]:
+        """XXE delivered as the request body, one per XML content type."""
+        return [
+            {"content": InjectionConfig.XXE_PAYLOAD,
+             "headers": {"Content-Type": content_type}}
+            for content_type in InjectionConfig.XXE_CONTENT_TYPES
+        ]
+
+    @staticmethod
+    def _xxe_uploads(endpoint: DiscoveredEndpoint) -> list[dict]:
+        """XXE delivered as an uploaded file, on endpoints that take files.
+
+        Only upload-shaped paths, so an ordinary API endpoint is not sent a
+        multipart body it never asked for. Servers route on the extension,
+        so each candidate filename is its own attempt.
+        """
+        path = urlparse(endpoint.url).path.lower()
+        if not any(
+            indicator in path
+            for indicator in SharedPatterns.UPLOAD_PATH_INDICATORS
+        ):
+            return []
+        return [
+            {"files": {
+                InjectionConfig.XXE_UPLOAD_FIELD: (
+                    filename, InjectionConfig.XXE_PAYLOAD, content_type,
+                )
+            }}
+            for filename in InjectionConfig.XXE_UPLOAD_FILENAMES
+            for content_type in InjectionConfig.XXE_CONTENT_TYPES[:1]
+        ]
+
+    async def _probe_xxe(
+        self,
+        client: RateLimitedClient,
+        endpoint: DiscoveredEndpoint,
+        attempts: list[dict],
+        delivery: str,
+    ) -> DeepFinding | None:
+        """Send each XXE attempt and look for file content in the response."""
+        if not attempts:
             return None
 
-        for content_type in InjectionConfig.XXE_CONTENT_TYPES:
+        for attempt in attempts:
             try:
                 response = await client.request(
-                    "POST",
-                    endpoint.url,
-                    content=InjectionConfig.XXE_PAYLOAD,
-                    headers={"Content-Type": content_type},
+                    "POST", endpoint.url, **attempt
                 )
                 body = response.text
             except (httpx.HTTPError, Exception):
@@ -731,7 +788,7 @@ class ActiveInjectionScanner(AuthAwareScanner):
                         ),
                         technical_detail=(
                             f"Matched file-system indicator: {match.group(0)} | "
-                            f"Content-Type used: {content_type}"
+                            f"Delivered as: {delivery}"
                         ),
                         evidence=body[:500],
                         confidence=InjectionConfig.CONFIDENCE_XXE,

--- a/tests/engine/test_injection_scanner.py
+++ b/tests/engine/test_injection_scanner.py
@@ -763,3 +763,136 @@ class TestAuthBypassSQLi:
         eps = [_make_endpoint(url="https://app.example.com/rest/products/search")]
         assert scanner._derive_base_url(eps) == "https://app.example.com"
         assert scanner._derive_base_url([]) is None
+
+
+# ---------------------------------------------------------------------------
+# XXE delivery (#188)
+# ---------------------------------------------------------------------------
+
+
+class TestXXEDelivery:
+    """How the XXE payload reaches the parser.
+
+    An endpoint that accepts XML as a *file* rejects it as a body. Juice
+    Shop's /file-upload answers 400 to a raw XML post and parses the same
+    payload when it arrives as an attachment; both of its XXE challenges are
+    there. SVG, DOCX and XLSX are zipped XML, so the shape is common.
+    """
+
+    @staticmethod
+    def _endpoint(path: str) -> DiscoveredEndpoint:
+        return DiscoveredEndpoint(
+            url=f"https://example.com{path}",
+            method=EndpointMethod.POST,
+            source_pattern="test",
+        )
+
+    def test_an_upload_path_is_probed_as_a_file(self) -> None:
+        scanner = ActiveInjectionScanner()
+        attempts = scanner._xxe_uploads(self._endpoint("/file-upload"))
+
+        assert attempts, "an upload endpoint must get a multipart attempt"
+        for attempt in attempts:
+            assert "files" in attempt
+            field, (filename, payload, _) = next(iter(attempt["files"].items()))
+            assert field == InjectionConfig.XXE_UPLOAD_FIELD
+            assert payload == InjectionConfig.XXE_PAYLOAD
+            assert filename in InjectionConfig.XXE_UPLOAD_FILENAMES
+
+    def test_extensions_are_varied(self) -> None:
+        """Servers route on the extension, so one filename is not enough."""
+        scanner = ActiveInjectionScanner()
+        names = {
+            next(iter(a["files"].values()))[0]
+            for a in scanner._xxe_uploads(self._endpoint("/upload"))
+        }
+        assert len(names) > 1
+
+    def test_an_ordinary_endpoint_gets_no_multipart_body(self) -> None:
+        """A path that takes no files should not be sent one."""
+        scanner = ActiveInjectionScanner()
+        assert scanner._xxe_uploads(self._endpoint("/api/Products")) == []
+
+    def test_the_body_probe_is_unchanged(self) -> None:
+        """The raw-body delivery keeps its content types; this adds a
+        delivery rather than replacing one."""
+        scanner = ActiveInjectionScanner()
+        attempts = scanner._xxe_bodies()
+
+        assert len(attempts) == len(InjectionConfig.XXE_CONTENT_TYPES)
+        for attempt in attempts:
+            assert attempt["content"] == InjectionConfig.XXE_PAYLOAD
+            assert attempt["headers"]["Content-Type"] in (
+                InjectionConfig.XXE_CONTENT_TYPES
+            )
+
+    @pytest.mark.asyncio
+    async def test_file_content_in_the_response_is_the_proof(self) -> None:
+        """The finding is raised on /etc/passwd coming back, not on a status
+        code — the endpoint answers 500 while leaking the file."""
+        scanner = ActiveInjectionScanner()
+        leaked = (
+            "Error: deprecated: <root>root:x:0:0:root:/root:/sbin/nologin"
+            "</root>"
+        )
+        client = AsyncMock()
+        client.request.return_value = _make_response(500, leaked)
+
+        finding = await scanner._probe_xxe(
+            client,
+            self._endpoint("/file-upload"),
+            scanner._xxe_uploads(self._endpoint("/file-upload")),
+            "uploaded file",
+        )
+
+        assert finding is not None
+        assert finding.title == InjectionConfig.TITLE_XXE
+        assert "uploaded file" in finding.technical_detail
+
+    @pytest.mark.asyncio
+    async def test_a_clean_response_raises_nothing(self) -> None:
+        scanner = ActiveInjectionScanner()
+        client = AsyncMock()
+        client.request.return_value = _make_response(200, '{"ok": true}')
+
+        finding = await scanner._probe_xxe(
+            client,
+            self._endpoint("/file-upload"),
+            scanner._xxe_uploads(self._endpoint("/file-upload")),
+            "uploaded file",
+        )
+        assert finding is None
+
+    @pytest.mark.asyncio
+    async def test_an_upload_is_probed_even_when_recorded_as_get(self) -> None:
+        """The end-to-end path, and the real-world case: discovery records
+        almost every endpoint as GET, so the body probe declines it — the
+        upload delivery has to run regardless of the recorded method."""
+        scanner = ActiveInjectionScanner()
+        endpoint = DiscoveredEndpoint(
+            url="https://example.com/file-upload",
+            method=EndpointMethod.GET,
+            source_pattern="test",
+        )
+        leaked = "<root>root:x:0:0:root:/root:/sbin/nologin</root>"
+        client = AsyncMock()
+        client.request.return_value = _make_response(500, leaked)
+
+        finding = await scanner._test_xxe_injection(client, endpoint)
+
+        assert finding is not None, (
+            "a GET-recorded upload endpoint must still be probed as a file"
+        )
+        assert "uploaded file" in finding.technical_detail
+
+    @pytest.mark.asyncio
+    async def test_no_attempts_means_no_requests(self) -> None:
+        scanner = ActiveInjectionScanner()
+        client = AsyncMock()
+
+        finding = await scanner._probe_xxe(
+            client, self._endpoint("/api/Products"), [], "uploaded file"
+        )
+
+        assert finding is None
+        client.request.assert_not_called()


### PR DESCRIPTION
Closes #188. **The benchmark number does not move** — see the last section, which is the point of the PR as much as the fix is.

## The bug

The XXE probe posted its payload one way: a request body with an XML content type. An endpoint that accepts XML *as a file* rejects exactly that. Verified by hand against Juice Shop v20.1.1:

```
POST /file-upload  Content-Type: application/xml   -> 400
POST /file-upload  multipart with an .xml file     -> parses it
```

And the parse leaks:

```
Error: ...deprecated...: <root>root:x:0:0:root:/root:/sbin/nologin...</root>
```

The shape is common, not a Juice Shop quirk: SVG, DOCX and XLSX are zipped XML; SAML assertions and sitemap imports arrive as uploads.

## The fix

The payload is delivered twice. The body probe is untouched, gate and all. The upload probe posts it as a multipart file part on upload-shaped paths, under two extensions because servers route on them.

It deliberately **ignores the recorded HTTP method** — discovery records nearly every endpoint as GET, so gating on POST would skip exactly the endpoints that take files. `UPLOAD_PATH_INDICATORS` moves to `SharedPatterns`, since an upload is a delivery mechanism rather than a vulnerability class and two scanners now need to recognise one.

Through the scanner, on the real endpoint:

```
active_injection on /file-upload: 2 finding(s)
   - XML External Entity (XXE) injection vulnerability
```

Title and endpoint both match the benchmark's `xxe` signature.

## Why the benchmark still reads xxe 0/2

`/file-upload` ranks **73rd of 77** in the injection scanner's priority order, and the scanner tests the top 30:

```
testable 77, tested 30 (cap 30)
/file-upload in the tested set : False
its rank among testable        : 73
```

The prioritizer scores on path and query parameters. An upload endpoint has neither *by construction* — the payload is the file — so the signal that makes it look least interesting is the same one that makes it an upload endpoint.

That's a defect in ranking shared by several scanners, so it's filed as **#191** rather than bolted on here. Fixing it would move `xxe`, and possibly the SSRF Cross-Site Imaging challenge at the same endpoint.

## Verification

Suite **2448 passed**. Benchmarks unchanged: juiceshop 24/45, juiceshop-auth 27/45, `file_upload` 4/4 in both, sast-injection 46/46 with 0 FP.

Two mutations caught gaps in my own tests while writing them: removing the upload delivery from `_test_xxe_injection` passed until I added an end-to-end test, which now also pins the GET-recorded case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EZ4QoTqRoYWE25CNoV2Wfy