### PR TITLE
feat(dast): scan every endpoint, bounded by time rather than by a fixed count

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -304,6 +304,40 @@ paths and discarded `/file-upload`, `/dataerasure`, `/profile` and
 so the four file-upload vulnerabilities behind `/file-upload` were unreachable
 no matter how good the file-upload scanner was.
 
+### Coverage limits
+
+Scanners used to stop after a fixed number of endpoints — 20 for XSS, 30 for
+injection, 5 for CORS. Against an app with 77 endpoints those caps decided
+which quarter got examined, in ranked order, and nothing said so.
+
+They are gone. Probing costs HTTP requests rather than tokens: measured over
+nine scans, a DAST run costs $0.12–$0.18 whether it covers 59 endpoints or
+154, while a SAST run is a flat ~$1.28 because its cost is the LLM reading
+files. The endpoint was never the scarce thing.
+
+What bounds a scan now is **time**, per scanner, via `TimeBudget` — raised
+accordingly, since timing out should mean something is wrong rather than that
+the app was large. A scan that takes half an hour and finishes beats one that
+takes ten minutes having skipped two thirds of the surface, provided it says
+what it is doing: every scanner that walks endpoints emits per-endpoint
+progress, so a long run is legible rather than silent.
+
+Two caps remain because they bound something genuinely scarce:
+`MAX_ENDPOINTS_IN_PROMPT` (LLM tokens) and `MAX_OOB_POST_ENDPOINTS`
+(registrations against an external callback service).
+
+### Testing the mutation surface
+
+`--probe-writes` derives state-changing endpoints from REST shape — POST to a
+collection, PUT to an item — because a path in a JS bundle carries no method,
+so everything is otherwise discovered as a GET and scanners filtering on
+POST/PUT find nothing to do. Stored XSS, mass assignment and CSRF all live
+behind that filter.
+
+It is off by default: it makes a scan write to whatever it is pointed at.
+DELETE is derived and deliberately never emitted — a scanner that destroys a
+record to prove it could is not worth the finding.
+
 ## Design Principles
 
 ### Protocol-Based (Dependency Inversion)

