### PR TITLE
fix(idor): an empty JSON envelope is not leaked data

### DIFF
--- a/benchmarks/RESULTS.md
+++ b/benchmarks/RESULTS.md
@@ -142,13 +142,19 @@ claims, hand-verified against the live app:
 |---|---|---|
 | `/api/Recycles/1` | `{"UserId":2,"AddressId":4,…}` | **real** — another user's record, unauthenticated |
 | `/rest/memories` | `{"UserId":13,…,"email":…}` | **real** — leaks users and emails |
-| `/rest/user/whoami` | `{"user":{}}` | **false positive** |
+| `/rest/user/whoami` | `{"user":{}}` | ~~false positive~~ **fixed** — empty envelopes no longer count as data |
 | `/api/Deliverys/1` | `{"name":"One Day Delivery","price":0.99}` | **false positive** — public catalogue |
 | `/api/Products/1` | public product | **false positive** — public catalogue |
 
-The `whoami` case has a specific cause worth recording: `_response_has_data` is
-a *length* test standing in for a *content* test — any JSON body of at least 10
-bytes counts as data, and `{"user":{}}` is 11. The remaining three unmatched are
+The `whoami` case had a specific cause: `_response_has_data` was a *length* test
+standing in for a *content* test — any JSON body of at least 10 bytes counted as
+data, and `{"user":{}}` is 11. **Fixed** — it now requires the decoded body to
+hold a substantive value (any scalar; empty containers, null and blank strings
+do not count), judged by structure so no envelope key name is guessed. The
+`Deliverys`/`Products` pair is a *different* bug — a swapped id returns the same
+public-catalogue record, and the swap probe reports "differs" whenever data
+comes back rather than comparing it to the original; that needs response
+discrimination and is still open. The remaining three unmatched are
 real-but-unscored (localStorage token, missing HSTS/CSP, wildcard CORS).
 
 > **`--probe-writes` takes ~72 minutes** (measured: injection 39 min, IDOR 14,

--- a/docs/scanners/idor-scanner.md
+++ b/docs/scanners/idor-scanner.md
@@ -8,7 +8,7 @@ Tests for Insecure Direct Object References by swapping resource identifiers in 
 
 Four test types:
 
-1. **Unauthenticated Access** — Sends requests without any auth headers. If the endpoint returns data, it's publicly accessible when it shouldn't be.
+1. **Unauthenticated Access** — Sends requests without any auth headers. If the endpoint returns data, it's publicly accessible when it shouldn't be. "Returns data" means the JSON body actually carries a value: an endpoint that answers an anonymous request with an empty envelope like `{"user":{}}` is telling you *nobody*, not leaking a record, and is not flagged. The check is structural (any non-empty scalar, anywhere) so it doesn't depend on recognising `data`/`result`/`user` envelope keys.
 
 2. **Path Parameter Swapping** — Changes `/api/tasks/USER-A-TASK-ID` to `/api/tasks/USER-B-TASK-ID`. If data is returned, there's no ownership check.
 

--- a/isitsecure/engine/scanners/idor_scanner.py
+++ b/isitsecure/engine/scanners/idor_scanner.py
@@ -387,11 +387,19 @@ class IDORScanner:
 
         content_type = response.headers.get("content-type", "").lower()
 
-        if "application/json" in content_type:
-            return True
-
-        if body.startswith(("{", "[")):
-            return True
+        looks_json = "application/json" in content_type or body.startswith(
+            ("{", "[")
+        )
+        if looks_json:
+            # A 200 with a JSON body is not proof of leaked data. An endpoint
+            # can answer an unauthenticated request with an empty envelope --
+            # Juice Shop's /rest/user/whoami returns {"user":{}} -- which
+            # clears the byte-length gate but carries nothing, and was scored
+            # as an IDOR. Require the decoded body to hold at least one
+            # substantive value, judged by structure alone (any scalar counts;
+            # empty containers, null and blank strings do not) so no envelope
+            # key name has to be guessed.
+            return _json_has_substantive_content(body)
 
         # HTML responses are likely error/redirect pages, not data
         if "text/html" in content_type:
@@ -1260,3 +1268,34 @@ class IDORScanner:
             if target_id in body_preview:
                 return True
         return False
+
+
+def _json_has_substantive_content(body: str) -> bool:
+    """Whether a JSON body carries any real value rather than an empty shell.
+
+    Key names are irrelevant -- only whether some leaf holds data -- so this
+    does not depend on recognising ``data``/``result``/``user`` envelopes.
+    A body that is JSON-shaped but does not decode is treated as content
+    rather than silently dropped.
+    """
+    try:
+        return _has_substantive_value(json.loads(body))
+    except (json.JSONDecodeError, ValueError):
+        return True
+
+
+def _has_substantive_value(value: object) -> bool:
+    """True if ``value`` contains at least one non-empty scalar, recursively.
+
+    Empty containers, ``null`` and blank strings are not substantive; numbers
+    and booleans are -- including ``0`` and ``False``, which are real data.
+    """
+    if isinstance(value, dict):
+        return any(_has_substantive_value(v) for v in value.values())
+    if isinstance(value, (list, tuple)):
+        return any(_has_substantive_value(v) for v in value)
+    if isinstance(value, str):
+        return value.strip() != ""
+    if value is None:
+        return False
+    return True

--- a/tests/engine/test_idor_response_has_data.py
+++ b/tests/engine/test_idor_response_has_data.py
@@ -1,0 +1,110 @@
+"""What counts as "the endpoint returned data" for the IDOR scanner.
+
+A 200 with a JSON body is not proof of a leak: an endpoint can answer an
+unauthenticated request with an empty envelope (Juice Shop's
+``/rest/user/whoami`` returns ``{"user":{}}``), which clears a byte-length gate
+while carrying nothing. These tests pin the content check that tells the two
+apart -- by structure, never by envelope key name.
+"""
+
+from __future__ import annotations
+
+import httpx
+
+from isitsecure.engine.scanners.idor_scanner import (
+    IDORScanner,
+    _has_substantive_value,
+    _json_has_substantive_content,
+)
+
+
+def _resp(body: str, status: int = 200, ctype: str = "application/json") -> httpx.Response:
+    return httpx.Response(
+        status_code=status,
+        headers={"content-type": ctype},
+        content=body.encode(),
+    )
+
+
+class TestSubstantiveValue:
+    def test_empty_containers_are_not_substantive(self) -> None:
+        assert not _has_substantive_value({})
+        assert not _has_substantive_value([])
+        assert not _has_substantive_value({"user": {}})
+        assert not _has_substantive_value({"a": {}, "b": [], "c": None})
+
+    def test_blank_string_and_null_are_not_substantive(self) -> None:
+        assert not _has_substantive_value("")
+        assert not _has_substantive_value("   ")
+        assert not _has_substantive_value(None)
+
+    def test_zero_and_false_are_real_data(self) -> None:
+        # A balance of 0 or a flag of False is a leaked value, not emptiness.
+        assert _has_substantive_value(0)
+        assert _has_substantive_value(False)
+        assert _has_substantive_value({"balance": 0})
+
+    def test_populated_record_is_substantive(self) -> None:
+        assert _has_substantive_value({"data": [{"UserId": 2, "quantity": 800}]})
+
+    def test_value_nested_below_empty_wrappers(self) -> None:
+        assert _has_substantive_value({"a": {"b": {"c": "x"}}})
+        assert not _has_substantive_value({"a": {"b": {"c": {}}}})
+
+
+class TestJsonHasSubstantiveContent:
+    def test_whoami_empty_envelope(self) -> None:
+        assert not _json_has_substantive_content('{"user":{}}')
+
+    def test_all_empty_containers_are_not_content(self) -> None:
+        assert not _json_has_substantive_content('{"user":{},"data":[]}')
+
+    def test_status_string_counts_as_content_by_design(self) -> None:
+        # The honest limit of a key-name-agnostic check: a "success" leaf on an
+        # otherwise-empty result IS a non-empty scalar, so it reads as content.
+        # Recognising it as mere envelope metadata would need an envelope-key
+        # allowlist -- the overfit this fix exists to avoid. Empty result sets
+        # are a separate concern, addressable only by response discrimination.
+        assert _json_has_substantive_content('{"status":"success","data":[]}')
+
+    def test_populated_envelope(self) -> None:
+        assert _json_has_substantive_content(
+            '{"status":"success","data":[{"UserId":2}]}'
+        )
+
+    def test_undecodable_json_is_treated_as_content(self) -> None:
+        # JSON-shaped but broken: don't silently drop a possible finding.
+        assert _json_has_substantive_content('{"data": [unclosed')
+
+
+class TestResponseHasData:
+    def test_empty_envelope_is_not_data(self) -> None:
+        # The regression: whoami cleared the old byte-length gate.
+        assert not IDORScanner()._response_has_data(_resp('{"user":{}}'))
+
+    def test_populated_json_is_data(self) -> None:
+        assert IDORScanner()._response_has_data(
+            _resp('{"status":"success","data":[{"UserId":2,"quantity":800}]}')
+        )
+
+    def test_error_status_is_never_data(self) -> None:
+        assert not IDORScanner()._response_has_data(
+            _resp('{"data":[{"id":1}]}', status=404)
+        )
+
+    def test_trivially_short_body_is_not_data(self) -> None:
+        assert not IDORScanner()._response_has_data(_resp("{}"))
+
+    def test_json_without_content_type_still_inspected(self) -> None:
+        # A JSON array served as text/plain is still judged on content.
+        assert IDORScanner()._response_has_data(
+            _resp('[{"id":1,"name":"x"}]', ctype="text/plain")
+        )
+        assert not IDORScanner()._response_has_data(
+            _resp('[{},{},{}]', ctype="text/plain")
+        )
+
+    def test_html_is_not_data(self) -> None:
+        assert not IDORScanner()._response_has_data(
+            _resp("<html><body>Not found</body></html>", ctype="text/html")
+        )


### PR DESCRIPTION
The IDOR scanner's `_response_has_data` counted **any JSON body ≥ 10 bytes** as "the endpoint returned data". Juice Shop's unauthenticated `/rest/user/whoami` answers with `{"user":{}}` — 11 bytes, structurally empty — so an endpoint saying *"you are nobody"* was scored as an IDOR (`LIKELY`, 0.8).

Same failure mode as the mass-assignment envelope bug shipped in v0.25.6: a **length test standing in for a content test**.

## The fix

`_response_has_data` now requires the decoded body to hold a **substantive value** somewhere — any scalar counts; empty containers, `null` and blank strings do not. The judgement is purely structural, so it does **not** depend on recognising `data`/`result`/`user` envelope key names — the overfit worth avoiding. It is strictly tighter than the old check, so it can only *remove* false "data returned", never add one.

```
{"user":{}}                              -> empty  (was: DATA)
{"status":"success","data":[{"UserId":2}]} -> DATA
{"balance":0}                            -> DATA   (0 is real data)
{"data":[]}                              -> empty
```

## Verification

Live against Juice Shop and via the harness:

| | before | after |
|---|--:|--:|
| url-only recall | 26/45 | **26/45** (unchanged) |
| idor class | 2/5 | **2/5** (unchanged) |
| idor findings | 6 | **5** — `whoami` gone |

The two real unauthenticated leaks whoami was mixed in with (`/api/Recycles/1`, `/rest/memories`) still fire. Suite **2505 passed** (16 new discrimination tests).

## Explicitly out of scope

`/api/Deliverys/1` and `/api/Products/1` are a **different** bug — a swapped id returns the same public-catalogue record, and the swap probe reports "differs" whenever any data comes back rather than comparing it to the original response. That needs response discrimination, is a larger change to the scanner's core, and is now noted as open in `benchmarks/RESULTS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EZ4QoTqRoYWE25CNoV2Wfy