### PR TITLE
fix(dast): let a scanner out of time return what it found

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -326,6 +326,31 @@ Two caps remain because they bound something genuinely scarce:
 `MAX_ENDPOINTS_IN_PROMPT` (LLM tokens) and `MAX_OOB_POST_ENDPOINTS`
 (registrations against an external callback service).
 
+### When a scanner runs out of time
+
+`run_scanner_safe` cancels a scanner at its hard timeout, and a cancelled
+coroutine cannot hand anything back — so every finding it had accumulated is
+discarded. Measured: `http_probe_scanner` ran 901s against a 900s timeout
+holding four real findings, an exposed `/.env` among them, and reported none
+of them.
+
+Scanners therefore stop *themselves*. The runner publishes its deadline; a
+`TimeBudget()` with no argument inherits it, so a scanner opts in with two
+lines and never needs to know its own timeout — which is how the inner and
+outer values drift apart. The hard cancel remains as a backstop for something
+genuinely hung, and logs loudly when it fires, because reaching it now means
+a scanner failed to yield rather than merely ran long.
+
+Granularity matters more than it looks. Checking between phases is not
+enough when one phase walks the whole inventory: it enters before the
+deadline, runs 800s, and is cancelled with everything in it. The check
+belongs in the per-endpoint loop.
+
+Order matters too. `http_probe` runs its fixed-cost checks — the ones probing
+a handful of known paths — before the ones that scale with the inventory, so
+a large app cannot spend its whole budget on method tampering and never reach
+the check that finds an exposed `.env`.
+
 ### Testing the mutation surface
 
 `--probe-writes` derives state-changing endpoints from REST shape — POST to a

--- a/isitsecure/engine/scanners/cors_scanner.py
+++ b/isitsecure/engine/scanners/cors_scanner.py
@@ -14,6 +14,7 @@ from urllib.parse import urlparse
 
 from isitsecure.engine.constants import CORSConfig, DeepScanConfig
 from isitsecure.engine.shared.progress import emit
+from isitsecure.engine.shared.time_budget import TimeBudget
 from isitsecure.engine.models import (
     DASTProbeCaptureEntry,
     DeepFinding,
@@ -77,7 +78,11 @@ class CORSScanner(AuthAwareScanner):
             user_agent=DeepScanConfig.USER_AGENT,
             extra_headers=self.auth_headers,
         ) as client:
+            budget = TimeBudget()
             for tested, ep in enumerate(representative):
+                if budget.expired():
+                    emit("CORS: out of time, returning what was found")
+                    break
                 emit(
                     f"CORS: probing {tested + 1}/{len(representative)} {ep.url}"
                 )

--- a/isitsecure/engine/scanners/csrf_scanner.py
+++ b/isitsecure/engine/scanners/csrf_scanner.py
@@ -14,6 +14,7 @@ from http.cookies import SimpleCookie
 
 from isitsecure.engine.constants import CSRFConfig, DeepScanConfig
 from isitsecure.engine.shared.progress import emit