--- a/isitsecure/cli/main.py
+++ b/isitsecure/cli/main.py
@@ -292,6 +292,16 @@ def scan(
     github_token: Optional[str] = typer.Option(None, "--github-token", envvar="GITHUB_TOKEN"),
     mode: str = typer.Option("auto", "--mode", "-m", help="Scan mode: auto|url-only|code-only|authenticated|full"),
     depth: str = typer.Option("quick", "--depth", help="Scan depth: quick (fast, default) | deep (adds time-based SQLi, active XSS, and other slow/aggressive probes)"),
+    probe_writes: bool = typer.Option(
+        False, "--probe-writes",
+        help=(
+            "Test the mutation surface: derive POST/PUT endpoints from REST "
+            "shape so stored XSS, mass assignment and CSRF can be reached. "
+            "The scan WRITES to the target — records created, notifications "
+            "possibly sent. Use on an app you own or have authorization to "
+            "test, not blindly against production."
+        ),
+    ),
     auth_email: Optional[str] = typer.Option(None, "--auth-email", help="Auth email/username for authenticated scanning (user A)"),
     auth_password: Optional[str] = typer.Option(None, "--auth-password", help="Auth password (user A)"),
     auth_email_b: Optional[str] = typer.Option(None, "--auth-email-b", help="Second user's email/username — enables cross-user IDOR testing"),
@@ -366,6 +376,7 @@ def scan(
         judgment_llm_client=judgment_llm_client,
         repo_ingestion_service=repo_service,
         depth=scan_depth,
+        probe_writes=probe_writes,
     )
 
     # Build credentials

--- a/isitsecure/engine/constants.py
+++ b/isitsecure/engine/constants.py
@@ -6,6 +6,21 @@ from isitsecure.engine.enums import FindingCategory, SeverityLevel
 class SharedPatterns:
     """Shared regex patterns and constants used across multiple scanners."""
 
+    # Endpoint caps used to bound probing. They are gone, because the thing
+    # they were protecting is not scarce: measured over nine scans, a DAST
+    # run costs $0.12-$0.18 and probing is HTTP requests, not tokens. Going
+    # from 59 endpoints to 154 moved the bill by five cents, and every one of
+    # those caps silently decided which half of an application was examined —
+    # a cap of 30 against 77 endpoints is a coin flip about what gets found.
+    #
+    # What still bounds a scan is time, per scanner, via TimeBudget. That
+    # bound is honest: it stops work when work is taking too long, rather
+    # than pretending the first 30 endpoints are the interesting ones.
+    #
+    # Caps on LLM prompt size and on out-of-band registrations are NOT this
+    # and remain: those bound tokens and an external service, both scarce.
+    UNBOUNDED_ENDPOINTS = 1_000_000
+
     # Directories that hold someone else's code or build output. Several
     # scanners walk a repo and every one of them needs this list; keeping one
     # copy is why it lives here rather than beside each walker.
@@ -95,7 +110,14 @@ class DeepScanConfig:
 class EndpointDiscoveryConfig:
     """Configuration for API endpoint discovery from JS bundles."""
 
-    MAX_ENDPOINTS_TO_DISCOVER = 100
+    MAX_ENDPOINTS_TO_DISCOVER = SharedPatterns.UNBOUNDED_ENDPOINTS
+
+    # The cap above bounds how many endpoints are *found*; these are then
+    # multiplied along two derived axes — an /{id} twin per collection, and
+    # a state-changing twin per endpoint when --probe-writes is on. Bounding
+    # the total instead starved the derived ones, which are generated last
+    # and so were truncated first. This is the ceiling on the product.
+    MAX_ENDPOINTS_TOTAL = MAX_ENDPOINTS_TO_DISCOVER * 4
     # Server-rendered HTML crawl: only triggered when JS/OpenAPI discovery
     # found few endpoints, and bounded to a small number of same-origin pages.
     HTML_CRAWL_TRIGGER = 10
@@ -261,7 +283,7 @@ class EndpointDiscoveryConfig:
 class IDORConfig:
     """Configuration for IDOR vulnerability testing."""
 
-    MAX_ENDPOINTS_TO_TEST = 50
+    MAX_ENDPOINTS_TO_TEST = SharedPatterns.UNBOUNDED_ENDPOINTS
     MAX_IDOR_PROBES_PER_ENDPOINT = 5
     HTTP_TIMEOUT_SECONDS = SharedPatterns.DEFAULT_HTTP_TIMEOUT_SECONDS
     MAX_CONCURRENT_PROBES = SharedPatterns.DEFAULT_MAX_CONCURRENT
@@ -1131,7 +1153,7 @@ class XSSConfig:
     """Configuration for active XSS scanning."""
 
     SCANNER_NAME = "xss_scanner"
-    MAX_ENDPOINTS_TO_TEST = 20
+    MAX_ENDPOINTS_TO_TEST = SharedPatterns.UNBOUNDED_ENDPOINTS
     MAX_PARAMS_PER_ENDPOINT = 5
     HTTP_TIMEOUT_SECONDS = 10
     MAX_CONCURRENT = SharedPatterns.DEFAULT_MAX_CONCURRENT
@@ -1253,7 +1275,7 @@ class XSSConfig:
     )
 
     # POST body XSS testing
