### PR TITLE
docs: --probe-writes measures 26/45 to 32/45, so say so

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,38 @@ isitsecure scan https://your-app.com --depth deep --llm none
 
 The scan narrates each phase and every scanner as it runs (with elapsed time), so a longer `deep` scan shows continuous progress rather than appearing to hang.
 
+## Testing the Mutation Surface (`--probe-writes`)
+
+A path in a JavaScript bundle carries no HTTP method, so every endpoint is
+discovered as a `GET`. Any scanner that tests `POST`/`PUT` then finds nothing
+to work on — which leaves **stored XSS, mass assignment, CSRF and SSTI
+untested**, because all of them live behind a state-changing request.
+
+`--probe-writes` derives those endpoints from REST shape: `POST` to a
+collection, `PUT` to an item.
+
+```bash
+isitsecure scan https://your-app.com --probe-writes
+```
+
+Measured on OWASP Juice Shop v20.1.1, url-only:
+
+| | without | with `--probe-writes` |
+|---|---|---|
+| **recall** | 26/45 (58%) | **32/45 (71%)** |
+| CSRF | 0/1 | 1/1 |
+| SSTI | 0/1 | 1/1 |
+| XSS | 1/7 | 4/7 |
+| IDOR | 2/5 | 3/5 |
+
+**It is off by default, and should stay off for anything you do not own.**
+The scan *writes to the target*: it creates records, and an endpoint that
+sends email or charges a card will do so. It also takes roughly 48 minutes
+against 27 on that app, since the inventory doubles.
+
+`DELETE` is derived and deliberately never sent — a scanner that destroys a
+record to prove it could is not worth the finding.
+
 ## What It Scans
 
 ### DAST Scanners — Tests Your Live App
@@ -549,6 +581,9 @@ Options:
   -b, --branch TEXT      Git branch [default: the repo's own default branch]
   -m, --mode TEXT        Scan mode: auto|url-only|code-only|authenticated|full
   --depth TEXT           Scan depth: quick|deep [default: quick]
+  --probe-writes         Test the mutation surface (stored XSS, mass
+                         assignment, CSRF). WRITES to the target — only for
+                         an app you own or are authorized to test.
   --llm TEXT             LLM provider: anthropic|google|none [default: anthropic]
   -o, --output TEXT      Output format: table|json|html|sarif|fixes [default: table]
   -f, --output-file TEXT Write report to file

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -363,6 +363,18 @@ It is off by default: it makes a scan write to whatever it is pointed at.
 DELETE is derived and deliberately never emitted — a scanner that destroys a
 record to prove it could is not worth the finding.
 
+Measured on Juice Shop, url-only: **26/45 → 32/45**, gaining CSRF, SSTI,
+three of the five XSS challenges and one IDOR, losing nothing. The scan takes
+about 48 minutes against 27, since the inventory doubles.
+
+That number was not always what it looked like. The first measurement read
+neutral — six gained, six lost — and the six "lost" were `exposed_data` and
+`info_disclosure`, both of which score off `http_probe_scanner`. It was
+running one second past its timeout and having every finding discarded by the
+hard cancel; the doubled inventory pushed it over. One bug wearing the
+costume of a trade-off, and worth remembering when a measurement shows a
+suspiciously tidy wash.
+
 ### Remediation scope
 
 Findings arrive one per affected location, which is right for detection and


### PR DESCRIPTION
Closes #202.

The flag shipped in v0.25.0 with a warning in `--help` and nothing else, because its only measurement read neutral. **That measurement was wrong** — the six challenges it appeared to lose were `exposed_data` and `info_disclosure`, both scoring off `http_probe_scanner`, which was running one second past its timeout and having every finding discarded by the hard cancel. Fixed in v0.25.3.

## Re-measured

Juice Shop v20.1.1, url-only, `--llm none`:

| | without | with `--probe-writes` |
|---|---|---|
| **recall** | 26/45 (58%) | **32/45 (71%)** |
| CSRF | 0/1 | 1/1 |
| SSTI | 0/1 | 1/1 |
| XSS | 1/7 | 4/7 |
| IDOR | 2/5 | 3/5 |
| exposed_data | 4/5 | 4/5 — held |
| info_disclosure | 2/2 | 2/2 — held |

**+6, nothing lost.**

## What's documented

**README** gains a section on why the flag exists — a path in a bundle carries no HTTP method, so everything is discovered as `GET` and any scanner filtering for `POST`/`PUT` finds nothing to do, leaving stored XSS, mass assignment, CSRF and SSTI untested. With the numbers, the ~48-minutes-against-27 cost, and the part that matters most: **it writes to the target**, so it stays off for anything you don't own. It's also added to the CLI options block, which had omitted it.

**architecture.md** records how the first measurement misled — a suspiciously tidy +6/−6 wash turned out to be one bug wearing the costume of a trade-off, which is worth remembering next time a number looks that neat.

Docs only; no code changes. Suite 2476 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EZ4QoTqRoYWE25CNoV2Wfy