### PR TITLE
fix(benchmarks): seed VAmPI before scanning it, so its result means something

### DIFF
--- a/benchmarks/run_benchmarks.py
+++ b/benchmarks/run_benchmarks.py
@@ -127,6 +127,15 @@ TARGETS: list[Target] = [
         url="http://localhost:5001",
         ready_url="http://localhost:5001/",
         down_cmd=["docker", "rm", "-f", "bench_vampi_vuln"],
+        # VAmPI ships an empty database and seeds it from /createdb. Without
+        # this the app answers HTTP 500 to every data route, so IDOR has
+        # nothing to find — and /createdb is itself a discovered endpoint, so
+        # a scan seeds the target by scanning it. Whether IDOR sees data then
+        # depends on whether some scanner reached /createdb first, which made
+        # the target's IDOR result a coin flip rather than a measurement.
+        pre_scan=["bash", "-c",
+                  "curl -s -o /dev/null http://localhost:5001/createdb || true"],
+
         expect=[
             Expectation("SQL injection (OWASP API8/Injection)", **SQLI),
             Expectation("Broken object-level auth / IDOR", **IDOR),
@@ -141,6 +150,15 @@ TARGETS: list[Target] = [
         url="http://localhost:5002",
         ready_url="http://localhost:5002/",
         down_cmd=["docker", "rm", "-f", "bench_vampi_secure"],
+        # VAmPI ships an empty database and seeds it from /createdb. Without
+        # this the app answers HTTP 500 to every data route, so IDOR has
+        # nothing to find — and /createdb is itself a discovered endpoint, so
+        # a scan seeds the target by scanning it. Whether IDOR sees data then
+        # depends on whether some scanner reached /createdb first, which made
+        # the target's IDOR result a coin flip rather than a measurement.
+        pre_scan=["bash", "-c",
+                  "curl -s -o /dev/null http://localhost:5002/createdb || true"],
+
         # Secure build: injection/IDOR findings would be FALSE POSITIVES.
         forbid=[
             Expectation("SQL injection (should be absent)", **SQLI),


### PR DESCRIPTION
Root-caused the IDOR variance that cost two investigations today. **It was never the scanner.**

## The mechanism

VAmPI ships an empty database and populates it from `/createdb`. Until that runs, every data route answers HTTP 500:

| state | `/users/v1` | IDOR findings |
|---|---|---|
| fresh container | `500 sqlalchemy.exc.OperationalError` | **0** |
| after `GET /createdb` | `200`, returns users | **2** |

Nothing in the harness called it — but **`/createdb` is itself a discovered endpoint**, so a scan seeded the target *by scanning it*. Whether IDOR saw data came down to whether some scanner reached `/createdb` before the IDOR phase did.

Both outcomes are perfectly deterministic given the state. Five runs of `IDORScanner` against a fixed endpoint list gave the identical answer every time in each state — the scanner was never the unstable part. What varied was the ordering of an incidental side effect.

## The fix

Both VAmPI targets seed in `pre_scan`, the way the Juice Shop targets already register their users. Three consecutive runs after:

```
run1: vulnerable Recall:3/3 | secure FalsePositives:2
run2: vulnerable Recall:3/3 | secure FalsePositives:2
run3: vulnerable Recall:3/3 | secure FalsePositives:2
```

## What this invalidates

The **"2 pre-existing IDOR false positives" on vampi-secure** — which I reported as a stable baseline three separate times today — were measured against a target in an undefined state. They reproduce consistently now that it's seeded, so the number stands, but it wasn't a measurement before.

Uncapping the scanners plausibly changed the odds too (more endpoints probed, different ordering), which is why this surfaced today rather than earlier. Not a regression, but not a coincidence.

## Juice Shop is not this

Its data is seeded at boot — a freshly registered user can already read baskets 1–7, so the BOLA is always testable. I checked the "no basket exists" hypothesis directly and it's wrong.

Its one low reading (`25/45`, `idor 0/5`) hasn't reproduced in isolation: **29/45 with `idor 4/5`** both before this work and on re-run. The single low value came during a five-target sweep. Left as an open question rather than attributed to a cause I haven't demonstrated.

Suite 2467 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EZ4QoTqRoYWE25CNoV2Wfy