-    MAX_POST_ENDPOINTS_TO_TEST = 15
+    MAX_POST_ENDPOINTS_TO_TEST = SharedPatterns.UNBOUNDED_ENDPOINTS
     MAX_POST_BODY_FIELDS = 25  # cap canaried fields per endpoint (bounds body size)
     # Fallback field names when an endpoint carried no discovered form fields.
     POST_BODY_FIELD_NAMES = (
@@ -1393,7 +1415,7 @@ class InjectionConfig:
     """Configuration for active injection scanning."""
 
     SCANNER_NAME = "active_injection_scanner"
-    MAX_ENDPOINTS_TO_TEST = 30
+    MAX_ENDPOINTS_TO_TEST = SharedPatterns.UNBOUNDED_ENDPOINTS
     MAX_PARAMS_PER_ENDPOINT = 5
     HTTP_TIMEOUT_SECONDS = 15
     MAX_CONCURRENT = SharedPatterns.DEFAULT_MAX_CONCURRENT
@@ -1604,7 +1626,7 @@ class CSRFConfig:
     """Configuration for CSRF scanning."""
 
     SCANNER_NAME = "csrf_scanner"
-    MAX_ENDPOINTS_TO_TEST = 30
+    MAX_ENDPOINTS_TO_TEST = SharedPatterns.UNBOUNDED_ENDPOINTS
     HTTP_TIMEOUT_SECONDS = 10
 
     CONFIDENCE_NO_CSRF_TOKEN = 0.85
@@ -1861,10 +1883,10 @@ class PrivilegeEscalationConfig:
     JSON_RECORD_KEYS = ("data", "result", "results", "items")
 
     # Limits
-    MAX_AUTH_ENDPOINTS_TO_TEST = 30
+    MAX_AUTH_ENDPOINTS_TO_TEST = SharedPatterns.UNBOUNDED_ENDPOINTS
     MAX_MUTATIONS_TO_REPLAY = 20
     MAX_RESOURCES_FOR_WRITE_TEST = 15
-    MAX_DIFFERENTIAL_ENDPOINTS = 20
+    MAX_DIFFERENTIAL_ENDPOINTS = SharedPatterns.UNBOUNDED_ENDPOINTS
 
     # Differential response thresholds
     DIFFERENTIAL_SIZE_RATIO = 1.5  # Admin response 50%+ larger → suspicious
@@ -6272,7 +6294,7 @@ class SecurityHeadersScannerConfig:
     REQUEST_DELAY_SECONDS = 0.3
 
     # Maximum number of representative endpoints to test
-    MAX_ENDPOINTS_TO_TEST = 5
+    MAX_ENDPOINTS_TO_TEST = SharedPatterns.UNBOUNDED_ENDPOINTS
 
     # --- Header names ---
     HEADER_HSTS = "strict-transport-security"
@@ -6395,7 +6417,7 @@ class CORSConfig:
     HTTP_TIMEOUT_SECONDS = SharedPatterns.DEFAULT_HTTP_TIMEOUT_SECONDS
     MAX_CONCURRENT = SharedPatterns.DEFAULT_MAX_CONCURRENT
     PROBE_DELAY = SharedPatterns.DEFAULT_PROBE_DELAY
-    MAX_ENDPOINTS_TO_TEST = 5
+    MAX_ENDPOINTS_TO_TEST = SharedPatterns.UNBOUNDED_ENDPOINTS
     PATH_PREFIX_DEPTH = 2
 
     # CORS response header names
@@ -6553,7 +6575,7 @@ class AuthBypassConfig:
     RESPONSE_BODY_PREVIEW_LENGTH = 500
 
     # Maximum protected endpoints to test for auth header bypass
-    MAX_AUTH_BYPASS_ENDPOINTS = 5
+    MAX_AUTH_BYPASS_ENDPOINTS = SharedPatterns.UNBOUNDED_ENDPOINTS
 
     # Lockout testing
     LOCKOUT_ATTEMPT_COUNT = 10
@@ -6713,10 +6735,10 @@ class HTTPProbeConfig:
 
     SCANNER_NAME = "http_probe_scanner"
 
-    MAX_ENDPOINTS_TO_TEST = 5
+    MAX_ENDPOINTS_TO_TEST = SharedPatterns.UNBOUNDED_ENDPOINTS
     MAX_CONCURRENT = 3
     PROBE_DELAY = 0.2
-    MAX_METHOD_TEST_ENDPOINTS = 3
+    MAX_METHOD_TEST_ENDPOINTS = SharedPatterns.UNBOUNDED_ENDPOINTS
 
     # --- Method tampering ---
     DANGEROUS_METHODS = ("TRACE", "CONNECT")
@@ -6861,7 +6883,7 @@ class TemplateInjectionConfig:
         ("{{7*'7'}}", "7777777", "Jinja2 string multiplication"),
     )
 
-    MAX_ENDPOINTS_TO_TEST = 10
+    MAX_ENDPOINTS_TO_TEST = SharedPatterns.UNBOUNDED_ENDPOINTS
     MAX_PARAMS_PER_ENDPOINT = 3
 
     CONFIDENCE_SSTI = 0.90

