### PR TITLE
fix(discovery): collect <link> JS chunks + see mass assignment past the response envelope

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,15 +198,16 @@ Measured on OWASP Juice Shop v20.1.1, url-only:
 
 | | without | with `--probe-writes` |
 |---|---|---|
-| **recall** | 26/45 (58%) | **32/45 (71%)** |
+| **recall** | 26/45 (58%) | **33/45 (73%)** |
 | CSRF | 0/1 | 1/1 |
 | SSTI | 0/1 | 1/1 |
 | XSS | 1/7 | 4/7 |
 | IDOR | 2/5 | 3/5 |
+| mass assignment | 0/2 | 1/2 |
 
 **It is off by default, and should stay off for anything you do not own.**
 The scan *writes to the target*: it creates records, and an endpoint that
-sends email or charges a card will do so. It also takes roughly 48 minutes
+sends email or charges a card will do so. It also takes roughly 72 minutes
 against 27 on that app, since the inventory doubles.
 
 `DELETE` is derived and deliberately never sent — a scanner that destroys a
@@ -290,6 +291,7 @@ record to prove it could is not worth the finding.
 
 | Feature | What It Does |
 |---|---|
+| Lazy-Chunk Bundle Collection | Collects JavaScript from `<link rel=modulepreload/preload/prefetch>` as well as `<script src>` — a code-split SPA ships its routes as `<link>` chunks, so a script-only sweep sees the shell and none of the API surface |
 | OpenAPI/Swagger Discovery | Probes `/openapi.json`, `/swagger.json`, `/v3/api-docs` and parses the spec into testable endpoints — finds attack surface on APIs with no crawlable frontend |
 | HTML Form/Link Discovery | Reads `<form>`/`<input>`/query-links from server-rendered pages (bounded url-only crawl + inside the authenticated crawler) — finds attack surface on classic MVC apps with no JS API bundle |
 | Endpoint Prioritizer + Time Budget | Ranks likely-vulnerable endpoints first and tests within a per-scanner time budget, so high-risk paths get covered before the clock runs out |
@@ -730,7 +732,7 @@ isitsecure scan http://localhost:4000 --repo ./test-app --mode full
 
 isitsecure ships a repeatable benchmark harness that scores **recall** (of the vulnerability classes an app is known to have, how many we catch) and **false positives** (findings that must not appear against a hardened build) on public, deliberately-vulnerable apps.
 
