### PR TITLE
fix(dast): rank file uploads for injection, which have no parameters to score

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -46,6 +46,8 @@ This matters because SPAs hide their API surface in JavaScript bundles, server-r
 
 **Endpoint prioritization + time budget** — before the DAST scanners run, a shared prioritizer (`endpoint_prioritizer.rank()`) scores endpoints per attack dimension (INJECTION, IDOR, XSS, CSRF, AUTH) so the most likely-vulnerable endpoints are tested first. Each scanner then works within a per-scanner `TimeBudget`, checking `budget.expired()` between endpoints so high-risk paths get covered before the external hard timeout cancels the scanner. The injection, XSS, IDOR, CSRF, auth-bypass, and HTTP-probe scanners all use this shared prioritizer.
 
+Ranking has to account for injection that arrives somewhere other than a parameter. A file upload takes no query string, no path parameter and no body field — its payload *is* the file — so every parameter-shaped signal scores it zero and a cap of 30 never reaches it. `EndpointCategory.FILE_ACCESS` therefore counts toward the INJECTION dimension: on Juice Shop that moved `/file-upload` from 73rd of 77 to 6th, and with it the two XXE vulnerabilities behind it.
+
 ### Phase 3: Authenticated Crawl
 
 If credentials are provided:

--- a/docs/scanners/active-injection-scanner.md
+++ b/docs/scanners/active-injection-scanner.md
@@ -23,7 +23,7 @@ Tests for server-side injection vulnerabilities by sending payloads to API endpo
 
 6. **SSTI (Server-Side Template Injection)** — Sends `{{7*7}}` and checks if `49` appears in the response, indicating template evaluation.
 
-Each payload is injected into **path parameters** (templated `{id}`-style segments), **query parameters**, and **JSON body fields** — not just the query string — so injection in REST-style path components is covered. Endpoints are ranked by a shared prioritizer so the most likely-injectable ones are tested first within the scanner's time budget.
+Each payload is injected into **path parameters** (templated `{id}`-style segments), **query parameters**, and **JSON body fields** — not just the query string — so injection in REST-style path components is covered. Endpoints are ranked by a shared prioritizer so the most likely-injectable ones are tested first within the scanner's time budget. File-upload endpoints rank high despite having no parameters at all: their payload is the file, which is where XXE and traversal filenames arrive.
 
 All payloads are **read-only** — no data modification or exfiltration is attempted.
 

--- a/isitsecure/engine/shared/endpoint_prioritizer.py
+++ b/isitsecure/engine/shared/endpoint_prioritizer.py
@@ -72,6 +72,16 @@ def score(ep: DiscoveredEndpoint, dimension: PriorityDimension) -> int:
             s += 3
         if method in _STATE_METHODS:
             s += 1  # body injection surface
+        if ep.category is EndpointCategory.FILE_ACCESS:
+            # Not every injection arrives in a parameter. A file upload's
+            # payload *is* the body — XXE through an uploaded .xml, traversal
+            # through a filename — so it takes no parameters by construction,
+            # and every signal above reads that as nothing to test.
+            #
+            # Juice Shop's /file-upload scored zero and ranked 73rd of 77
+            # against a cap of 30, so the two XXE vulnerabilities behind it
+            # were unreachable however good the probe was.
+            s += 3
 
     elif dimension is PriorityDimension.IDOR:
         # Object-level access control needs an object id and matters most on

--- a/tests/engine/test_endpoint_prioritizer.py
+++ b/tests/engine/test_endpoint_prioritizer.py
@@ -43,6 +43,58 @@ class TestInjectionDimension:
         assert "http://x/rest/products/search" in top
 
 