--- a/isitsecure/engine/factory.py
+++ b/isitsecure/engine/factory.py
@@ -223,6 +223,7 @@ def create_deep_security_scan_agent(
     repo_ingestion_service=None,
     auth_provider: AuthProviderProtocol | None = None,
     depth: ScanDepth = ScanDepth.QUICK,
+    probe_writes: bool = False,
 ) -> DeepSecurityScanAgent:
     """Create a fully wired DeepSecurityScanAgent with all scanners.
 
@@ -339,7 +340,7 @@ def create_deep_security_scan_agent(
     return DeepSecurityScanAgent(
         # Required
         ingestion_service=URLIngestionService(),
-        endpoint_scanner=EndpointDiscoveryScanner(),
+        endpoint_scanner=EndpointDiscoveryScanner(probe_writes=probe_writes),
         # Scanner lists (OCP)
         dast_scanners=dast_scanners,
         sast_scanners=sast_scanners,

--- a/isitsecure/engine/scanners/cors_scanner.py
+++ b/isitsecure/engine/scanners/cors_scanner.py
@@ -13,6 +13,7 @@ import logging
 from urllib.parse import urlparse
 
 from isitsecure.engine.constants import CORSConfig, DeepScanConfig
+from isitsecure.engine.shared.progress import emit
 from isitsecure.engine.models import (
     DASTProbeCaptureEntry,
     DeepFinding,
@@ -76,7 +77,10 @@ class CORSScanner(AuthAwareScanner):
             user_agent=DeepScanConfig.USER_AGENT,
             extra_headers=self.auth_headers,
         ) as client:
-            for ep in representative:
+            for tested, ep in enumerate(representative):
+                emit(
+                    f"CORS: probing {tested + 1}/{len(representative)} {ep.url}"
+                )
                 ep_findings = await self._test_endpoint(client, ep)
                 findings.extend(ep_findings)
 

--- a/isitsecure/engine/scanners/csrf_scanner.py
+++ b/isitsecure/engine/scanners/csrf_scanner.py
@@ -13,6 +13,7 @@ import re
 from http.cookies import SimpleCookie
 
 from isitsecure.engine.constants import CSRFConfig, DeepScanConfig
+from isitsecure.engine.shared.progress import emit
 from isitsecure.engine.models import (
     DeepFinding,
     DiscoveredEndpoint,
@@ -106,7 +107,14 @@ class CSRFScanner(AuthAwareScanner):
             user_agent=DeepScanConfig.USER_AGENT,
             extra_headers=self.auth_headers,
         ) as client:
-            for ep in rank(endpoints, PriorityDimension.CSRF)[: CSRFConfig.MAX_ENDPOINTS_TO_TEST]:
+            ranked = rank(endpoints, PriorityDimension.CSRF)[
+                : CSRFConfig.MAX_ENDPOINTS_TO_TEST
+            ]
+            for tested, ep in enumerate(ranked):
+                emit(
+                    f"CSRF: forged-origin probe {tested + 1}/{len(ranked)} "
+                    f"{ep.method.value} {ep.url}"
+                )
                 finding = await self._test_forged_origin(client, ep)
                 if finding:
                     findings.append(finding)

--- a/isitsecure/engine/scanners/endpoint_discovery.py
+++ b/isitsecure/engine/scanners/endpoint_discovery.py
@@ -53,6 +53,16 @@ class EndpointDiscoveryScanner:
         "delete": EndpointMethod.DELETE,
     }
 
+    def __init__(self, probe_writes: bool = False) -> None:
+        """
+        Args:
+            probe_writes: derive state-changing methods from REST shape, so
+                scanners can reach the mutation surface. Off by default: it
+                makes a scan send POST/PUT/DELETE, which writes to whatever
+                is being scanned.
+        """
+        self._probe_writes = probe_writes
+
     # Routes that are purely frontend pages, not API endpoints
     _SKIP_FRONTEND_ROUTES = {
         "/login", "/register", "/signup", "/signin",
@@ -123,6 +133,13 @@ class EndpointDiscoveryScanner:
             self._detect_parameters(endpoint)
             self._categorize_endpoint(endpoint)
 
+        # The cap bounds how much of the app is discovered, so it applies to
+        # what was found — not to what is derived from it. Appending variants
+        # first and truncating afterwards starved them: they are generated
+        # last, so they were cut first, and the PUT twins of /{id} endpoints
+        # never survived at all.
+        endpoints = endpoints[: EndpointDiscoveryConfig.MAX_ENDPOINTS_TO_DISCOVER]
+
         # Generate /{id} variants for REST collection endpoints so IDOR and
         # per-param injection have object-level targets to test (e.g.
         # /api/Products -> /api/Products/1).
@@ -130,13 +147,25 @@ class EndpointDiscoveryScanner:
             self._categorize_endpoint(variant)
             endpoints.append(variant)
 
+        # Everything above is discovered as a GET, because a path in a bundle
+        # carries no method. That leaves the mutation surface untested by
+        # every scanner: stored XSS, mass assignment, CSRF and the rest live
+        # behind POST and PUT, and a scanner filtering on `method == POST`
+        # finds nothing to do. REST says which methods a shape accepts —
+        # POST to a collection, PUT and DELETE to an item — the same
+        # convention `_build_id_variants` already reads.
+        if self._probe_writes:
+            for variant in self._build_method_variants(endpoints, raw_endpoints):
+                self._categorize_endpoint(variant)
+                endpoints.append(variant)
+
         logger.info(
             "EndpointDiscovery complete: %d unique endpoints from %d bytes of content",
             len(endpoints),
             len(all_content),
         )
         emit(f"discovered {len(endpoints)} endpoint(s)")
-        return endpoints[: EndpointDiscoveryConfig.MAX_ENDPOINTS_TO_DISCOVER]
+        return endpoints[: EndpointDiscoveryConfig.MAX_ENDPOINTS_TOTAL]
 
     # --- Phase 1: Static extraction methods ---
 
@@ -785,6 +814,38 @@ class EndpointDiscoveryScanner:
                     path_param_names=["id"],
                 )
             )
+        return variants
+
+    def _build_method_variants(
+        self,
+        endpoints: list[DiscoveredEndpoint],
+        seen: dict[str, DiscoveredEndpoint],
+    ) -> list[DiscoveredEndpoint]:
+        """State-changing twins of REST-shaped endpoints.
+
+        A collection takes POST; an item takes PUT and DELETE. Both follow
+        from the shape alone, which is why no list of paths is involved.
+
+        DELETE is derived but not emitted. The others write a record that can
+        be inspected and rolled back; DELETE destroys one, and a scanner that
+        deletes a customer's data to prove it could is not worth the finding.
+        """
+        variants: list[DiscoveredEndpoint] = []
+        for ep in endpoints:
+            if ep.method is not EndpointMethod.GET:
+                continue
+            method = (
+                EndpointMethod.PUT if ep.has_path_params
+                else EndpointMethod.POST
+            )
+            key = f"{method.value}:{ep.url}"
+            if key in seen:
+                continue
+            variant = ep.model_copy(
+                update={"method": method, "source_pattern": "rest_method"}
+            )
+            seen[key] = variant
+            variants.append(variant)
         return variants
 
     def _detect_parameters(self, endpoint: DiscoveredEndpoint) -> None:

--- a/isitsecure/engine/scanners/xss_scanner.py
+++ b/isitsecure/engine/scanners/xss_scanner.py
@@ -17,6 +17,7 @@ import uuid
 from urllib.parse import parse_qs, urlencode, urlparse
 
 from isitsecure.engine.constants import DeepScanConfig, XSSConfig
+from isitsecure.engine.shared.progress import emit
 from isitsecure.engine.models import (
     DeepFinding,
     DiscoveredEndpoint,
@@ -304,7 +305,15 @@ class XSSScanner(AuthAwareScanner):
                         "XSSScanner: POST-body budget reached, tested %d/%d endpoints",
                         tested, len(candidates),
                     )
+                    emit(
+                        f"XSS: time budget reached after {tested}/"
+                        f"{len(candidates)} write endpoints"
+                    )
                     break
+                emit(
+                    f"XSS: body probe {tested + 1}/{len(candidates)} "
+                    f"{endpoint.method.value} {urlparse(endpoint.url).path}"
+                )
                 finding = await self._test_single_post_body(client, endpoint)
                 if finding:
                     findings.append(finding)

--- a/isitsecure/engine/shared/scanner_runner.py
+++ b/isitsecure/engine/shared/scanner_runner.py
@@ -10,27 +10,40 @@ logger = logging.getLogger(__name__)
 
 
 class ScannerTimeouts:
-    """Per-scanner timeout configuration."""
+    """Per-scanner timeout configuration.
 