+from isitsecure.engine.shared.time_budget import TimeBudget
 from isitsecure.engine.models import (
     DeepFinding,
     DiscoveredEndpoint,
@@ -110,7 +111,11 @@ class CSRFScanner(AuthAwareScanner):
             ranked = rank(endpoints, PriorityDimension.CSRF)[
                 : CSRFConfig.MAX_ENDPOINTS_TO_TEST
             ]
+            budget = TimeBudget()
             for tested, ep in enumerate(ranked):
+                if budget.expired():
+                    emit("CSRF: out of time, returning what was found")
+                    break
                 emit(
                     f"CSRF: forged-origin probe {tested + 1}/{len(ranked)} "
                     f"{ep.method.value} {ep.url}"

--- a/isitsecure/engine/scanners/http_probe_scanner.py
+++ b/isitsecure/engine/scanners/http_probe_scanner.py
@@ -25,6 +25,7 @@ from isitsecure.engine.models import (
 )
 from isitsecure.engine.shared.endpoint_prioritizer import PriorityDimension, rank
 from isitsecure.engine.shared.progress import emit
+from isitsecure.engine.shared.time_budget import TimeBudget
 from isitsecure.engine.shared.rate_limited_client import (
     RateLimitedClient,
 )
@@ -77,30 +78,42 @@ class HTTPProbeScanner(AuthAwareScanner):
             user_agent=DeepScanConfig.USER_AGENT,
             extra_headers=self.auth_headers,
         ) as client:
-            emit("http-probe: method tampering (OPTIONS/TRACE)")
-            findings.extend(
-                await self._check_method_tampering(test_endpoints, client)
+            # Fixed-cost checks first, per-endpoint checks after. The first
+            # two probe a handful of known paths on the base URL and cost the
+            # same whatever the inventory holds; the rest walk every endpoint
+            # and grow with it. Run the other way round — as this did — and a
+            # large app spends its whole budget on method tampering and never
+            # reaches the check that finds an exposed .env.
+            checks = (
+                ("verbose error pages",
+                 lambda: self._check_verbose_errors(base_url, client)),
+                ("directory listing & sensitive files (.git/.env)",
+                 lambda: self._check_directory_listing(base_url, client)),
+                ("method tampering (OPTIONS/TRACE)",
+                 lambda: self._check_method_tampering(test_endpoints, client)),
+                ("host header injection",
+                 lambda: self._check_host_header_injection(
+                     base_url, test_endpoints, client)),
+                ("CRLF header injection",
+                 lambda: self._check_crlf_injection(test_endpoints, client)),
             )
-            emit("http-probe: host header injection")
-            findings.extend(
-                await self._check_host_header_injection(
-                    base_url, test_endpoints, client,
-                )
-            )
-            emit("http-probe: verbose error pages")
-            findings.extend(
-                await self._check_verbose_errors(base_url, client)
-            )
-            emit("http-probe: directory listing & sensitive files (.git/.env)")
-            findings.extend(
-                await self._check_directory_listing(base_url, client)
-            )
-            emit("http-probe: CRLF header injection")
-            findings.extend(
-                await self._check_crlf_injection(
-                    test_endpoints, client,
-                )
-            )
+
+            # Stop between checks rather than be cancelled mid-way. This
+            # scanner ran 901s against a 900s timeout holding four findings —
+            # an exposed .env among them — and the hard cancel discarded all
+            # four. Returning three of five checks' worth beats returning
+            # nothing.
+            budget = TimeBudget()
+            for label, run_check in checks:
+                if budget.expired():
+                    logger.info(
+                        "HTTPProbeScanner: budget spent, skipping '%s' and "
+                        "any checks after it", label,
+                    )
+                    emit(f"http-probe: out of time before {label}")
+                    break
+                emit(f"http-probe: {label}")
+                findings.extend(await run_check())
 
         logger.info(
             "HTTPProbeScanner: %d findings from %d endpoints",
@@ -122,7 +135,13 @@ class HTTPProbeScanner(AuthAwareScanner):
         findings: list[DeepFinding] = []
         tested: set[str] = set()
 
+        budget = TimeBudget()
         for ep in rank(endpoints, PriorityDimension.CSRF)[: HTTPProbeConfig.MAX_METHOD_TEST_ENDPOINTS]:
+            # Per endpoint, not per check: one of these walks the whole
+            # inventory, so checking only between checks let it run 800s
+            # past the deadline and be cancelled with everything in it.
+            if budget.expired():
+                break
             if ep.url in tested:
                 continue
             tested.add(ep.url)
@@ -365,7 +384,10 @@ class HTTPProbeScanner(AuthAwareScanner):
         """
         findings: list[DeepFinding] = []
 
+        budget = TimeBudget()
         for ep in rank(endpoints, PriorityDimension.CSRF)[:HTTPProbeConfig.MAX_METHOD_TEST_ENDPOINTS]:
+            if budget.expired():
+                break
             for param in HTTPProbeConfig.CRLF_PARAM_NAMES:
                 for payload in HTTPProbeConfig.CRLF_PAYLOADS:
                     try:

--- a/isitsecure/engine/scanners/idor_scanner.py
+++ b/isitsecure/engine/scanners/idor_scanner.py
@@ -38,6 +38,7 @@ from isitsecure.engine.models import (
 )
 from isitsecure.engine.shared.endpoint_prioritizer import PriorityDimension, rank
 from isitsecure.engine.shared.progress import emit
+from isitsecure.engine.shared.time_budget import TimeBudget
 from isitsecure.engine.shared.rate_limited_client import RateLimitedClient
 from isitsecure.engine.enums import FindingCategory, SeverityLevel
 from urllib.parse import quote
@@ -77,6 +78,7 @@ class IDORScanner:
         )
 
         testable = testable[: IDORConfig.MAX_ENDPOINTS_TO_TEST]
+        budget = TimeBudget()
         results: list[IDORTestResult] = []
         mutation_findings: list[DeepFinding] = []
 
@@ -87,6 +89,9 @@ class IDORScanner:
             user_agent=DeepScanConfig.USER_AGENT,
         ) as client:
             for endpoint in testable:
+                if budget.expired():
+                    emit("IDOR: out of time, returning what was found")
+                    break
                 emit(f"IDOR: testing {endpoint.url}")
                 result = await self._test_endpoint(client, endpoint)
                 results.append(result)
@@ -94,6 +99,9 @@ class IDORScanner:
             # Mutation IDOR: test PUT/PATCH/DELETE with swapped IDs
             mutation_testable = self._filter_mutation_endpoints(endpoints)
             for endpoint in mutation_testable[: IDORConfig.MAX_ENDPOINTS_TO_TEST]:
+                if budget.expired():
+                    emit("IDOR: out of time during mutation tests")
+                    break
                 emit(f"IDOR: mutation test {endpoint.method.value} {endpoint.url}")
                 findings = await self._test_mutation_idor(
                     client, endpoint

--- a/isitsecure/engine/shared/scanner_runner.py
+++ b/isitsecure/engine/shared/scanner_runner.py
@@ -5,6 +5,8 @@ import logging
 from typing import Any, Coroutine
 
 from isitsecure.engine.models import DeepFinding
+from isitsecure.engine.shared.progress import emit
+from isitsecure.engine.shared.time_budget import scanner_deadline
 
 logger = logging.getLogger(__name__)
 
@@ -66,10 +68,22 @@ async def run_scanner_safe(
         List of findings, or empty list on failure.
     """
     try:
-        return await asyncio.wait_for(scan_coro, timeout=timeout_seconds)
+        # Publish the deadline so the scanner can stop itself and RETURN what
+        # it found. A cancel here discards everything: http_probe_scanner ran
+        # 901s against a 900s timeout holding four real findings — an exposed
+        # /.env among them — and reported none of them.
+        with scanner_deadline(timeout_seconds):
+            return await asyncio.wait_for(scan_coro, timeout=timeout_seconds)
     except asyncio.TimeoutError:
         logger.warning(
-            "Scanner '%s' timed out after %ss", scanner_name, timeout_seconds
+            "Scanner '%s' timed out after %ss — findings discarded. It did "
+            "not stop on the cooperative deadline, which means either it has "
+            "no TimeBudget or it blocked between checks.",
+            scanner_name, timeout_seconds,
+        )
+        emit(
+            f"{scanner_name}: hard timeout at {timeout_seconds}s, "
+            "findings lost"
         )
         return []
     except Exception as e:

--- a/isitsecure/engine/shared/time_budget.py
+++ b/isitsecure/engine/shared/time_budget.py
@@ -21,18 +21,59 @@ margin) so the scanner returns cleanly instead of being cancelled.
 from __future__ import annotations
 
 import time
+from contextlib import contextmanager
+from contextvars import ContextVar
+
+# The deadline `run_scanner_safe` is enforcing, published so a scanner can
+# stop itself just before the cancel lands. Ambient rather than passed down,
+# because the alternative is threading a timeout through every scanner's
+# constructor and every call site to fix a problem none of them caused.
+_deadline: ContextVar[float | None] = ContextVar("scanner_deadline", default=None)
+
+DEFAULT_SAFETY_MARGIN = 0.15
+
+
+@contextmanager
+def scanner_deadline(
+    total_seconds: float, safety_margin: float = DEFAULT_SAFETY_MARGIN
+):
+    """Publish the deadline a scanner is running under.
+
+    Set by the runner around the hard timeout. `TimeBudget()` with no
+    argument picks it up, so a scanner opts into graceful degradation with
+    two lines and no knowledge of what its own timeout is.
+    """
+    usable = max(0.0, total_seconds * (1.0 - safety_margin))
+    token = _deadline.set(time.monotonic() + usable)
+    try:
+        yield
+    finally:
+        _deadline.reset(token)
 
 
 class TimeBudget:
     """Tracks a cooperative deadline, set inside a scanner's hard timeout."""
 
-    def __init__(self, total_seconds: float, safety_margin: float = 0.15) -> None:
+    def __init__(
+        self,
+        total_seconds: float | None = None,
+        safety_margin: float = DEFAULT_SAFETY_MARGIN,
+    ) -> None:
         """
         Args:
-            total_seconds: The scanner's external timeout budget.
+            total_seconds: The scanner's external timeout budget. Omit it to
+                inherit the deadline the runner published, which is the
+                normal case — a scanner rarely knows its own timeout, and
+                hardcoding one is how the two drift apart.
             safety_margin: Fraction of the budget reserved so the scanner
                 returns before the external timeout cancels it.
         """
+        if total_seconds is None:
+            ambient = _deadline.get()
+            # Unbounded outside a scanner run — a directly-invoked scanner
+            # should not stop early because nobody set a deadline.
+            self._deadline = ambient if ambient is not None else float("inf")
+            return
         usable = max(0.0, total_seconds * (1.0 - safety_margin))
         self._deadline = time.monotonic() + usable
 

--- a/tests/engine/test_time_budget.py
+++ b/tests/engine/test_time_budget.py
@@ -1,0 +1,107 @@
+# ---------------------------------------------------------------------------
+# Ambient deadline — graceful degradation under the runner's hard timeout
+# ---------------------------------------------------------------------------
+
+import asyncio
+
+import pytest
+
+from isitsecure.engine.shared.time_budget import TimeBudget, scanner_deadline
+
+
+class TestAmbientDeadline:
+    """A scanner should stop itself and return, not be cancelled holding
+    findings.
+
+    http_probe_scanner ran 901s against a 900s timeout with four real
+    findings — an exposed /.env among them — and `run_scanner_safe` discarded
+    every one. Cancellation cannot return partial results, so the scanner has
+    to stop first.
+    """
+
+    def test_no_deadline_means_unbounded(self) -> None:
+        """A scanner invoked directly, outside a run, must not stop early
+        because nobody published a deadline."""
+        assert TimeBudget().remaining() == float("inf")
+        assert not TimeBudget().expired()
+
+    def test_a_published_deadline_is_inherited(self) -> None:
+        with scanner_deadline(100):
+            assert TimeBudget().remaining() == pytest.approx(85, abs=1)
+
+    def test_the_margin_leaves_room_to_return(self) -> None:
+        """The cooperative deadline has to land before the hard one, or the
+        scanner is cancelled while tidying up."""
+        with scanner_deadline(100):
+            assert TimeBudget().remaining() < 100
+
+    def test_an_explicit_budget_still_wins(self) -> None:
+        """Scanners that know their own budget keep it."""
+        with scanner_deadline(1000):
+            assert TimeBudget(10).remaining() == pytest.approx(8.5, abs=0.5)
+
+    def test_the_deadline_does_not_leak_out_of_the_block(self) -> None:
+        with scanner_deadline(100):
+            pass
+        assert TimeBudget().remaining() == float("inf")
+
+    @pytest.mark.asyncio
+    async def test_it_crosses_the_task_boundary(self) -> None:
+        """`run_scanner_safe` wraps the scanner in `wait_for`, which runs it
+        in a new Task. A Task copies the context at creation, so a deadline
+        set beforehand is visible inside — this pins that."""
+
+        async def inside() -> float:
+            return TimeBudget().remaining()
+
+        with scanner_deadline(100):
+            remaining = await asyncio.wait_for(inside(), timeout=100)
+        assert remaining == pytest.approx(85, abs=1)
+
+    def test_an_expired_deadline_reports_expired(self) -> None:
+        with scanner_deadline(0):
+            assert TimeBudget().expired()
+
+
+class TestRunnerPublishesTheDeadline:
+    """The end-to-end behaviour: partial results survive, cancellation does
+    not return them."""
+
+    @pytest.mark.asyncio
+    async def test_a_scanner_that_stops_early_keeps_its_findings(self) -> None:
+        """The regression this guards. Without a published deadline the
+        scanner never stops, `wait_for` cancels it, and everything it found
+        is thrown away."""
+        from isitsecure.engine.shared.scanner_runner import run_scanner_safe
+
+        found = []
+
+        async def scanner():
+            budget = TimeBudget()
+            for i in range(1000):
+                if budget.expired():
+                    break
+                found.append(i)
+                await asyncio.sleep(0.01)
+            return found
+
+        results = await run_scanner_safe("test_scanner", scanner(), timeout_seconds=0.5)
+
+        assert results, "a scanner that stopped on the deadline must return"
+        assert results is found
+
+    @pytest.mark.asyncio
+    async def test_a_scanner_that_ignores_the_deadline_still_returns_nothing(
+        self,
+    ) -> None:
+        """Cancellation cannot recover state, so the hard timeout remains
+        all-or-nothing. That is the reason to stop cooperatively, and why the
+        runner logs loudly when it has to cancel."""
+        from isitsecure.engine.shared.scanner_runner import run_scanner_safe
+
+        async def stubborn():
+            await asyncio.sleep(5)
+            return ["never reached"]
+
+        results = await run_scanner_safe("stubborn", stubborn(), timeout_seconds=0.3)
+        assert results == []


### PR DESCRIPTION
Closes the regression in #202.

## The bug

`run_scanner_safe` cancels a scanner at its hard timeout, and a cancelled coroutine hands nothing back. Everything it accumulated is discarded.

Not hypothetical — measured:

```
http_probe_scanner, 154 endpoints, 900s timeout
  ran 901s, holding:  /.env  ·  /.env.local  ·  verbose error page  ·  /robots.txt
  reported:           nothing
```

One second over. Both `exposed_data` and `info_disclosure` score off that single scanner, so losing it silently cost **six challenges** on the Juice Shop benchmark and presented as two separate detection regressions.

**Removing the endpoint caps is what made this urgent.** Time is now the only bound, so hitting a timeout went from unusual to ordinary — and **17 scanners walk endpoints with no `TimeBudget` at all**, meaning all of them were one slow target away from this.

## The fix

Scanners stop *themselves*. The runner publishes its deadline through a contextvar; `TimeBudget()` with no argument inherits it, so a scanner opts in with two lines and never needs to know its own timeout — which is exactly how inner and outer budgets drift apart. The hard cancel stays as a backstop for something genuinely hung, and now logs loudly when it fires.

```
before:  returned 0 finding(s) after 900s   (cancelled)
after:   returned 4 finding(s) after 768s   (stopped itself)
```

Applied to `http_probe`, `idor`, `cors` and `csrf` — the endpoint-walkers the cap removal put most at risk.

`http_probe` also runs its **fixed-cost checks first**. Two of its five probe a handful of known paths and cost the same whatever the inventory holds; the other three scale with it. Running them last meant a large app spent its budget on method tampering and never reached the check that finds the `.env`.

## What my first attempt got wrong

I checked the budget *between* `http_probe`'s five checks. It didn't work — one check walks the whole inventory, so it entered before the deadline, ran 800s, and was cancelled with everything in it. The check belongs in the per-endpoint loop.

**Only the real 900-second run caught that.** The unit tests passed against the broken version: they verified the mechanism, and nothing verified that the scanner yields often enough to use it. The mutation check caught a different gap (the runner not publishing the deadline) but not this one.

## Verification

| target | result |
|---|---|
| juiceshop | 26/45, `exposed_data 4/5`, `info_disclosure 2/2` |
| juiceshop-auth | 29/45, `exposed_data 4/5`, `info_disclosure 2/2` |
| vampi-vulnerable | 3/3 |
| vampi-secure | unchanged |
| sast-injection | 46/46, 0 FP |
| suite | **2476 passed** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EZ4QoTqRoYWE25CNoV2Wfy