+class TestInjectionReachesFileUploads:
+    """A file upload takes no parameters, and that is not a reason to skip it.
+
+    Its payload *is* the body — XXE through an uploaded .xml, traversal
+    through a filename — so every parameter-shaped signal reads it as nothing
+    to test. Juice Shop's /file-upload scored zero and ranked 73rd of 77
+    against a cap of 30, which made the two XXE vulnerabilities behind it
+    unreachable however good the probe was.
+    """
+
+    def test_an_upload_outranks_a_bare_collection(self):
+        upload = _ep("http://x/file-upload", category=EndpointCategory.FILE_ACCESS)
+        bare = _ep("http://x/api/Products")
+        assert score(upload, PriorityDimension.INJECTION) > score(
+            bare, PriorityDimension.INJECTION
+        )
+
+    def test_an_upload_survives_a_realistic_cap(self):
+        """The regression this guards: buried past every parameterless
+        neighbour, so a cap of 30 never reaches it."""
+        crowd = [_ep(f"http://x/api/Thing{i}") for i in range(60)]
+        upload = _ep("http://x/file-upload", category=EndpointCategory.FILE_ACCESS)
+        ranked = rank([*crowd, upload], PriorityDimension.INJECTION)
+
+        assert upload in ranked[:30]
+
+    def test_a_parameterised_endpoint_still_outranks_nothing(self):
+        """Widening reach must not demote the parameter surface injection
+        actually lives in."""
+        searchy = _ep("http://x/rest/products/search", query_params=["q"])
+        upload = _ep("http://x/file-upload", category=EndpointCategory.FILE_ACCESS)
+        assert score(searchy, PriorityDimension.INJECTION) > score(
+            upload, PriorityDimension.INJECTION
+        )
+
+    def test_other_dimensions_are_untouched(self):
+        """Only injection changed; a file endpoint must not start
+        outranking an id-bearing resource for IDOR."""
+        upload = _ep("http://x/file-upload", category=EndpointCategory.FILE_ACCESS)
+        owned = _ep(
+            "http://x/api/Users/1", path_params=True,
+            category=EndpointCategory.USER_DATA, requires_auth=True,
+        )
+        for dimension in (
+            PriorityDimension.IDOR,
+            PriorityDimension.XSS,
+            PriorityDimension.CSRF,
+            PriorityDimension.AUTH,
+        ):
+            assert score(owned, dimension) >= score(upload, dimension), dimension
+
+
 class TestIdorDimension:
     def test_id_bearing_sensitive_resource_ranks_first(self):
         eps = [


### PR DESCRIPTION
Closes #191. **xxe 0/2 → 2/2**, and the XXE work from v0.24.1 finally pays out.

## The bug

The injection prioritizer scores what injection usually rides on: query parameters, path parameters, search-shaped path words, body-capable methods. A file upload has **none of them** — its payload is the file — so it scores zero and sorts below every parameterless neighbour.

```
/file-upload rank: 73 of 77   (cap 30)  →  never tested
```

The XXE probe shipped in v0.24.1 worked when pointed at that endpoint directly and never ran during a scan. The signal that made it look least interesting is the same one that makes it a file upload.

## The fix

`EndpointCategory.FILE_ACCESS` now counts toward the INJECTION dimension.

```
/file-upload rank: 73  →  6
```

The **category** is used rather than another list of path words, because ingestion already classifies endpoints and the prioritizer's stated design is that its signals are generic conventions rather than strings someone thought of in advance. `FILE_ACCESS` is exactly that classification, already computed.

## Results

| Juice Shop | before | after |
|---|---|---|
| url-only | 24/45 (53%) | **26/45 (58%)** |
| authenticated | 27/45 (60%) | **29/45 (64%)** |
| xxe | 0/2 | **2/2** |

## No collateral

`rank()` is shared, so every target was re-run:

- `idor` 2/5 url-only and 4/5 authenticated — unchanged
- `xss` 1/7 and 2/7 — unchanged
- `file_upload` 4/4 — unchanged
- vampi-vulnerable 3/3 — unchanged
- vampi-secure — same two pre-existing IDOR false positives
- sast-injection 46/46, 0 FP — unchanged

Only `active_injection_scanner` requests the INJECTION dimension, so the blast radius is one scanner. The other four dimensions are untouched, and a test pins that an id-bearing resource still outranks a file endpoint for IDOR/XSS/CSRF/AUTH.

Suite **2452 passed**. Removing the new score fails two tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EZ4QoTqRoYWE25CNoV2Wfy