### PR TITLE
fix(triage): group findings by how many places they have to be fixed in

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -338,6 +338,32 @@ It is off by default: it makes a scan write to whatever it is pointed at.
 DELETE is derived and deliberately never emitted — a scanner that destroys a
 record to prove it could is not worth the finding.
 
+### Remediation scope
+
+Findings arrive one per affected location, which is right for detection and
+wrong for reporting. `RemediationScope` says how many places a category has
+to be fixed in, and deduplication follows it:
+
+| scope | means | reported | categories |
+|---|---|---|---|
+| `SERVER` | one config change covers everything | once, listing affected endpoints as evidence | missing headers, CORS, mixed content, source maps, SRI |
+| `INSTANCE` | each occurrence is its own fix | every one, never collapsed across locations | IDOR, injection, auth, privilege escalation, business logic, open redirect |
+| `SHARED_ROOT` | one cause, many call sites | grouped under the cause, sites listed | exposed secrets, dependencies, RLS, client exposure |
+
+The two failure modes point opposite ways, which is why one rule cannot serve
+both. "Missing Content-Security-Policy" restated on 76 endpoints buries a
+report; four IDORs collapsed into one hides three vulnerabilities behind
+something that looks handled. Deduplicating on the title alone — the only
+signal available before this existed — does the first correctly and the
+second silently.
+
+Every pass consults it, the fuzzy title pass included: that one is the
+loosest, so a wrong merge there is both most likely and least visible.
+
+Deduplication needs no LLM, and no longer waits for one. It used to sit
+behind the triage phase, so `--llm none` shipped the raw list — 296 findings
+on Juice Shop, of which 272 were five issues restated per endpoint.
+
 ## Design Principles
 
 ### Protocol-Based (Dependency Inversion)

--- a/isitsecure/engine/agent.py
+++ b/isitsecure/engine/agent.py
@@ -1171,9 +1171,9 @@ class DeepSecurityScanAgent:
         # ==============================================================
         # Phase 9.5: LLM Triage (deduplicate, enrich, prioritize)
         # ==============================================================
-        if self._llm_triage and ctx.all_findings:
-            from isitsecure.engine.constants import TriageConfig
+        from isitsecure.engine.constants import TriageConfig
 