-**Measured coverage — be realistic about what a scanner catches.** On [OWASP Juice Shop](https://owasp.org/www-project-juice-shop/) `v20.1.1` — a deliberately hard benchmark of 113 challenges — isitsecure detects **58% of the 45 DAST-detectable challenge classes** in a url-only scan, scored automatically against the app's own `/api/Challenges` list. `--probe-writes` takes that to **71%** and an authenticated two-user pass to **64%** (they find different things: writes buy the stored-XSS, CSRF and SSTI challenges, authentication buys cross-user object access). All three are **deterministic and reproducible in one command** (`python benchmarks/run_benchmarks.py juiceshop`, ~27 min — identical on repeat runs). It's perfect on SQL injection (7/7, including login/authentication-bypass SQLi — a tautology that logs in where a real credential is rejected), file upload (4/4) and XXE (2/2), and strong on exposed data/secrets, open redirects and misconfiguration. The **remaining gaps are SSRF (0/2), mass assignment (0/2), rate limiting, and the stored/header XSS variants**, plus challenges needing multi-step business-logic exploitation. **NoSQL injection is a known weak class:** the detector finds common operator-injection leaks but is noisy — it can false-positive on endpoints with naturally variable responses, so treat NoSQL findings as leads to confirm, not confirmed bugs. In other words: a solid automated first pass that catches whole classes of real bugs in one command — **not** a substitute for a manual pentest. Full per-class breakdown, gaps, and methodology are in [benchmarks/RESULTS.md](benchmarks/RESULTS.md).
+**Measured coverage — be realistic about what a scanner catches.** On [OWASP Juice Shop](https://owasp.org/www-project-juice-shop/) `v20.1.1` — a deliberately hard benchmark of 113 challenges — isitsecure detects **58% of the 45 DAST-detectable challenge classes** in a url-only scan, scored automatically against the app's own `/api/Challenges` list. `--probe-writes` takes that to **73%** and an authenticated two-user pass to **64%** (they find different things: writes buy the stored-XSS, CSRF and SSTI challenges, authentication buys cross-user object access). All three are **deterministic and reproducible in one command** (`python benchmarks/run_benchmarks.py juiceshop`, ~27 min — identical on repeat runs). It's perfect on SQL injection (7/7, including login/authentication-bypass SQLi — a tautology that logs in where a real credential is rejected), file upload (4/4) and XXE (2/2), and strong on exposed data/secrets, open redirects and misconfiguration. The **remaining gaps are SSRF (0/2), the captcha-gated half of mass assignment (1/2), rate limiting, and the stored/header XSS variants**, plus challenges needing multi-step business-logic exploitation. **NoSQL injection is a known weak class:** the detector finds common operator-injection leaks but is noisy — it can false-positive on endpoints with naturally variable responses, so treat NoSQL findings as leads to confirm, not confirmed bugs. In other words: a solid automated first pass that catches whole classes of real bugs in one command — **not** a substitute for a manual pentest. Full per-class breakdown, gaps, and methodology are in [benchmarks/RESULTS.md](benchmarks/RESULTS.md).
 
 ```bash
 python benchmarks/run_benchmarks.py juiceshop   # OWASP Juice Shop — the headline recall number

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -10,14 +10,22 @@ Semgrep taint layer against a local injection fixture (see below).
 pip install -e ".[all]"          # isitsecure on PATH + browser deps
 python benchmarks/run_benchmarks.py            # default: VAmPI (both builds) + sast-injection
 python benchmarks/run_benchmarks.py juiceshop  # OWASP Juice Shop — the headline recall number
+python benchmarks/run_benchmarks.py juiceshop-writes  # + --probe-writes (mutates the target; ~72 min)
 python benchmarks/run_benchmarks.py --all      # + NodeGoat + crAPI + Juice Shop (heavy)
 python benchmarks/run_benchmarks.py crapi      # a single target
 python benchmarks/run_benchmarks.py sast-injection            # taint recall/FP, no Docker
 python benchmarks/run_benchmarks.py --keep vampi-vulnerable   # leave it running
+python benchmarks/run_benchmarks.py juiceshop --report-dir /tmp/r  # keep the raw JSON reports
 ```
 
 Docker is required for every target **except** `sast-injection`, which instead
 needs the `semgrep` binary (`pipx install semgrep` or `pip install semgrep`).
+
+`--report-dir DIR` keeps each target's raw JSON report instead of discarding
+it. The scorecard says *how many* findings went unmatched but not *which*, and
+an unmatched finding is either a real-but-undocumented vulnerability or a false
+positive — exactly the distinction worth a look. Without the report, answering
+that means re-running a scan that can take over an hour.
 
 ## What it measures
 

--- a/benchmarks/RESULTS.md
+++ b/benchmarks/RESULTS.md
@@ -14,8 +14,8 @@ _Runs: 2026-09 · `--llm none` (pure DAST detection, no LLM) · Juice Shop pinne
 
 | Target | Mode | Recall | False positives | Findings |
 |---|---|--:|--:|--:|
-| `juiceshop` | url-only | **26/45 (58%)** — per-challenge, deterministic | not yet measured | 26 |
-| `juiceshop` | url-only + `--probe-writes` | **32/45 (71%)** | not yet measured | 74 |
+| `juiceshop` | url-only | **26–27/45 (58–60%)** — per-challenge, deterministic | **3 IDOR** (see triage below) | 30 |
+| `juiceshop-writes` | url-only + `--probe-writes` | **33/45 (73%)** | 8 unmatched of 95 | 95 |
 | `juiceshop-auth` | authenticated, two-user | **29/45 (64%)** | not yet measured | 35 |
 | `vampi-vulnerable` | url-only | **3/3** (SQLi, IDOR, headers) | — | 8–10 |
 | `vampi-secure` | url-only | — | **2** (IDOR) | 7–9 |
@@ -84,11 +84,11 @@ registered users.
 | xss | 1/7 | **4/7** | 2/7 |
 | csrf | 0/1 | **1/1** | 0/1 |
 | ssti | 0/1 | **1/1** | 0/1 |
-| mass_assignment | 0/2 | 0/2 | 0/2 |
+| mass_assignment | 0/2 | **1/2** | 0/2 |
 | ssrf | 0/2 | 0/2 | 0/2 |
 | auth | 0/1 | 0/1 | 0/1 |
 | rate_limit | 0/1 | 0/1 | 0/1 |
-| **total** | **26/45** | **32/45** | **29/45** |
+| **total** | **26/45** | **33/45** | **29/45** |
 
 **Biggest gaps (the recall levers):**
 
@@ -115,9 +115,49 @@ registered users.
   posted a raw XML body, where that endpoint takes XML as an uploaded file.
   Three separate fixes, none of them to a scanner's detection logic.
 
-- **mass_assignment is 0/2 even with `--probe-writes`**, despite both challenges
-  needing a POST that the flag now supplies — so something beyond method
-  discovery blocks them. Open.
+- **mass_assignment is 1/2**, and getting there took two fixes in different
+  layers. `POST /api/Users` was never in the inventory: Juice Shop ships 10 of
+  its 13 JavaScript files as `<link rel="modulepreload">` chunks, and ingestion
+  only collected `<script src>`. Once discovered, the probe *was* accepted —
+  201, `role: admin` echoed back — but the reflection check only inspected the
+  top level of the response, and the object came wrapped in
+  `{"status":"success","data":{…}}`. A live, challenge-solving mass assignment
+  read as clean. Fixing discovery alone, or the envelope alone, yields nothing.
+
+  The other half, `feedbackChallenge`, stays open for a different reason: the
+  probe sends the escalation field with **no valid base payload**, and
+  `POST /api/Feedbacks` also demands a captcha. That is app-specific
+  anti-automation rather than a generic gap, so it is documented in
+  [the scanner's doc](../docs/scanners/mass-assignment-scanner.md) rather than
+  special-cased.
+
+### url-only false positives (triaged 2026-09)
+
+The scorecard counts unmatched findings but the harness used to discard the
+report that said *which*, so this was unanswerable without a re-run;
+`--report-dir` now keeps it. Of the 8 unmatched on a url-only run, 5 are IDOR
+claims, hand-verified against the live app:
+
+| endpoint | response | verdict |
+|---|---|---|
+| `/api/Recycles/1` | `{"UserId":2,"AddressId":4,…}` | **real** — another user's record, unauthenticated |
+| `/rest/memories` | `{"UserId":13,…,"email":…}` | **real** — leaks users and emails |
+| `/rest/user/whoami` | `{"user":{}}` | **false positive** |
+| `/api/Deliverys/1` | `{"name":"One Day Delivery","price":0.99}` | **false positive** — public catalogue |
+| `/api/Products/1` | public product | **false positive** — public catalogue |
+
+The `whoami` case has a specific cause worth recording: `_response_has_data` is
+a *length* test standing in for a *content* test — any JSON body of at least 10
+bytes counts as data, and `{"user":{}}` is 11. The remaining three unmatched are
+real-but-unscored (localStorage token, missing HSTS/CSP, wildcard CORS).
+
+> **`--probe-writes` takes ~72 minutes** (measured: injection 39 min, IDOR 14,
+> DOM-XSS 5, the other eleven scanners ~2 min between them, over a 248-endpoint
+> inventory). Its harness budget is 3h. It previously sat at 1h, which returned
+> *no report at all* — a scan that blows its budget is scored as an error, not
+> as lower recall, so too small a budget erases the measurement rather than
+> shrinking it. One scanner's own ceiling (injection, 90 min) already exceeded
+> that 1h cap, so this mode could never have fit inside it.
 
 ## Authenticated cross-user BOLA (manually verified — heavy to reproduce)
 
@@ -129,7 +169,7 @@ challenges, taking `idor` from 2/5 to **4/5**.
 
 It is now harness-scored at **29/45 (64%)** rather than measured by hand, and
 runs in one command like the others. Note it scores *lower* than
-`--probe-writes` (32/45) while finding different things — authentication buys
+`--probe-writes` (33/45) while finding different things — authentication buys
 the object-access challenges, writes buy the stored/CSRF/SSTI ones. Nothing
 stops both being used together; that combination has not been measured.
 

--- a/benchmarks/run_benchmarks.py
+++ b/benchmarks/run_benchmarks.py
@@ -68,6 +68,9 @@ class Target:
     url: str                      # base URL to scan once ready
     ready_url: str                # URL to poll for readiness
     scan_mode: str = "url-only"
+    # Extra CLI flags for the scan. A mode we publish a recall number
+    # for has to be reproducible with one command, same as the others.
+    extra_args: list[str] = field(default_factory=list)
     expect: list[Expectation] = field(default_factory=list)   # recall
     forbid: list[Expectation] = field(default_factory=list)   # false positives
     ready_timeout: int = 180
@@ -244,6 +247,25 @@ TARGETS: list[Target] = [
               "(the '36% url-only' headline number).",
     ),
     Target(
+        name="juiceshop-writes",
+        up_cmd=["docker", "run", "-d", "--name", "bench_juiceshop",
+                "-p", "3000:3000", "bkimminich/juice-shop:v20.1.1"],
+        url="http://localhost:3000",
+        ready_url="http://localhost:3000/",
+        down_cmd=["docker", "rm", "-f", "bench_juiceshop"],
+        ready_timeout=300,
+        extra_args=["--probe-writes"],
+        # Measured at 72m16s. The old 3600s default cut this off 12 minutes
+        # short and yielded NO report at all -- a timeout is scored as an
+        # error, not a lower recall, so too small a budget erases the whole
+        # measurement. 3h leaves room for the injection scanner, which used
+        # 39 of its 90-minute budget here and is free to use all of it.
+        scan_timeout=10800,
+        ground_truth="juiceshop",
+        notes="OWASP Juice Shop with --probe-writes — the mutation surface. "
+              "Writes to the target, so it needs a disposable container.",
+    ),
+    Target(
         name="juiceshop-auth",
         up_cmd=["docker", "run", "-d", "--name", "bench_juiceshop",
                 "-p", "3000:3000", "bkimminich/juice-shop:v20.1.1"],
@@ -291,6 +313,14 @@ def wait_ready(url: str, timeout: int) -> bool:
     return False
 
 
+# When set, each target's raw report is kept here instead of discarded.
+# The scorecard reports how many findings went unmatched but not WHICH --
+# and an unmatched finding is either a real-but-undocumented vuln or a
+# false positive, which is exactly the distinction you re-run a 30-minute
+# scan to make. Keep the report and it is answerable without the re-run.
+REPORT_DIR: str | None = None
+
+
 def scan(target: Target) -> list[dict] | None:
     """Run isitsecure and return its findings.
 
@@ -301,6 +331,7 @@ def scan(target: Target) -> list[dict] | None:
         out = f.name
     cmd = ["isitsecure", "scan", target.url, "--mode", target.scan_mode,
            "--llm", "none", "--output", "json", "-f", out]
+    cmd += target.extra_args
     if target.auth_email and target.auth_password:
         cmd += ["--auth-email", target.auth_email,
                 "--auth-password", target.auth_password]
@@ -325,10 +356,18 @@ def scan(target: Target) -> list[dict] | None:
             return None
         return data.get("findings", [])
     finally:
-        try:
-            os.unlink(out)
-        except OSError:
-            pass
+        if REPORT_DIR:
+            kept = os.path.join(REPORT_DIR, f"{target.name}.json")
+            try:
+                os.replace(out, kept)
+                print(f"    report kept at {kept}")
+            except OSError:
+                pass
+        else:
+            try:
+                os.unlink(out)
+            except OSError:
+                pass
 
 
 def score(findings: list[dict], target: Target) -> dict:
@@ -467,7 +506,14 @@ def main() -> int:
     ap.add_argument("targets", nargs="*", help="target names (default: vampi + sast-injection)")
     ap.add_argument("--keep", action="store_true", help="don't tear down containers")
     ap.add_argument("--all", action="store_true", help="include heavy compose targets")
+    ap.add_argument("--report-dir", help="keep each target's raw JSON report here "
+                                         "(so unmatched findings can be triaged)")
     args = ap.parse_args()
+
+    global REPORT_DIR
+    if args.report_dir:
+        os.makedirs(args.report_dir, exist_ok=True)
+        REPORT_DIR = args.report_dir
 
     by_name = {t.name: t for t in TARGETS}
     docker_names, want_sast, unknown = resolve_selection(args.targets, args.all)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -35,7 +35,12 @@ Phase 11: Fix Generation         ─── AI generates code patches (optional, 
 
 The scanner first understands your application's attack surface using **four complementary discovery strategies** (`EndpointDiscoveryScanner`), so it works on SPAs, classic server-rendered apps, and frontend-less REST APIs alike:
 
-1. **Playwright** navigates to your URL and captures the rendered HTML + all loaded JavaScript bundles
+1. **Playwright** navigates to your URL and captures the rendered HTML + all loaded JavaScript bundles.
+   Bundles are collected from `<script src>` **and** from `<link href="….js">` — modulepreload,
+   preload and prefetch. A code-split SPA ships its entry bundle as a `<script>` and every lazy
+   route chunk as a `<link>`, so a script-only sweep sees the shell and none of the routes. On
+   Juice Shop that gap hid 10 of the 13 JavaScript files, and with them `/api/Users` and
+   `/api/Feedbacks`: adding the `<link>` source took url-only discovery from 61 endpoints to 123
 2. **Seven regex patterns** extract API endpoints from the JS code: fetch calls, axios requests, Supabase `from()` queries, route definitions, parameterized paths
 3. **OpenAPI/Swagger spec discovery** — probes 13 well-known spec locations (`/openapi.json`, `/swagger.json`, `/v3/api-docs`, `/v2/api-docs`, `/swagger/v1/swagger.json`, `/.well-known/openapi.json`, …) for each API base, parses any spec it finds, and extracts every declared endpoint with its methods, path parameters (including `{templated}` segments), and query parameters. This surfaces APIs with no crawlable frontend
 4. **HTML form/link discovery** (`html_endpoint_extractor`) — parses server-rendered pages with a stdlib `HTMLParser` to extract `<form action>` targets (with their `<input>`/`<select>`/`<textarea>` field names as parameters) and `<a href>` links that carry query parameters. This surfaces classic MVC apps that have no JS API bundle. It runs both in url-only discovery (bounded same-origin crawl) and inside the authenticated crawler after each page load
@@ -363,7 +368,7 @@ It is off by default: it makes a scan write to whatever it is pointed at.
 DELETE is derived and deliberately never emitted — a scanner that destroys a
 record to prove it could is not worth the finding.
 
-Measured on Juice Shop, url-only: **26/45 → 32/45**, gaining CSRF, SSTI,
+Measured on Juice Shop, url-only: **26/45 → 33/45**, gaining CSRF, SSTI,
 three of the five XSS challenges and one IDOR, losing nothing. The scan takes
 about 48 minutes against 27, since the inventory doubles.
 

--- a/docs/scanners/mass-assignment-scanner.md
+++ b/docs/scanners/mass-assignment-scanner.md
@@ -8,6 +8,16 @@ Sends POST/PATCH requests with extra fields that shouldn't be accepted — `is_a
 
 Also tests Supabase-specific escalation fields via the REST API.
 
+### Where it looks in the response
+
+The injected field is searched for **anywhere in the response body**, not just at the top level. Most APIs wrap the object they just created in an envelope — `{"status": "success", "data": {...}}`, `{"result": {...}}`, JSON:API's `{"data": {"attributes": {...}}}` — and a top-level-only check reads every one of those as "not reflected". That is how a confirmed, reproducible mass assignment reports as clean.
+
+The value still has to match: finding `role` nested somewhere proves nothing if it came back as `customer`.
+
+### What it does not do yet
+
+The probe sends the escalation field **on its own**, with no valid base payload. An endpoint that validates its required fields rejects that request outright, so the escalation never gets evaluated. This is the reason Juice Shop's `feedbackChallenge` (a `POST /api/Feedbacks` that also demands a captcha) is out of reach while `registerAdminChallenge` (a `POST /api/Users` that accepts a bare body) is not.
+
 ## Why It Matters
 
 If your API blindly accepts all fields from the request body, attackers can:

--- a/isitsecure/engine/ingestion/constants.py
+++ b/isitsecure/engine/ingestion/constants.py
@@ -10,7 +10,10 @@ class ScanConfig:
     PAGE_LOAD_TIMEOUT_MS = 60000
     ASSET_FETCH_TIMEOUT_SECONDS = 15
     MAX_JS_BUNDLE_SIZE_BYTES = 10 * 1024 * 1024  # 10MB
-    MAX_ASSETS_TO_FETCH = 20
+    # A code-split SPA routinely ships 30-80 chunks. 20 was enough when
+    # only <script src> was collected; once preloaded chunks count too,
+    # a low cap silently truncates the API surface we can discover.
+    MAX_ASSETS_TO_FETCH = 100
     MAX_PROBE_CONTENT_LENGTH = 5000
     MIN_INLINE_SCRIPT_LENGTH = 50
 

--- a/isitsecure/engine/ingestion/url_ingestion.py
+++ b/isitsecure/engine/ingestion/url_ingestion.py
@@ -29,6 +29,21 @@ class URLIngestionService:
     SCRIPT_SRC_PATTERN = re.compile(
         r'<script[^>]+src=["\']([^"\']+)["\']', re.IGNORECASE
     )
+    # Bundlers emit lazy-loaded chunks as <link rel="modulepreload"> rather
+    # than <script src>, so a script-only sweep sees the entry bundle and
+    # none of the route chunks — which is where most of an SPA's API surface
+    # lives. A <link> pointing at JavaScript exists to load that JavaScript,
+    # whatever the rel says, so match on the href instead of on a rel list.
+    LINK_JS_PATTERN = re.compile(
+        r'<link[^>]+href=["\'](?P<link>[^"\']+\.m?js(?:\?[^"\']*)?)["\']', re.IGNORECASE
+    )
+    # One pass over the document so scripts and preloaded chunks come back
+    # interleaved as they appear, rather than all of one then all of the other.
+    JAVASCRIPT_REF_PATTERN = re.compile(
+        r'<script[^>]+src=["\'](?P<script>[^"\']+)["\']'
+        r'|' + LINK_JS_PATTERN.pattern,
+        re.IGNORECASE,
+    )
     SOURCE_MAP_COMMENT_PATTERN = re.compile(
         r"//[#@]\s*sourceMappingURL=(\S+)"
     )
@@ -118,8 +133,7 @@ class URLIngestionService:
         """Extract script URLs from HTML and fetch their content."""
         assets: list[PageAsset] = []
 
-        script_urls = self.SCRIPT_SRC_PATTERN.findall(html_content)
-        script_urls = script_urls[: ScanConfig.MAX_ASSETS_TO_FETCH]
+        script_urls = self._javascript_urls(html_content)
 
         inline_scripts = self.INLINE_SCRIPT_PATTERN.findall(html_content)
         for i, content in enumerate(inline_scripts):
@@ -148,6 +162,25 @@ class URLIngestionService:
                     assets.append(asset)
 
         return assets
+
+    def _javascript_urls(self, html_content: str) -> list[str]:
+        """Every JavaScript URL the page references, in document order.
+
+        Both <script src> and <link href="...js"> (modulepreload/preload/
+        prefetch), de-duplicated so a chunk that is both preloaded and
+        scripted is fetched once. Document order matters because the cap
+        truncates the tail: collecting all scripts before any chunk would
+        let a script-heavy page starve out the chunks, which are the half
+        that carries the lazy-loaded API surface.
+        """
+        seen: set[str] = set()
+        urls: list[str] = []
+        for match in self.JAVASCRIPT_REF_PATTERN.finditer(html_content):
+            src = match.group("script") or match.group("link")
+            if src and src not in seen:
+                seen.add(src)
+                urls.append(src)
+        return urls[: ScanConfig.MAX_ASSETS_TO_FETCH]
 
     async def _fetch_single_asset(
         self,

--- a/isitsecure/engine/scanners/mass_assignment_scanner.py
+++ b/isitsecure/engine/scanners/mass_assignment_scanner.py
@@ -218,19 +218,39 @@ class MassAssignmentScanner(AuthAwareScanner):
             # Fallback: string matching
             return str(field_name) in response_body and str(field_value) in response_body
 
-        # Check top-level dict
-        if isinstance(data, dict):
-            return _dict_has_field(data, field_name, field_value)
+        return _contains_field(data, field_name, field_value)
 
-        # Check array of dicts (common for Supabase)
-        if isinstance(data, list):
-            return any(
-                _dict_has_field(item, field_name, field_value)
-                for item in data
-                if isinstance(item, dict)
-            )
 
+# Most APIs wrap the created object in an envelope -- {"status": .., "data": ..},
+# {"result": ..}, JSON:API's {"data": {"attributes": ..}}. A top-level-only
+# check calls every one of those "not reflected" and reports nothing, which is
+# how a live, confirmed mass assignment reads as clean. Search the whole tree
+# instead of guessing at envelope key names.
+MAX_RESPONSE_DEPTH = 8
+
+
+def _contains_field(
+    data: Any, field_name: str, field_value: Any, depth: int = 0
+) -> bool:
+    """Whether the field appears anywhere in a decoded JSON response."""
+    if depth > MAX_RESPONSE_DEPTH:
         return False
+
+    if isinstance(data, dict):
+        if _dict_has_field(data, field_name, field_value):
+            return True
+        return any(
+            _contains_field(value, field_name, field_value, depth + 1)
+            for value in data.values()
+        )
+
+    if isinstance(data, list):
+        return any(
+            _contains_field(item, field_name, field_value, depth + 1)
+            for item in data
+        )
+
+    return False
 
 
 def _dict_has_field(data: dict[str, Any], field_name: str, field_value: Any) -> bool:

--- a/isitsecure/engine/shared/scanner_runner.py
+++ b/isitsecure/engine/shared/scanner_runner.py
@@ -29,23 +29,25 @@ class ScannerTimeouts:
 
     DEFAULT_SECONDS = 600
     AUTHENTICATED_CRAWLER_SECONDS = 900  # Browser login + BFS crawl of 50 pages
-    IDOR_CROSS_USER_SECONDS = 1800
-    PRIVILEGE_ESCALATION_SECONDS = 1800  # 8 tests: differential, mutation replay, object write, etc.
+    IDOR_CROSS_USER_SECONDS = 1800   # 30 min
+    PRIVILEGE_ESCALATION_SECONDS = 1800  # 30 min — 8 tests: differential, mutation replay, object write, etc.
     GIT_SECRET_SCAN_SECONDS = 90
     SEMGREP_TAINT_SECONDS = 150  # above SemgrepAnalyzer's own 120s subprocess timeout
     LLM_CODE_REVIEW_SECONDS = 900  # 15 min — reviews in parallel batches (includes import-graph files)
-    LSP_VALIDATION_SECONDS = 600   # 2 min — LSP init + auth flow tracing
+    LSP_VALIDATION_SECONDS = 600   # 10 min — LSP init + auth flow tracing
     TRIAGE_SECONDS = 900           # 15 min — batched LLM triage + themes + owner summary
     INJECTION_ADJUDICATOR_SECONDS = 240  # 4 min — batched LLM genuine-vs-benign injection review (#5)
-    XSS_ACTIVE_SECONDS = 3600       # 10 min — 20 endpoints × 5 params × 3 probe stages (deep)
-    XSS_QUICK_SECONDS = 900        # 2 min — reflected + POST-body only, no DOM pass (quick, #118)
-    INJECTION_ACTIVE_SECONDS = 5400  # 15 min — 30 endpoints × 5 params, time-based SQLi (3s sleeps)
-    AUTH_BYPASS_SECONDS = 1800       # 5 min — multiple login attempts + timing measurements
-    RATE_LIMIT_SECONDS = 900        # 5 min — 100+ burst requests
-    HTTP_PROBE_SECONDS = 900        # 3 min — TRACE, host injection, directory listing, CRLF
+    XSS_ACTIVE_SECONDS = 3600       # 60 min — every endpoint × 5 params × 3 probe stages (deep)
+    XSS_QUICK_SECONDS = 900        # 15 min — reflected + POST-body only, no DOM pass (quick, #118)
+    INJECTION_ACTIVE_SECONDS = 5400  # 90 min — every endpoint × 5 params, time-based SQLi (3s sleeps).
+    # The largest single budget by far, and the one that decides how long a
+    # full scan takes: any wall-clock cap below this cannot fit one scan.
+    AUTH_BYPASS_SECONDS = 1800       # 30 min — multiple login attempts + timing measurements
+    RATE_LIMIT_SECONDS = 900        # 15 min — 100+ burst requests
+    HTTP_PROBE_SECONDS = 900        # 15 min — TRACE, host injection, directory listing, CRLF
     PROBE_ANALYZER_SECONDS = 30     # Pure data analysis, no HTTP requests
-    GUIDED_DAST_SECONDS = 1800       # 10 min — SAST-guided test cases
-    DOM_XSS_SECONDS = 1800           # 15 min — Playwright: navigate + hook sinks on up to 30 pages
+    GUIDED_DAST_SECONDS = 1800       # 30 min — SAST-guided test cases
+    DOM_XSS_SECONDS = 1800           # 30 min — Playwright: navigate + hook sinks on up to 30 pages
     OOB_POLL_SECONDS = 30           # OOB callback poll (just HTTP calls, no scanning)
 
 

--- a/tests/engine/test_mass_assignment_scanner.py
+++ b/tests/engine/test_mass_assignment_scanner.py
@@ -263,3 +263,39 @@ class TestEdgeCases:
         assert not MassAssignmentScanner._field_in_response(
             "role", "admin", "nothing relevant"
         )
+
+
+class TestEnvelopedResponses:
+    """A created object is rarely at the top level of the response."""
+
+    def test_field_inside_data_envelope(self) -> None:
+        """{"status": .., "data": {..}} is the most common API shape."""
+        body = '{"status":"success","data":{"id":28,"role":"admin","email":null}}'
+        assert MassAssignmentScanner._field_in_response("role", "admin", body)
+
+    def test_field_inside_jsonapi_attributes(self) -> None:
+        """JSON:API nests the object two levels down."""
+        body = '{"data":{"type":"users","attributes":{"is_admin":true}}}'
+        assert MassAssignmentScanner._field_in_response("is_admin", True, body)
+
+    def test_field_inside_array_of_envelopes(self) -> None:
+        """A list response still has to be searched element by element."""
+        body = '{"results":[{"user":{"plan":"free"}},{"user":{"plan":"enterprise"}}]}'
+        assert MassAssignmentScanner._field_in_response(
+            "plan", "enterprise", body
+        )
+
+    def test_nested_wrong_value_is_not_a_hit(self) -> None:
+        """Finding the key nested is not enough -- the value must match."""
+        body = '{"status":"success","data":{"role":"customer"}}'
+        assert not MassAssignmentScanner._field_in_response("role", "admin", body)
+
+    def test_absent_field_stays_absent_however_deep(self) -> None:
+        """Recursion must not turn a clean response into a finding."""
+        body = '{"status":"success","data":{"a":{"b":{"c":[1,2,{"d":"e"}]}}}}'
+        assert not MassAssignmentScanner._field_in_response("role", "admin", body)
+
+    def test_depth_is_bounded(self) -> None:
+        """A pathologically deep response must not blow the stack."""
+        body = "{" + '"a":{' * 400 + '"role":"admin"' + "}" * 400 + "}"
+        assert not MassAssignmentScanner._field_in_response("role", "admin", body)

--- a/tests/engine/test_url_ingestion_assets.py
+++ b/tests/engine/test_url_ingestion_assets.py
@@ -1,0 +1,76 @@
+"""Which JavaScript a page actually ships, as opposed to which it <script>s."""
+
+from __future__ import annotations
+
+from isitsecure.engine.ingestion.constants import ScanConfig
+from isitsecure.engine.ingestion.url_ingestion import URLIngestionService
+
+
+class TestJavaScriptURLExtraction:
+    def test_script_src_is_collected(self) -> None:
+        html = '<script src="/main.js"></script>'
+        assert URLIngestionService()._javascript_urls(html) == ["/main.js"]
+
+    def test_modulepreload_chunks_are_collected(self) -> None:
+        """Code-split chunks reach the page as <link>, not <script>.
+
+        Missing them costs the whole lazy-loaded route surface -- which on a
+        typical SPA is where most of the API calls live.
+        """
+        html = (
+            '<link rel="modulepreload" href="chunk-ABC.js">'
+            '<script src="main.js"></script>'
+        )
+        urls = URLIngestionService()._javascript_urls(html)
+        assert urls == ["chunk-ABC.js", "main.js"]
+
+    def test_order_follows_the_document_not_the_tag_type(self) -> None:
+        """The cap truncates the tail, so ordering decides what gets dropped.
+
+        Gathering every <script> before any <link> would let a script-heavy
+        page starve out the chunks -- the half carrying the lazy API surface.
+        """
+        html = (
+            '<script src="a.js"></script>'
+            '<link rel="modulepreload" href="b.js">'
+            '<script src="c.js"></script>'
+            '<link rel="modulepreload" href="d.js">'
+        )
+        assert URLIngestionService()._javascript_urls(html) == [
+            "a.js",
+            "b.js",
+            "c.js",
+            "d.js",
+        ]
+
+    def test_preload_and_prefetch_and_mjs(self) -> None:
+        html = (
+            '<link rel="preload" as="script" href="/a.js">'
+            "<link rel='prefetch' href='/b.mjs'>"
+            '<link rel="modulepreload" href="/c.js?v=2">'
+        )
+        assert URLIngestionService()._javascript_urls(html) == [
+            "/a.js",
+            "/b.mjs",
+            "/c.js?v=2",
+        ]
+
+    def test_stylesheet_links_are_ignored(self) -> None:
+        html = '<link rel="stylesheet" href="/styles.css">'
+        assert URLIngestionService()._javascript_urls(html) == []
+
+    def test_a_chunk_both_preloaded_and_scripted_is_fetched_once(self) -> None:
+        html = (
+            '<link rel="modulepreload" href="main.js">'
+            '<script src="main.js"></script>'
+        )
+        assert URLIngestionService()._javascript_urls(html) == ["main.js"]
+
+    def test_cap_applies_across_both_sources(self) -> None:
+        """The cap bounds total fetches, not each tag type separately."""
+        html = "".join(
+            f'<link rel="modulepreload" href="c{i}.js">'
+            for i in range(ScanConfig.MAX_ASSETS_TO_FETCH + 20)
+        )
+        urls = URLIngestionService()._javascript_urls(html)
+        assert len(urls) == ScanConfig.MAX_ASSETS_TO_FETCH


### PR DESCRIPTION
Two independent bugs kept OWASP Juice Shop's `mass_assignment` challenges at **0/2 even with `--probe-writes`**, both of the kind where failure erases rather than degrades — a live, challenge-solving vulnerability read as clean.

## 1. Ingestion only collected `<script src>`

A code-split SPA ships its entry bundle as `<script>` and every lazy route chunk as `<link rel="modulepreload">`. A script-only sweep sees the shell and none of the routes — where most of the API surface lives. On Juice Shop that hid **10 of 13 JS files**, and with them `POST /api/Users` and `/api/Feedbacks`.

Collecting `<link href="...js">` too (modulepreload/preload/prefetch) took url-only discovery from **61 → 123 endpoints**, none lost. Extraction is a single pass in document order — the fetch cap truncates the tail, and gathering all scripts before any chunk would starve out the chunks. Cap raised 20 → 100.

## 2. The reflection check couldn't see past a response envelope

`POST /api/Users {"role":"admin"}` returns `201` with `{"status":"success","data":{...,"role":"admin",...}}`. The check inspected only the top level — where the keys are `status` and `data` — and called it "not reflected." It now searches the whole decoded tree (depth-bounded, value still required to match), covering `{"result":...}` and JSON:API too.

## Result

`mass_assignment` **0/2 → 1/2** on Juice Shop with `--probe-writes` — `registerAdminChallenge` fires end to end, confirmed on a fresh container during a real scan. `feedbackChallenge` stays open: the probe sends the escalation field with no valid base payload, and that endpoint also demands a captcha — app-specific anti-automation, documented rather than special-cased.

Removing either fix alone yields nothing: the endpoint must be discovered *and* the echo must be seen.

## Also

- Corrects the `ScannerTimeouts` comments, which understated their values by 3–6× (`# 15 min` next to `5400`) after the caps were removed and budgets grew.

## Verification

| target | pass | result |
|---|---|---|
| Juice Shop | `--probe-writes` | **32 → 33/45** (gain = mass_assignment) |
| Juice Shop | url-only | 26–27/45, unchanged |
| heylevi | url-only | 20 findings, no regression (fix inert — not code-split) |
| heylevi | authenticated | 20 findings, identical set, crawler reached 31 pages / 23 endpoints |

Suite: **2489 passed** (8 new: envelope-nesting + `<link>`/document-order extraction).

The benchmark harness additions (`juiceshop-writes` target, `--report-dir`, measured RESULTS numbers) are in the second commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EZ4QoTqRoYWE25CNoV2Wfy