-    DEFAULT_SECONDS = 60
-    AUTHENTICATED_CRAWLER_SECONDS = 300  # Browser login + BFS crawl of 50 pages
-    IDOR_CROSS_USER_SECONDS = 120
-    PRIVILEGE_ESCALATION_SECONDS = 180  # 8 tests: differential, mutation replay, object write, etc.
+    These are now the *only* bound on how much of an application a scanner
+    covers: the endpoint caps that used to stop work after the first 20 or 30
+    endpoints are gone, because probing costs HTTP requests rather than
+    tokens and a cap of 30 against 77 endpoints was a coin flip about which
+    half got examined.
+
+    They are correspondingly generous. A scan that takes an hour and finishes
+    is worth more than one that takes ten minutes and quietly skipped two
+    thirds of the surface — provided it says what it is doing, which is what
+    `progress.emit` is for. Timing out is now a real failure signal rather
+    than the normal way a scanner ends.
+    """
+
+    DEFAULT_SECONDS = 600
+    AUTHENTICATED_CRAWLER_SECONDS = 900  # Browser login + BFS crawl of 50 pages
+    IDOR_CROSS_USER_SECONDS = 1800
+    PRIVILEGE_ESCALATION_SECONDS = 1800  # 8 tests: differential, mutation replay, object write, etc.
     GIT_SECRET_SCAN_SECONDS = 90
     SEMGREP_TAINT_SECONDS = 150  # above SemgrepAnalyzer's own 120s subprocess timeout
     LLM_CODE_REVIEW_SECONDS = 900  # 15 min — reviews in parallel batches (includes import-graph files)
-    LSP_VALIDATION_SECONDS = 120   # 2 min — LSP init + auth flow tracing
+    LSP_VALIDATION_SECONDS = 600   # 2 min — LSP init + auth flow tracing
     TRIAGE_SECONDS = 900           # 15 min — batched LLM triage + themes + owner summary
     INJECTION_ADJUDICATOR_SECONDS = 240  # 4 min — batched LLM genuine-vs-benign injection review (#5)
-    XSS_ACTIVE_SECONDS = 600       # 10 min — 20 endpoints × 5 params × 3 probe stages (deep)
-    XSS_QUICK_SECONDS = 120        # 2 min — reflected + POST-body only, no DOM pass (quick, #118)
-    INJECTION_ACTIVE_SECONDS = 900  # 15 min — 30 endpoints × 5 params, time-based SQLi (3s sleeps)
-    AUTH_BYPASS_SECONDS = 300       # 5 min — multiple login attempts + timing measurements
-    RATE_LIMIT_SECONDS = 300        # 5 min — 100+ burst requests
-    HTTP_PROBE_SECONDS = 180        # 3 min — TRACE, host injection, directory listing, CRLF
+    XSS_ACTIVE_SECONDS = 3600       # 10 min — 20 endpoints × 5 params × 3 probe stages (deep)
+    XSS_QUICK_SECONDS = 900        # 2 min — reflected + POST-body only, no DOM pass (quick, #118)
+    INJECTION_ACTIVE_SECONDS = 5400  # 15 min — 30 endpoints × 5 params, time-based SQLi (3s sleeps)
+    AUTH_BYPASS_SECONDS = 1800       # 5 min — multiple login attempts + timing measurements
+    RATE_LIMIT_SECONDS = 900        # 5 min — 100+ burst requests
+    HTTP_PROBE_SECONDS = 900        # 3 min — TRACE, host injection, directory listing, CRLF
     PROBE_ANALYZER_SECONDS = 30     # Pure data analysis, no HTTP requests
-    GUIDED_DAST_SECONDS = 600       # 10 min — SAST-guided test cases
-    DOM_XSS_SECONDS = 900           # 15 min — Playwright: navigate + hook sinks on up to 30 pages
+    GUIDED_DAST_SECONDS = 1800       # 10 min — SAST-guided test cases
+    DOM_XSS_SECONDS = 1800           # 15 min — Playwright: navigate + hook sinks on up to 30 pages
     OOB_POLL_SECONDS = 30           # OOB callback poll (just HTTP calls, no scanning)
 
 

--- a/tests/engine/test_endpoint_discovery.py
+++ b/tests/engine/test_endpoint_discovery.py
@@ -682,7 +682,14 @@ class TestEndpointDiscoveryScanner:
 
             endpoints = await scanner.discover(js_content, "", BASE_URL)
 
-        assert len(endpoints) <= EndpointDiscoveryConfig.MAX_ENDPOINTS_TO_DISCOVER
+        # MAX_ENDPOINTS_TO_DISCOVER bounds what is *found*; those are then
+        # multiplied along derived axes (an /{id} twin, and a state-changing
+        # twin under --probe-writes), so the product has its own ceiling.
+        # Bounding the total instead truncated the derived endpoints, which
+        # are generated last.
+        found = [e for e in endpoints if e.source_pattern != "id_variant"]
+        assert len(found) <= EndpointDiscoveryConfig.MAX_ENDPOINTS_TO_DISCOVER
+        assert len(endpoints) <= EndpointDiscoveryConfig.MAX_ENDPOINTS_TOTAL
 
     # --- Deduplication ---
 
@@ -898,3 +905,109 @@ class TestOpenAPISpecParsing:
 
     def test_non_json_spec_returns_none(self, scanner):
         assert scanner._try_parse_spec("<html>not json</html>") is None
+
+
+# ---------------------------------------------------------------------------
+# State-changing method variants (opt-in)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def _no_network():
+    """Discovery probes API base URLs over HTTP; these tests are about the
+    static derivation, so the probe is stubbed out rather than waited on."""
+    with patch(
+        "isitsecure.engine.scanners.endpoint_discovery.RateLimitedClient"
+    ) as mock_cls:
+        client = AsyncMock()
+        client.get = AsyncMock(side_effect=httpx.HTTPError("stubbed"))
+        client.__aenter__ = AsyncMock(return_value=client)
+        client.__aexit__ = AsyncMock(return_value=None)
+        mock_cls.return_value = client
+        yield
+
+
+@pytest.mark.usefixtures("_no_network")
+class TestMethodVariants:
+    """Reaching the mutation surface.
+
+    A path in a JS bundle carries no method, so everything is discovered as a
+    GET. Scanners that filter on `method in (POST, PUT, PATCH)` then find
+    nothing to do, which left stored XSS, mass assignment and CSRF untested
+    on every target. REST says which methods a shape accepts.
+
+    Off by default: deriving them makes a scan write to whatever it is
+    pointed at.
+    """
+
+    JS = 'fetch("/api/Products"); fetch("/rest/basket")'
+
+    @pytest.mark.asyncio
+    async def test_off_by_default(self) -> None:
+        eps = await EndpointDiscoveryScanner().discover(self.JS, "", BASE_URL)
+        assert {e.method for e in eps} == {EndpointMethod.GET}
+
+    @pytest.mark.asyncio
+    async def test_a_collection_gains_post(self) -> None:
+        eps = await EndpointDiscoveryScanner(probe_writes=True).discover(
+            self.JS, "", BASE_URL
+        )
+        methods = {
+            e.method for e in eps if e.url.endswith("/api/Products")
+        }
+        assert EndpointMethod.POST in methods
+
+    @pytest.mark.asyncio
+    async def test_an_item_gains_put_not_post(self) -> None:
+        """POST to a collection, PUT to an item — the shape decides."""
+        eps = await EndpointDiscoveryScanner(probe_writes=True).discover(
+            self.JS, "", BASE_URL
+        )
+        methods = {
+            e.method for e in eps if e.url.endswith("/api/Products/1")
+        }
+        assert EndpointMethod.PUT in methods
+        assert EndpointMethod.POST not in methods
+
+    @pytest.mark.asyncio
+    async def test_delete_is_never_derived(self) -> None:
+        """A scanner that deletes a customer's data to prove it could is not
+        worth the finding."""
+        eps = await EndpointDiscoveryScanner(probe_writes=True).discover(
+            self.JS, "", BASE_URL
+        )
+        assert EndpointMethod.DELETE not in {e.method for e in eps}
+
+    @pytest.mark.asyncio
+    async def test_the_get_surface_is_unchanged(self) -> None:
+        """Opting in must add to what is tested, never replace it."""
+        plain = await EndpointDiscoveryScanner().discover(self.JS, "", BASE_URL)
+        writes = await EndpointDiscoveryScanner(probe_writes=True).discover(
+            self.JS, "", BASE_URL
+        )
+        gets = {e.url for e in writes if e.method is EndpointMethod.GET}
+        assert {e.url for e in plain} <= gets
+
+    @pytest.mark.asyncio
+    async def test_variants_are_not_starved_by_the_cap(
+        self, monkeypatch
+    ) -> None:
+        """The regression this guards: the cap applied after variants were
+        appended, so the PUT twins — generated last — were cut first and
+        never survived at all.
+
+        The cap is patched low rather than exceeded, since it is now
+        effectively unbounded and building a million endpoints to prove a
+        point about ordering is its own kind of mistake."""
+        from isitsecure.engine.constants import EndpointDiscoveryConfig
+
+        monkeypatch.setattr(
+            EndpointDiscoveryConfig, "MAX_ENDPOINTS_TO_DISCOVER", 5
+        )
+        many = "".join(f'fetch("/api/Thing{i}");' for i in range(20))
+        eps = await EndpointDiscoveryScanner(probe_writes=True).discover(
+            many, "", BASE_URL
+        )
+        methods = {e.method for e in eps}
+        assert EndpointMethod.POST in methods
+        assert EndpointMethod.PUT in methods

--- a/tests/engine/test_scanner_runner.py
+++ b/tests/engine/test_scanner_runner.py
@@ -98,9 +98,15 @@ class TestRunScannerSafe:
 class TestScannerTimeouts:
     """Tests for ScannerTimeouts constants."""
 
-    def test_default_timeout_value(self) -> None:
-        """Default timeout should be 60 seconds."""
-        assert ScannerTimeouts.DEFAULT_SECONDS == 60
+    def test_default_timeout_is_generous(self) -> None:
+        """Time is the only bound left on coverage, so it is not tight.
+
+        Was 60s, alongside endpoint caps that stopped a scanner after 20 or
+        30 endpoints. With those gone a scanner walks the whole surface, and
+        a minute is no longer the right ceiling — timing out should mean
+        something is wrong, not that the app was large.
+        """
+        assert ScannerTimeouts.DEFAULT_SECONDS >= 300
 
     def test_llm_timeout_is_longest(self) -> None:
         """LLM code review should have the longest timeout."""

--- a/tests/engine/test_xss_scanner.py
+++ b/tests/engine/test_xss_scanner.py
@@ -249,13 +249,19 @@ class TestReflectedXSS:
         assert len(findings) == 0
 
     @pytest.mark.asyncio
-    async def test_respects_max_endpoints(self) -> None:
-        """Should not test more than MAX_ENDPOINTS_TO_TEST endpoints."""
+    async def test_tests_every_endpoint_it_is_given(self) -> None:
+        """No endpoint cap: the bound is the scanner's time budget.
+
+        This asserted a cap of 20, which against an app with 77 endpoints
+        decided which quarter got examined. Probing costs HTTP requests
+        rather than tokens — measured, a DAST scan runs $0.12-$0.18 whether
+        it covers 59 endpoints or 154 — so the endpoint was never the scarce
+        thing being protected.
+        """
         scanner = XSSScanner()
-        # Create more endpoints than the limit
         endpoints = [
             _make_endpoint(url=f"https://example.com/page{i}?q=test")
-            for i in range(XSSConfig.MAX_ENDPOINTS_TO_TEST + 20)
+            for i in range(40)
         ]
 
         call_count = 0
@@ -277,12 +283,9 @@ class TestReflectedXSS:
 
             await scanner.scan(endpoints)
 
-        # Each endpoint with existing query params has 1 param ("q") and
-        # 3 probes per param
-        max_expected_calls = (
-            XSSConfig.MAX_ENDPOINTS_TO_TEST * len(XSSConfig.REFLECTION_PROBES)
-        )
-        assert call_count <= max_expected_calls
+        # One param ("q") per endpoint, one call per reflection probe. Every
+        # endpoint is reached, where a cap of 20 would have stopped halfway.
+        assert call_count == 40 * len(XSSConfig.REFLECTION_PROBES)
 
     @pytest.mark.asyncio
     async def test_handles_request_exception_gracefully(self) -> None:


### PR DESCRIPTION
Scanners stopped after a fixed number of endpoints — 20 for XSS, 30 for injection and CSRF, 5 for CORS and security headers. Against Juice Shop's 77 endpoints those caps decided which **quarter** of the app was examined, in ranked order, and nothing in the report said a limit had been hit.

## The caps guarded something that isn't scarce

Measured over nine scans this session:

| mode | tokens | cost |
|---|---|---|
| DAST url-only ×4 | 17–24k | **$0.12–$0.18** |
| SAST code-only ×5 | 122–126k | **$1.27–$1.30** |

p50 $1.27, p90 $1.30. **DAST cost is flat in endpoint count** — 59 endpoints $0.1233, 154 endpoints $0.1776 — because probing is HTTP requests, not tokens. SAST is flat at ~$1.28 regardless, since its cost is the LLM reading files and no endpoint cap touches it.

Going uncapped on Juice Shop cost **two cents**.

## What changed

- **14 endpoint caps removed.** Time is the only bound left.
- **Budgets raised** to match: default 60s → 600s, injection 900s → 5400s. Timing out now means something is wrong, not that the app was large.
- **Progress emission added** to XSS, CORS and CSRF — they emitted *nothing*, and uncapped would have walked hundreds of endpoints in silence. A 27-minute run produced 121 progress lines, ticking `982.3s · injection: testing /orders` throughout.
- **Two caps kept**: `MAX_ENDPOINTS_IN_PROMPT` (LLM tokens) and `MAX_OOB_POST_ENDPOINTS` (external callback service). Those bound scarce things.

## `--probe-writes`, off by default

A path in a JS bundle carries no method, so every endpoint is discovered as a GET and any scanner filtering for POST/PUT finds nothing to do — leaving stored XSS, mass assignment and CSRF untested everywhere. The flag derives state-changing endpoints from REST shape: POST to a collection, PUT to an item.

Opt-in, because it makes a scan write to whatever it's pointed at. **DELETE is derived and deliberately never emitted** — a scanner that destroys a record to prove it could isn't worth the finding.

## Measurements

| Juice Shop url-only | capped | uncapped |
|---|---|---|
| recall | 26/45 | **26/45** — class-by-class identical |
| findings (LLM triage on) | 15 | 17 |
| cost | $0.12 | $0.15 |
| duration | 817s | 1636s |

Suite 2458 passed.

## Known, and the next change

With `--llm none` the raw finding count goes 32 → **296**, of which **272 are five real issues restated per endpoint**: 76 copies of "Missing Content-Security-Policy", 43 of the CORS wildcard.

Those two caps were doing *deduplication*, not budgeting. LLM triage collapses them by exact title, which is why a normal scan is unaffected — but relying on that is wrong in both directions, and the same title-based pass discards **4 distinct IDORs on 4 different endpoints, keeping 1**. Each needs its own ownership check; three holes stay open behind a report that shows one.

The fix isn't a cap — it's a finding-level notion of **remediation scope**: server-config issues (one fix covers everything) reported once with affected endpoints as evidence; per-instance issues never collapsed across endpoints; shared-root issues grouped by root with call sites listed. That's the next PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EZ4QoTqRoYWE25CNoV2Wfy