+        if self._llm_triage and ctx.all_findings:
             yield DeepScanEvent(
                 DeepScanPhase.TRIAGE,
                 TriageConfig.MSG_TRIAGING,
@@ -1200,6 +1200,27 @@ class DeepSecurityScanAgent:
             except Exception as e:
                 logger.warning("Triage failed: %s: %s", type(e).__name__, e)
 
+        elif ctx.all_findings:
+            # Deduplication needs no LLM — it is a rule about remediation
+            # scope, not a judgement — but it lived behind the triage phase,
+            # so `--llm none` shipped the raw list: 296 findings on Juice
+            # Shop, of which 272 were five real issues restated once per
+            # endpoint. Anyone scanning without an API key got the version
+            # that is unreadable.
+            from isitsecure.engine.triage.llm_triage_service import (
+                LLMTriageService,
+            )
+
+            before = len(ctx.all_findings)
+            ctx.all_findings, merged = LLMTriageService._rule_based_dedup(
+                ctx.all_findings
+            )
+            if merged:
+                yield DeepScanEvent(
+                    DeepScanPhase.TRIAGE,
+                    f"Grouped {before} findings into {len(ctx.all_findings)}",
+                    TriageConfig.PROGRESS_TRIAGE,
+                )
 
     # ------------------------------------------------------------------
     # Progress draining

--- a/isitsecure/engine/enums.py
+++ b/isitsecure/engine/enums.py
@@ -46,6 +46,85 @@ class FindingCategory(str, Enum):
     BUSINESS_LOGIC = "business_logic"
 
 
+class RemediationScope(str, Enum):
+    """How many places a finding has to be fixed in.
+
+    Findings arrive one per affected location, which is right for detection
+    and wrong for reporting: "Missing Content-Security-Policy" on 76
+    endpoints is one header on one server, while an IDOR on 4 endpoints is 4
+    ownership checks somebody has to write. Collapsing by title — the only
+    signal available before this existed — gets the first right and the
+    second catastrophically wrong, discarding three real vulnerabilities and
+    showing a report that looks handled.
+
+    What separates them is not the scanner or the wording. It is whether one
+    change fixes every instance.
+    """
+
+    SERVER = "server"
+    """One configuration change covers every endpoint.
+
+    Report once, and keep the affected endpoints as evidence — the list is
+    what tells someone the header is missing everywhere rather than on the
+    one URL that happened to be kept.
+    """
+
+    INSTANCE = "instance"
+    """Each occurrence is its own fix, in its own handler.
+
+    Never collapsed across locations. Two IDORs are two ownership checks; a
+    report showing one of them is a report that hides the other.
+    """
+
+    SHARED_ROOT = "shared_root"
+    """One cause, many call sites — a vulnerable helper, a leaked credential
+    used in several places, a dependency imported all over.
+
+    Grouped under the cause, with the sites listed: fixing it once is right,
+    but whoever fixes it needs to know what it touched, and whoever verifies
+    it needs somewhere to look.
+    """
+
+
+# How much of an application each finding category makes someone change.
+# Deliberately a table rather than a method on the enum: it is a judgement
+# about remediation, revisited as categories are added, and worth reading in
+# one place.
+REMEDIATION_SCOPE: dict["FindingCategory", RemediationScope] = {}
+
+
+def _classify() -> None:
+    """Populate REMEDIATION_SCOPE once FindingCategory is defined."""
+    c, s = FindingCategory, RemediationScope
+    REMEDIATION_SCOPE.update({
+        # --- Server configuration: one header, one policy, one setting ---
+        c.MISSING_HEADERS: s.SERVER,
+        c.CORS_MISCONFIGURATION: s.SERVER,
+        c.MIXED_CONTENT: s.SERVER,
+        c.SOURCE_MAP_LEAK: s.SERVER,
+        c.MISSING_SRI: s.SERVER,
+
+        # --- One handler at a time. Each of these is somebody writing a
+        # check in a specific place; a second occurrence is a second fix. ---
+        c.IDOR: s.INSTANCE,
+        c.INJECTION_RISK: s.INSTANCE,
+        c.AUTH_WEAKNESS: s.INSTANCE,
+        c.PRIVILEGE_ESCALATION: s.INSTANCE,
+        c.BUSINESS_LOGIC: s.INSTANCE,
+        c.OPEN_REDIRECT: s.INSTANCE,
+        c.EXPOSED_API_ENDPOINT: s.INSTANCE,
+        c.INFO_DISCLOSURE: s.INSTANCE,
+        c.DEAD_FUNCTIONALITY: s.INSTANCE,
+        c.UNENCRYPTED_PII: s.INSTANCE,
+
+        # --- One cause reached from many places ---
+        c.EXPOSED_SECRETS: s.SHARED_ROOT,      # rotate the key, fix each use
+        c.DEPENDENCY_VULNERABILITY: s.SHARED_ROOT,  # bump once, imported widely
+        c.RLS_MISCONFIGURATION: s.SHARED_ROOT,  # one policy, many tables
+        c.CLIENT_EXPOSURE: s.SHARED_ROOT,      # one bundle, many leaked values
+    })
+
+
 class AssetType(str, Enum):
     """Types of web assets captured during ingestion."""
 
@@ -312,3 +391,6 @@ class ReviewTriggerType(str, Enum):
     RISK_INDICATOR = "risk_indicator"
     IMPORT_GRAPH_CENTRALITY = "import_graph_centrality"
     INJECTION_PATTERN_FLAG = "injection_pattern_flag"
+
+
+_classify()

--- a/isitsecure/engine/scanners/cors_scanner.py
+++ b/isitsecure/engine/scanners/cors_scanner.py
@@ -47,7 +47,7 @@ class CORSScanner(AuthAwareScanner):
     @property
     def scan_categories(self) -> list[FindingCategory]:
         """Finding categories this scanner can detect."""
-        return [FindingCategory.AUTH_WEAKNESS]
+        return [FindingCategory.CORS_MISCONFIGURATION]
 
     async def scan(
         self,
@@ -312,7 +312,7 @@ class CORSScanner(AuthAwareScanner):
         """Construct a DeepFinding for a CORS misconfiguration."""
         return DeepFinding(
             source=FindingSource.DAST_URL,
-            category=FindingCategory.AUTH_WEAKNESS,
+            category=FindingCategory.CORS_MISCONFIGURATION,
             severity=severity,
             title=title,
             description=description,

--- a/isitsecure/engine/triage/llm_triage_service.py
+++ b/isitsecure/engine/triage/llm_triage_service.py
@@ -36,6 +36,8 @@ from isitsecure.engine.enums import (
     ImpactCategory,
     LikelihoodLevel,
     ScanMode,
+    REMEDIATION_SCOPE,
+    RemediationScope,
 )
 from isitsecure.engine.models import (
     DeepFinding,
@@ -60,6 +62,11 @@ class TriageResult:
     triaged_findings: list[DeepFinding] = field(default_factory=list)
     owner_summary: OwnerSummary = field(default_factory=OwnerSummary)
     themes: list[SecurityTheme] = field(default_factory=list)
+
+
+# How many affected endpoints to name before summarising the rest. Long
+# enough to show the spread, short enough that a finding stays readable.
+MAX_AFFECTED_SHOWN = 8
 
 
 class LLMTriageService:
@@ -286,16 +293,66 @@ class LLMTriageService:
                     )
             return best
 
+        def _scope_of(f: DeepFinding) -> RemediationScope:
+            return REMEDIATION_SCOPE.get(f.category, RemediationScope.INSTANCE)
+
+        def _location_of(f: DeepFinding) -> str:
+            """Where a finding has to be fixed — endpoint, else source line."""
+            if f.endpoint_url:
+                return f.endpoint_url
+            if f.code_location:
+                return (
+                    f"{f.code_location.file_path}:"
+                    f"{f.code_location.line_number}"
+                )
+            return f.id
+
+        def _merge_locations(group: list[DeepFinding]) -> DeepFinding:
+            """Keep one finding and record every endpoint it was seen on.
+
+            The list is the point. "Missing Content-Security-Policy" on one
+            URL reads like one page is misconfigured; the same finding
+            carrying 76 endpoints says the server has no CSP at all, which is
+            both the truth and what tells someone the single fix is worth
+            making.
+            """
+            best = _pick_best(group)
+            endpoints = sorted({
+                f.endpoint_url for f in group if f.endpoint_url
+            })
+            if len(endpoints) > 1:
+                shown = endpoints[:MAX_AFFECTED_SHOWN]
+                more = len(endpoints) - len(shown)
+                best.description += (
+                    f"\n\nAffects {len(endpoints)} endpoints: "
+                    + ", ".join(shown)
+                    + (f", and {more} more" if more else "")
+                )
+            return best
+
         removed = 0
 
-        # Pass 1: Exact title match
+        # Pass 1: same title — collapsed only where one fix covers every
+        # occurrence.
+        #
+        # Collapsing on the title alone was right for a missing header and
+        # wrong for everything that needs fixing in more than one place: four
+        # IDORs on four endpoints share a title and are four separate
+        # ownership checks, and keeping one of them discarded three real
+        # vulnerabilities behind a report that looked handled. What decides
+        # is the category's remediation scope, not the wording.
         title_groups: dict[str, list[DeepFinding]] = defaultdict(list)
         for f in findings:
-            title_groups[f.title.lower().strip()].append(f)
+            if _scope_of(f) is RemediationScope.INSTANCE:
+                # Per location, so two endpoints stay two findings.
+                key = f"{f.title.lower().strip()}|{_location_of(f)}"
+            else:
+                key = f.title.lower().strip()
+            title_groups[key].append(f)
 
         after_p1: list[DeepFinding] = []
         for group in title_groups.values():
-            after_p1.append(_pick_best(group))
+            after_p1.append(_merge_locations(group))
             removed += len(group) - 1
 
         # Pass 2: Same file + same line number
@@ -303,6 +360,11 @@ class LLMTriageService:
         for f in after_p1:
             if f.code_location and f.code_location.line_number:
                 key = f"{f.code_location.file_path}:{f.code_location.line_number}"
+                # Same source line reached from two endpoints is still two
+                # fixes when the category says so — a shared handler with a
+                # missing ownership check needs one per route it serves.
+                if _scope_of(f) is RemediationScope.INSTANCE and f.endpoint_url:
+                    key = f"{key}|{f.endpoint_url}"
             else:
                 key = f"__no_loc_{f.id}"
             loc_groups[key].append(f)
@@ -363,11 +425,22 @@ class LLMTriageService:
                 # Never fuzzy-merge two live findings that target DIFFERENT
                 # endpoints — same-template titles (e.g. per-table RLS findings
                 # that differ only by the table name) are distinct issues, not
-                # textual duplicates. Pure-SAST cross-file merges are untouched.
+                # textual duplicates.
                 if (
                     f1.endpoint_url
                     and f2.endpoint_url
                     and f1.endpoint_url != f2.endpoint_url
+                ):
+                    continue
+                # The same holds across files, which the endpoint check
+                # cannot see: "Missing auth on /orders" and "Missing auth on
+                # /users" overlap on two words in three and are two handlers
+                # somebody has to fix. Fuzzy matching is the loosest pass
+                # here, so it is the one where a wrong merge is most likely
+                # and least visible.
+                if (
+                    _scope_of(f1) is RemediationScope.INSTANCE
+                    and _location_of(f1) != _location_of(f2)
                 ):
                     continue
                 overlap = len(w1 & w2) / max(len(w1), len(w2))

--- a/tests/engine/test_remediation_scope.py
+++ b/tests/engine/test_remediation_scope.py
@@ -1,0 +1,149 @@
+"""Tests for remediation scope — how many places a finding must be fixed in.
+
+Findings arrive one per affected location. That is right for detection and
+wrong for reporting, and the two failure modes point opposite ways: a missing
+header restated on 76 endpoints buries the report, while four IDORs collapsed
+into one hides three vulnerabilities behind something that looks handled.
+"""
+
+from __future__ import annotations
+
+from isitsecure.engine.enums import (
+    REMEDIATION_SCOPE,
+    FindingCategory,
+    RemediationScope,
+    SeverityLevel,
+)
+from isitsecure.engine.models import DeepFinding
+from isitsecure.engine.triage.llm_triage_service import LLMTriageService
+
+
+def _finding(category: FindingCategory, title: str, endpoint: str) -> DeepFinding:
+    return DeepFinding(
+        source="dast_url",
+        category=category,
+        severity=SeverityLevel.MEDIUM,
+        title=title,
+        description="d",
+        confidence=0.9,
+        scanner_name="test_scanner",
+        endpoint_url=endpoint,
+    )
+
+
+class TestEveryCategoryIsClassified:
+    def test_no_category_is_left_out(self) -> None:
+        """An unclassified category falls back to INSTANCE — never
+        collapsed — so the failure is noisy rather than silent. Still, a new
+        category should be a deliberate decision."""
+        missing = [c for c in FindingCategory if c not in REMEDIATION_SCOPE]
+        assert missing == []
+
+    def test_the_scopes_are_all_used(self) -> None:
+        used = set(REMEDIATION_SCOPE.values())
+        assert used == set(RemediationScope)
+
+
+class TestServerScopeCollapses:
+    """One configuration change covers every endpoint."""
+
+    def test_a_missing_header_is_reported_once(self) -> None:
+        findings = [
+            _finding(
+                FindingCategory.MISSING_HEADERS,
+                "Missing Content-Security-Policy header",
+                f"https://x/api/r{i}",
+            )
+            for i in range(76)
+        ]
+        deduped, removed = LLMTriageService._rule_based_dedup(findings)
+
+        assert len(deduped) == 1
+        assert removed == 75
+
+    def test_the_affected_endpoints_survive_the_collapse(self) -> None:
+        """The list is the point: one URL reads like one misconfigured page,
+        while 76 says the server has no CSP at all."""
+        findings = [
+            _finding(
+                FindingCategory.MISSING_HEADERS,
+                "Missing Content-Security-Policy header",
+                f"https://x/api/r{i}",
+            )
+            for i in range(76)
+        ]
+        deduped, _ = LLMTriageService._rule_based_dedup(findings)
+
+        assert "Affects 76 endpoints" in deduped[0].description
+
+    def test_a_cors_wildcard_is_reported_once(self) -> None:
+        findings = [
+            _finding(
+                FindingCategory.CORS_MISCONFIGURATION,
+                "CORS allows wildcard origin (data leakage risk)",
+                f"https://x/api/r{i}",
+            )
+            for i in range(43)
+        ]
+        deduped, _ = LLMTriageService._rule_based_dedup(findings)
+        assert len(deduped) == 1
+
+
+class TestInstanceScopeIsNeverCollapsed:
+    """Each occurrence is its own fix, in its own handler."""
+
+    def test_four_idors_stay_four_findings(self) -> None:
+        """The regression this guards. Collapsing on title kept one of these
+        and discarded three real vulnerabilities — each needing its own
+        ownership check — behind a report that looked handled."""
+        endpoints = [
+            "https://x/api/Products/1",
+            "https://x/rest/track-order/1",
+            "https://x/api/Deliverys/1",
+            "https://x/rest/memories",
+        ]
+        findings = [
+            _finding(
+                FindingCategory.IDOR,
+                "IDOR — resource accessible via direct ID reference",
+                e,
+            )
+            for e in endpoints
+        ]
+        deduped, removed = LLMTriageService._rule_based_dedup(findings)
+
+        assert len(deduped) == 4
+        assert removed == 0
+        assert {f.endpoint_url for f in deduped} == set(endpoints)
+
+    def test_injection_on_two_routes_stays_two(self) -> None:
+        findings = [
+            _finding(FindingCategory.INJECTION_RISK, "SQL injection", "https://x/a"),
+            _finding(FindingCategory.INJECTION_RISK, "SQL injection", "https://x/b"),
+        ]
+        deduped, _ = LLMTriageService._rule_based_dedup(findings)
+        assert len(deduped) == 2
+
+    def test_the_same_endpoint_twice_is_still_one(self) -> None:
+        """Not collapsing across endpoints is not the same as never
+        collapsing: one endpoint reported twice is one fix."""
+        findings = [
+            _finding(FindingCategory.IDOR, "IDOR", "https://x/a"),
+            _finding(FindingCategory.IDOR, "IDOR", "https://x/a"),
+        ]
+        deduped, _ = LLMTriageService._rule_based_dedup(findings)
+        assert len(deduped) == 1
+
+
+class TestSharedRootGroups:
+    """One cause, many call sites."""
+
+    def test_a_leaked_secret_is_grouped(self) -> None:
+        findings = [
+            _finding(FindingCategory.EXPOSED_SECRETS, "Stripe key in bundle", f"https://x/{i}")
+            for i in range(5)
+        ]
+        deduped, _ = LLMTriageService._rule_based_dedup(findings)
+
+        assert len(deduped) == 1
+        assert "Affects 5 endpoints" in deduped[0].description

--- a/tests/engine/test_scan_phases.py
+++ b/tests/engine/test_scan_phases.py
@@ -50,16 +50,23 @@ def _finding(title: str = "A finding", **kwargs) -> DeepFinding:
     return DeepFinding(**defaults)
 
 
-def _code_finding(suppressed: bool = False):
+def _code_finding(suppressed: bool = False, route: str = "route"):
+    """A SAST finding. ``route`` distinguishes two of them.
+
+    Two findings identical in title, file and line are one finding, and
+    deduplication now says so — so a test about suppression has to make its
+    findings genuinely different, or it cannot tell a suppressed finding from
+    a merged duplicate.
+    """
     from isitsecure.engine.code_analysis.models import CodeFinding
 
     return CodeFinding(
         scanner_name="route_auth",
         severity=SeverityLevel.HIGH,
         category=FindingCategory.AUTH_WEAKNESS,
-        title="Missing auth",
+        title=f"Missing auth on /{route}",
         description="d",
-        file_path="src/api/route.ts",
+        file_path=f"src/api/{route}.ts",
         line_number=10,
         confidence=0.85,
         lsp_suppressed=suppressed,
@@ -396,7 +403,7 @@ class TestLSPValidation:
     @pytest.mark.asyncio
     async def test_findings_the_tracer_confirms_are_kept(self) -> None:
         """Suppression must remove only what was disproved, nothing else."""
-        a, b = _code_finding(), _code_finding()
+        a, b = _code_finding(route="orders"), _code_finding(route="users")
         scanner = _sast_scanner([a, b], validate=lambda findings, _fl: findings)
         ingestion = AsyncMock()
         ingestion.ingest.return_value = _repo_snapshot()

--- a/tests/engine/test_triage/test_llm_triage_service.py
+++ b/tests/engine/test_triage/test_llm_triage_service.py
@@ -117,11 +117,24 @@ def _make_service(
 class TestRuleBasedDedup:
     """Test rule-based deduplication (pre-filter, no LLM)."""
 
-    def test_identical_titles_keep_highest_severity(self) -> None:
+    def test_identical_titles_at_one_location_keep_highest_severity(self) -> None:
+        """Same title *and* same place — one fix, so the stronger reading of
+        it survives.
+
+        The endpoint is explicit because an IDOR is fixed per handler: the
+        same title on two endpoints is two ownership checks and must not
+        collapse. See tests/engine/test_remediation_scope.py.
+        """
         service, _ = _make_service()
         findings = [
-            _make_finding(finding_id="f1", title="Missing auth", severity=SeverityLevel.MEDIUM),
-            _make_finding(finding_id="f2", title="Missing auth", severity=SeverityLevel.HIGH),
+            _make_finding(
+                finding_id="f1", title="Missing auth",
+                severity=SeverityLevel.MEDIUM, endpoint_url="https://x/a",
+            ),
+            _make_finding(
+                finding_id="f2", title="Missing auth",
+                severity=SeverityLevel.HIGH, endpoint_url="https://x/a",
+            ),
         ]
         deduped, removed = service._rule_based_dedup(findings)
         assert len(deduped) == 1
@@ -139,12 +152,17 @@ class TestRuleBasedDedup:
         assert removed == 0
 
     def test_prefers_llm_over_sast_on_tie(self) -> None:
+        """Two reports of the same thing in the same place — the richer one
+        survives. The endpoint is shared because that is what makes them the
+        same thing; two rate-limit gaps on two routes are two fixes."""
         service, _ = _make_service()
         findings = [
             _make_finding(finding_id="sast", title="Rate limit issue",
-                          scanner_name="express_middleware_analyzer"),
+                          scanner_name="express_middleware_analyzer",
+                          endpoint_url="https://x/a"),
             _make_finding(finding_id="llm", title="Rate limit issue",
-                          scanner_name="llm_code_reviewer"),
+                          scanner_name="llm_code_reviewer",
+                          endpoint_url="https://x/a"),
         ]
         deduped, _ = service._rule_based_dedup(findings)
         assert len(deduped) == 1


### PR DESCRIPTION
Findings arrive one per affected location — right for detection, wrong for reporting. Deduplication had only the **title** to go on, which gets one half of the problem right and the other half silently wrong.

## The two failure modes point opposite ways

```
Missing Content-Security-Policy   ×76 endpoints  →  one header, one server
IDOR — direct ID reference        ×4  endpoints  →  four ownership checks
```

Both arrive as several findings sharing a title. Collapsing on that alone buries the report in the first case and, in the second, **kept one IDOR and discarded three real vulnerabilities** behind something that looked handled.

## RemediationScope

| scope | means | reported |
|---|---|---|
| `SERVER` | one config change covers everything | once, carrying the affected endpoints |
| `INSTANCE` | each occurrence is its own fix | every one, never collapsed across locations |
| `SHARED_ROOT` | one cause, many call sites | grouped under the cause, sites listed |

All 19 categories classified. Every dedup pass consults it — including the **fuzzy title pass**, which needed it most: `Missing auth on /orders` and `…/users` overlap on two words in three, and that pass is the loosest, so a wrong merge there is both most likely and least visible.

The affected-endpoint list matters as much as the collapse: one URL reads like one misconfigured page, while 76 says the server has no CSP at all.

## Two things that surfaced while building it

**The CORS scanner emitted `AUTH_WEAKNESS`.** `CORS_MISCONFIGURATION` was never produced by anything, and the plain-English explanation written for it was unreachable. Corrected — which is also what lets the wildcard finding collapse.

**Dedup was unreachable without an LLM.** It needs none — it's a rule about remediation, not a judgement — but it sat behind the triage phase, so `--llm none` shipped the raw list. Anyone scanning without an API key got the unreadable version, and so does the benchmark harness.

## Measured on Juice Shop

| | before | after |
|---|---|---|
| security headers | 229 | **3** + "Affects 76 endpoints" |
| CORS wildcard | 43 | **1** |
| **IDOR** | **1** | **4** — which is how many there are |
| total, `--llm none` | 296 | **26** |

## Recall unchanged everywhere

| target | result |
|---|---|
| juiceshop | 26/45 |
| juiceshop-auth | 29/45, `idor 4/5` |
| vampi-vulnerable | 3/3 |
| sast-injection | 46/46, 0 FP |
| suite | 2467 passed |

Worth knowing: **both `juiceshop-auth` and `vampi-vulnerable` read low on the first sweep** (25/45 with `idor 0/5`; 2/3) and **matched their baselines when re-run with identical code**. IDOR detection varies between runs. That's pre-existing and not this change, but it means a single benchmark run can mislead in either direction — worth its own look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EZ4QoTqRoYWE25CNoV2Wfy