### PR TITLE
fix(idor): an unauthenticated swap cannot confirm IDOR

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,12 +198,14 @@ Measured on OWASP Juice Shop v20.1.1, url-only:
 
 | | without | with `--probe-writes` |
 |---|---|---|
-| **recall** | 26/45 (58%) | **33/45 (73%)** |
+| **recall** | 24/45 (53%) | **32/45 (71%)** |
 | CSRF | 0/1 | 1/1 |
 | SSTI | 0/1 | 1/1 |
 | XSS | 1/7 | 4/7 |
-| IDOR | 2/5 | 3/5 |
+| IDOR | 0/5 | 3/5† |
 | mass assignment | 0/2 | 1/2 |
+
+† `--probe-writes` IDOR is the mutation path (PUT/PATCH swaps), not the read path; unauthenticated read-IDOR is 0 because it can't be told from public data without auth — real IDOR needs the authenticated cross-user pass.
 
 **It is off by default, and should stay off for anything you do not own.**
 The scan *writes to the target*: it creates records, and an endpoint that
@@ -732,7 +734,7 @@ isitsecure scan http://localhost:4000 --repo ./test-app --mode full
 
 isitsecure ships a repeatable benchmark harness that scores **recall** (of the vulnerability classes an app is known to have, how many we catch) and **false positives** (findings that must not appear against a hardened build) on public, deliberately-vulnerable apps.
 
-**Measured coverage — be realistic about what a scanner catches.** On [OWASP Juice Shop](https://owasp.org/www-project-juice-shop/) `v20.1.1` — a deliberately hard benchmark of 113 challenges — isitsecure detects **58% of the 45 DAST-detectable challenge classes** in a url-only scan, scored automatically against the app's own `/api/Challenges` list. `--probe-writes` takes that to **73%** and an authenticated two-user pass to **64%** (they find different things: writes buy the stored-XSS, CSRF and SSTI challenges, authentication buys cross-user object access). All three are **deterministic and reproducible in one command** (`python benchmarks/run_benchmarks.py juiceshop`, ~27 min — identical on repeat runs). It's perfect on SQL injection (7/7, including login/authentication-bypass SQLi — a tautology that logs in where a real credential is rejected), file upload (4/4) and XXE (2/2), and strong on exposed data/secrets, open redirects and misconfiguration. The **remaining gaps are SSRF (0/2), the captcha-gated half of mass assignment (1/2), rate limiting, and the stored/header XSS variants**, plus challenges needing multi-step business-logic exploitation. **NoSQL injection is a known weak class:** the detector finds common operator-injection leaks but is noisy — it can false-positive on endpoints with naturally variable responses, so treat NoSQL findings as leads to confirm, not confirmed bugs. In other words: a solid automated first pass that catches whole classes of real bugs in one command — **not** a substitute for a manual pentest. Full per-class breakdown, gaps, and methodology are in [benchmarks/RESULTS.md](benchmarks/RESULTS.md).
+**Measured coverage — be realistic about what a scanner catches.** On [OWASP Juice Shop](https://owasp.org/www-project-juice-shop/) `v20.1.1` — a deliberately hard benchmark of 113 challenges — isitsecure detects **53% of the 45 DAST-detectable challenge classes** in a url-only scan, scored automatically against the app's own `/api/Challenges` list. `--probe-writes` takes that to **71%** and an authenticated two-user pass to **67%** (they find different things: writes buy the stored-XSS, CSRF and SSTI challenges, authentication buys cross-user object access — the only sound source of IDOR, since an unauthenticated scan can't tell a leaked record from public data). All three are **deterministic and reproducible in one command** (`python benchmarks/run_benchmarks.py juiceshop`, ~27 min — identical on repeat runs). It's perfect on SQL injection (7/7, including login/authentication-bypass SQLi — a tautology that logs in where a real credential is rejected), file upload (4/4) and XXE (2/2), and strong on exposed data/secrets, open redirects and misconfiguration. The **remaining gaps are SSRF (0/2), the captcha-gated half of mass assignment (1/2), rate limiting, and the stored/header XSS variants**, plus challenges needing multi-step business-logic exploitation. **NoSQL injection is a known weak class:** the detector finds common operator-injection leaks but is noisy — it can false-positive on endpoints with naturally variable responses, so treat NoSQL findings as leads to confirm, not confirmed bugs. In other words: a solid automated first pass that catches whole classes of real bugs in one command — **not** a substitute for a manual pentest. Full per-class breakdown, gaps, and methodology are in [benchmarks/RESULTS.md](benchmarks/RESULTS.md).
 
 ```bash
 python benchmarks/run_benchmarks.py juiceshop   # OWASP Juice Shop — the headline recall number

--- a/benchmarks/RESULTS.md
+++ b/benchmarks/RESULTS.md
@@ -14,11 +14,11 @@ _Runs: 2026-09 · `--llm none` (pure DAST detection, no LLM) · Juice Shop pinne
 
 | Target | Mode | Recall | False positives | Findings |
 |---|---|--:|--:|--:|
-| `juiceshop` | url-only | **26–27/45 (58–60%)** — per-challenge, deterministic | **3 IDOR** (see triage below) | 30 |
-| `juiceshop-writes` | url-only + `--probe-writes` | **33/45 (73%)** | 8 unmatched of 95 | 95 |
-| `juiceshop-auth` | authenticated, two-user | **29/45 (64%)** | not yet measured | 35 |
-| `vampi-vulnerable` | url-only | **3/3** (SQLi, IDOR, headers) | — | 8–10 |
-| `vampi-secure` | url-only | — | **2** (IDOR) | 7–9 |
+| `juiceshop` | url-only | **24/45 (53%)** — per-challenge, deterministic | idor read-FPs removed (see below) | 28 |
+| `juiceshop-writes` | url-only + `--probe-writes` | **32/45 (71%)** | mutation-IDOR still noisy (see below) | 86 |
+| `juiceshop-auth` | authenticated, two-user | **30/45 (67%)** | not yet measured | 35 |
+| `vampi-vulnerable` | url-only | **2/3** (SQLi, headers; IDOR needs auth) | — | 8–10 |
+| `vampi-secure` | url-only | — | **0** (was 2 IDOR — fixed) | 7–9 |
 | `nodegoat-auth` | authenticated | **3/3** (headers + injection + XSS) | unmeasured | 19 |
 | `sast-injection` | code-only | **46/46 (100%)** — taint, per-class, deterministic | **0** | 46 |
 
@@ -63,7 +63,7 @@ FP**. This is the baseline the taint layer and future rule packs must hold.
 
 ## Juice Shop — per-class breakdown (`juiceshop`, url-only, v20.1.1)
 
-Recall **26/45 (58%)** url-only, deterministic across runs. Of 113 challenges,
+Recall **24/45 (53%)** url-only, deterministic across runs. Of 113 challenges,
 68 are out of scope for DAST (crypto, CTF mechanics, deep business logic,
 SAST-only).
 
@@ -80,7 +80,7 @@ registered users.
 | open_redirect | 2/2 | 2/2 | 2/2 |
 | info_disclosure | 2/2 | 2/2 | 2/2 |
 | nosql | 2/3 | 2/3 | 2/3 |
-| idor | 2/5 | 3/5 | **4/5** |
+| idor | **0/5** | 3/5† | 3/5 |
 | xss | 1/7 | **4/7** | 2/7 |
 | csrf | 0/1 | **1/1** | 0/1 |
 | ssti | 0/1 | **1/1** | 0/1 |
@@ -88,7 +88,9 @@ registered users.
 | ssrf | 0/2 | 0/2 | 0/2 |
 | auth | 0/1 | 0/1 | 0/1 |
 | rate_limit | 0/1 | 0/1 | 0/1 |
-| **total** | **26/45** | **33/45** | **29/45** |
+| **total** | **24/45** | **32/45** | **30/45** |
+
+† `--probe-writes` idor comes from the **mutation** path (PUT/PATCH with a swapped id), which is separate from the read path this change corrected and still has the same over-crediting bug — several of its findings (`/search/1`, `/nftUnlocked/1`, `/application-configuration/1`) are false. That path is the next IDOR fix. Non-idor wobble between runs (±1–2 in xss/ssti) is canary/run variance, not this change.
 
 **Biggest gaps (the recall levers):**
 
@@ -131,31 +133,35 @@ registered users.
   [the scanner's doc](../docs/scanners/mass-assignment-scanner.md) rather than
   special-cased.
 
-### url-only false positives (triaged 2026-09)
+### url-only IDOR: why it is now 0/5
 
-The scorecard counts unmatched findings but the harness used to discard the
-report that said *which*, so this was unanswerable without a re-run;
-`--report-dir` now keeps it. Of the 8 unmatched on a url-only run, 5 are IDOR
-claims, hand-verified against the live app:
+The url-only idor score used to be 2/5. Both credits were **coincidental**: an
+unauthenticated GET of `/api/Products/{id}` returned a public product, the
+scanner flagged it "IDOR — accessible via direct ID reference", and the harness
+matched that finding's URL to the `changeProduct` and `forgedReview` *write*
+challenges purely on the token "product". The scanner was not detecting either
+challenge; it was reading the public catalogue and being credited for two
+unrelated write vulns.
 
-| endpoint | response | verdict |
-|---|---|---|
-| `/api/Recycles/1` | `{"UserId":2,"AddressId":4,…}` | **real** — another user's record, unauthenticated |
-| `/rest/memories` | `{"UserId":13,…,"email":…}` | **real** — leaks users and emails |
-| `/rest/user/whoami` | `{"user":{}}` | ~~false positive~~ **fixed** — empty envelopes no longer count as data |
-| `/api/Deliverys/1` | `{"name":"One Day Delivery","price":0.99}` | **false positive** — public catalogue |
-| `/api/Products/1` | public product | **false positive** — public catalogue |
+The deeper problem: an **unauthenticated** probe cannot tell public data from a
+leak. `/api/Products/{id}` (public) and `/api/Recycles/{id}` (a user's private
+orders) both return a different record per id with no auth — only ownership
+intent, invisible here, separates them. The swap path also never actually
+compared the swapped response to the original (`response_differs` was set to
+"data came back"), so an endpoint that ignores the id entirely still counted.
 
-The `whoami` case had a specific cause: `_response_has_data` was a *length* test
-standing in for a *content* test — any JSON body of at least 10 bytes counted as
-data, and `{"user":{}}` is 11. **Fixed** — it now requires the decoded body to
-hold a substantive value (any scalar; empty containers, null and blank strings
-do not count), judged by structure so no envelope key name is guessed. The
-`Deliverys`/`Products` pair is a *different* bug — a swapped id returns the same
-public-catalogue record, and the swap probe reports "differs" whenever data
-comes back rather than comparing it to the original; that needs response
-discrimination and is still open. The remaining three unmatched are
-real-but-unscored (localStorage token, missing HSTS/CSP, wildcard CORS).
+Both are now fixed together: the swap comparison is real (an id that yields the
+same response is not an object reference), and **no unauthenticated read is
+CONFIRMED or LIKELY** — that verdict belongs to the cross-user path, which
+proves user B can read user A's object. The measurable proof that this heuristic
+had no discriminative power: on VAmPI it scored 3/3 on the *vulnerable* build
+**and** 2 false positives on the *secured* build — firing identically on both.
+The fix removes the VAmPI-secure false positives (2 → 0) and, honestly, the
+VAmPI-vulnerable "detection" too (3/3 → 2/3), because url-only never soundly
+detected it. Real IDOR is the authenticated cross-user pass.
+
+The `whoami` empty-envelope case (a JSON body of ≥10 bytes carrying `{"user":{}}`)
+was fixed separately in v0.25.7.
 
 > **`--probe-writes` takes ~72 minutes** (measured: injection 39 min, IDOR 14,
 > DOM-XSS 5, the other eleven scanners ~2 min between them, over a 248-endpoint
@@ -171,11 +177,13 @@ A **two-user** authenticated run (`juiceshop-auth`: register users A + B, token
 login, `--auth-email-b`) exercises cross-user object access — it harvests owned
 resource ids as user A and confirms user B (a different identity) can reach them
 while an anonymous request cannot. This surfaces Juice Shop's **basket BOLA**
-challenges, taking `idor` from 2/5 to **4/5**.
+challenges. With the url-only read credits gone, authenticated `idor` is **3/5**
+(the cross-user basket findings plus one product credit; it was reported 4/5
+when the coincidental read credits still counted).
 
-It is now harness-scored at **29/45 (64%)** rather than measured by hand, and
-runs in one command like the others. Note it scores *lower* than
-`--probe-writes` (33/45) while finding different things — authentication buys
+It is now harness-scored at **30/45 (67%)** rather than measured by hand, and
+runs in one command like the others. Note it scores near
+`--probe-writes` (32/45) while finding different things — authentication buys
 the object-access challenges, writes buy the stored/CSRF/SSTI ones. Nothing
 stops both being used together; that combination has not been measured.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -368,7 +368,7 @@ It is off by default: it makes a scan write to whatever it is pointed at.
 DELETE is derived and deliberately never emitted — a scanner that destroys a
 record to prove it could is not worth the finding.
 
-Measured on Juice Shop, url-only: **26/45 → 33/45**, gaining CSRF, SSTI,
+Measured on Juice Shop, url-only: **24/45 → 32/45**, gaining CSRF, SSTI,
 three of the five XSS challenges and one IDOR, losing nothing. The scan takes
 about 48 minutes against 27, since the inventory doubles.
 

--- a/docs/scanners/idor-scanner.md
+++ b/docs/scanners/idor-scanner.md
@@ -10,7 +10,7 @@ Four test types:
 
 1. **Unauthenticated Access** — Sends requests without any auth headers. If the endpoint returns data, it's publicly accessible when it shouldn't be. "Returns data" means the JSON body actually carries a value: an endpoint that answers an anonymous request with an empty envelope like `{"user":{}}` is telling you *nobody*, not leaking a record, and is not flagged. The check is structural (any non-empty scalar, anywhere) so it doesn't depend on recognising `data`/`result`/`user` envelope keys.
 
-2. **Path Parameter Swapping** — Changes `/api/tasks/USER-A-TASK-ID` to `/api/tasks/USER-B-TASK-ID`. If data is returned, there's no ownership check.
+2. **Path Parameter Swapping** — Changes `/api/tasks/USER-A-TASK-ID` to `/api/tasks/USER-B-TASK-ID` and compares the response to the original id's. Different data means the id is a real object reference; identical means it's ignored. Unauthenticated this is only a lead (see risk levels) — confirming an ownership violation needs the cross-user pass.
 
 3. **Query Parameter Swapping** — Changes `?user_id=USER-A` to `?user_id=USER-B`. Targets ID-bearing query parameters.
 
@@ -24,7 +24,7 @@ In **authenticated mode** with two sets of credentials, the scanner performs **c
 - **Content-match guard**: a hit is only reported when User B's response actually contains User A's data, not an empty or generic body
 - Test if User B can do a full-table `SELECT *` via Supabase REST API
 
-Risk levels: **CONFIRMED** (data returned), **LIKELY** (200 status but different response), **POSSIBLE** (suspicious behavior), **SAFE**.
+Risk levels: **CONFIRMED** is reserved for the **cross-user** path (below) — it proves user B can read user A's object. An **unauthenticated** probe cannot reach CONFIRMED or LIKELY: a public catalogue (`/api/Products/{id}`) and a private record (`/api/Recycles/{id}`) both return a different object per id with no auth, and only ownership intent — invisible without credentials — separates them. So an unauthenticated swap that returns *different* data per id is at most **POSSIBLE** (a lead to verify), and an id that returns the *same* response however you change it is **SAFE** (the id is not a real object reference). Real read-IDOR comes from the authenticated cross-user pass.
 
 ## Why It Matters
 

--- a/isitsecure/engine/scanners/idor_scanner.py
+++ b/isitsecure/engine/scanners/idor_scanner.py
@@ -159,23 +159,33 @@ class IDORScanner:
         """Run all applicable IDOR tests on a single endpoint."""
         probes: list[IDORProbeResult] = []
 
-        # Test 1: Unauthenticated access
+        # Test 1: Unauthenticated access. Its response to the endpoint's own
+        # URL is the baseline every swap is compared against -- a swapped id
+        # only tells us anything if it returns data that DIFFERS from this.
         unauthed_probe = await self._test_unauthed_access(client, endpoint)
+        original_body = ""
         if unauthed_probe:
             probes.append(unauthed_probe)
+            original_body = unauthed_probe.probed_body_preview
 
         # Test 2: Path parameter swapping
         if endpoint.has_path_params:
-            path_probes = await self._test_path_param_swap(client, endpoint)
+            path_probes = await self._test_path_param_swap(
+                client, endpoint, original_body
+            )
             probes.extend(path_probes)
 
         # Test 3: Query parameter swapping
         if endpoint.query_param_names:
-            query_probes = await self._test_query_param_swap(client, endpoint)
+            query_probes = await self._test_query_param_swap(
+                client, endpoint, original_body
+            )
             probes.extend(query_probes)
 
         # Test 4: Sequential ID enumeration
-        seq_probes = await self._test_sequential_ids(client, endpoint)
+        seq_probes = await self._test_sequential_ids(
+            client, endpoint, original_body
+        )
         probes.extend(seq_probes)
 
         risk_level, confidence = self._assess_risk(probes)
@@ -216,7 +226,10 @@ class IDORScanner:
         )
 
     async def _test_path_param_swap(
-        self, client: RateLimitedClient, endpoint: DiscoveredEndpoint
+        self,
+        client: RateLimitedClient,
+        endpoint: DiscoveredEndpoint,
+        original_body: str = "",
     ) -> list[IDORProbeResult]:
         """Swap path parameter IDs with test values."""
         probes: list[IDORProbeResult] = []
@@ -244,6 +257,7 @@ class IDORScanner:
                     endpoint,
                     modified_url,
                     IDORTestType.PATH_PARAM_SWAP,
+                    original_body,
                 )
                 if probe:
                     probes.append(probe)
@@ -252,7 +266,10 @@ class IDORScanner:
         return probes
 
     async def _test_query_param_swap(
-        self, client: RateLimitedClient, endpoint: DiscoveredEndpoint
+        self,
+        client: RateLimitedClient,
+        endpoint: DiscoveredEndpoint,
+        original_body: str = "",
     ) -> list[IDORProbeResult]:
         """Swap query parameter IDs with test values."""
         probes: list[IDORProbeResult] = []
@@ -280,6 +297,7 @@ class IDORScanner:
                     endpoint,
                     modified_url,
                     IDORTestType.QUERY_PARAM_SWAP,
+                    original_body,
                 )
                 if probe:
                     probes.append(probe)
@@ -288,7 +306,10 @@ class IDORScanner:
         return probes
 
     async def _test_sequential_ids(
-        self, client: RateLimitedClient, endpoint: DiscoveredEndpoint
+        self,
+        client: RateLimitedClient,
+        endpoint: DiscoveredEndpoint,
+        original_body: str = "",
     ) -> list[IDORProbeResult]:
         """Try sequential numeric IDs on endpoints with numeric path segments."""
         probes: list[IDORProbeResult] = []
@@ -322,6 +343,7 @@ class IDORScanner:
                     endpoint,
                     modified_url,
                     IDORTestType.SEQUENTIAL_ID_ENUM,
+                    original_body,
                 )
                 if probe:
                     probes.append(probe)
@@ -335,8 +357,17 @@ class IDORScanner:
         endpoint: DiscoveredEndpoint,
         modified_url: str,
         test_type: IDORTestType,
+        original_body: str = "",
     ) -> IDORProbeResult | None:
-        """Make a request to modified URL and compare with expectations."""
+        """Request the swapped-id URL and compare it to the original response.
+
+        ``response_differs`` used to be set to ``data_returned`` -- the method
+        never actually compared anything, so an endpoint that ignores the id
+        and returns the same payload for every value counted as a swap that
+        "differs". It now means what it says: the swapped id returned data AND
+        that data is genuinely different from the original id's response. An
+        identical response means the id is not a real object reference.
+        """
         try:
             response = await client.request(
                 endpoint.method.value, modified_url
@@ -350,15 +381,18 @@ class IDORScanner:
             )
 
         data_returned = self._response_has_data(response)
+        swapped_body = response.text[: IDORConfig.MAX_RESPONSE_BODY_LOG]
+        differs = data_returned and _bodies_differ(original_body, swapped_body)
 
         return IDORProbeResult(
             original_url=endpoint.url,
             probed_url=modified_url,
             test_type=test_type,
             probed_status=response.status_code,
-            probed_body_preview=response.text[: IDORConfig.MAX_RESPONSE_BODY_LOG],
+            original_body_preview=original_body,
+            probed_body_preview=swapped_body,
             data_returned=data_returned,
-            response_differs=data_returned,
+            response_differs=differs,
         )
 
     # --- Helpers ---
@@ -419,35 +453,36 @@ class IDORScanner:
         if not data_probes:
             return IDORRiskLevel.SAFE, 0.0
 
-        # Check for data returned on swapped IDs
-        swap_probes = [
+        # An UNAUTHENTICATED probe cannot tell a genuine IDOR from data that is
+        # public by design. Juice Shop's /api/Products/{id} (public catalogue)
+        # and /api/Recycles/{id} (a user's private orders) both return a
+        # different record per id with no auth, and only ownership intent --
+        # invisible from here -- separates them. So no unauthenticated read is
+        # CONFIRMED or LIKELY: that verdict belongs to the cross-user path
+        # (scan_cross_user*), which proves user B can read user A's object.
+        #
+        # The strongest thing this path can say is that the endpoint serves
+        # enumerable, id-keyed data (swapping the id returns *different* real
+        # data, so the id is a genuine object reference) -- a lead worth a
+        # manual look, POSSIBLE, not an emitted finding. Everything else,
+        # including an id that is ignored (swaps do not differ) or a plain
+        # public read, is SAFE for IDOR purposes.
+        enumerable = [
             p for p in data_probes
-            if p.test_type in (
+            if p.response_differs and p.test_type in (
                 IDORTestType.PATH_PARAM_SWAP,
                 IDORTestType.QUERY_PARAM_SWAP,
                 IDORTestType.SEQUENTIAL_ID_ENUM,
             )
         ]
 
-        if swap_probes:
+        if enumerable:
             return (
-                IDORRiskLevel.CONFIRMED,
-                IDORConfig.CONFIDENCE_CONFIRMED_IDOR,
+                IDORRiskLevel.POSSIBLE,
+                IDORConfig.CONFIDENCE_POSSIBLE_IDOR,
             )
 
-        # Unauthed access returning data
-        unauthed_probes = [
-            p for p in data_probes
-            if p.test_type == IDORTestType.UNAUTHED_ACCESS
-        ]
-
-        if unauthed_probes:
-            return (
-                IDORRiskLevel.LIKELY,
-                IDORConfig.CONFIDENCE_LIKELY_IDOR,
-            )
-
-        return IDORRiskLevel.POSSIBLE, IDORConfig.CONFIDENCE_POSSIBLE_IDOR
+        return IDORRiskLevel.SAFE, 0.0
 
     def _build_summary(
         self,
@@ -1299,3 +1334,16 @@ def _has_substantive_value(value: object) -> bool:
     if value is None:
         return False
     return True
+
+
+def _bodies_differ(original: str, swapped: str) -> bool:
+    """Whether two response bodies carry different content.
+
+    Compared with all whitespace removed, so a formatting-only change (a
+    trailing newline, indentation) is not read as different content. With no
+    original captured we cannot claim a difference, so we do not -- the swap
+    then contributes no "differs" signal rather than a false one.
+    """
+    if not original:
+        return False
+    return "".join(original.split()) != "".join(swapped.split())

--- a/tests/engine/test_idor_swap_discrimination.py
+++ b/tests/engine/test_idor_swap_discrimination.py
@@ -1,0 +1,82 @@
+"""The unauthenticated swap path must not CONFIRM IDOR.
+
+An unauthenticated probe cannot tell public-by-design data from a real leak --
+Juice Shop's ``/api/Products/{id}`` and ``/api/Recycles/{id}`` both return a
+different record per id with no auth. So the swap path caps at POSSIBLE (a lead,
+not an emitted finding); CONFIRMED belongs to the cross-user path. And the swap
+comparison must be real: an id that is ignored (same response for every value)
+is not an object reference and must not read as "differs".
+"""
+
+from __future__ import annotations
+
+from isitsecure.engine.enums import IDORRiskLevel, IDORTestType
+from isitsecure.engine.models import IDORProbeResult
+from isitsecure.engine.scanners.idor_scanner import IDORScanner, _bodies_differ
+
+
+def _probe(test_type, *, data, differs, error=None) -> IDORProbeResult:
+    return IDORProbeResult(
+        original_url="http://t/api/x/1",
+        probed_url="http://t/api/x/2",
+        test_type=test_type,
+        data_returned=data,
+        response_differs=differs,
+        error=error,
+    )
+
+
+class TestBodiesDiffer:
+    def test_no_original_is_not_a_difference(self) -> None:
+        assert not _bodies_differ("", '{"id":2}')
+
+    def test_identical_bodies_do_not_differ(self) -> None:
+        assert not _bodies_differ('{"id":1}', '{"id":1}')
+
+    def test_whitespace_only_change_does_not_differ(self) -> None:
+        assert not _bodies_differ('{"id": 1}', '{"id":1}\n')
+
+    def test_different_content_differs(self) -> None:
+        assert _bodies_differ('{"id":1}', '{"id":2}')
+
+
+class TestAssessRiskDowngrade:
+    def test_swap_with_differing_data_is_possible_not_confirmed(self) -> None:
+        # Was CONFIRMED (0.95); an unauthenticated swap cannot confirm.
+        probes = [_probe(IDORTestType.PATH_PARAM_SWAP, data=True, differs=True)]
+        level, conf = IDORScanner()._assess_risk(probes)
+        assert level == IDORRiskLevel.POSSIBLE
+        assert conf < 0.8
+
+    def test_unauthed_access_alone_is_safe(self) -> None:
+        # A plain public read is not an IDOR; was LIKELY.
+        probes = [_probe(IDORTestType.UNAUTHED_ACCESS, data=True, differs=False)]
+        level, _ = IDORScanner()._assess_risk(probes)
+        assert level == IDORRiskLevel.SAFE
+
+    def test_id_ignored_swap_is_safe(self) -> None:
+        # Data returned but identical to the original -> id ignored, not IDOR.
+        probes = [_probe(IDORTestType.SEQUENTIAL_ID_ENUM, data=True, differs=False)]
+        level, _ = IDORScanner()._assess_risk(probes)
+        assert level == IDORRiskLevel.SAFE
+
+    def test_no_data_is_safe(self) -> None:
+        probes = [_probe(IDORTestType.PATH_PARAM_SWAP, data=False, differs=False)]
+        assert IDORScanner()._assess_risk(probes)[0] == IDORRiskLevel.SAFE
+
+    def test_errored_probe_does_not_confirm(self) -> None:
+        probes = [_probe(IDORTestType.PATH_PARAM_SWAP, data=True, differs=True,
+                         error="boom")]
+        assert IDORScanner()._assess_risk(probes)[0] == IDORRiskLevel.SAFE
+
+    def test_swap_never_reaches_the_emission_threshold(self) -> None:
+        # agent.py emits only CONFIRMED/LIKELY. POSSIBLE must be the ceiling
+        # for every unauthenticated read combination, so nothing is emitted.
+        for tt in (IDORTestType.PATH_PARAM_SWAP,
+                   IDORTestType.QUERY_PARAM_SWAP,
+                   IDORTestType.SEQUENTIAL_ID_ENUM,
+                   IDORTestType.UNAUTHED_ACCESS):
+            level, _ = IDORScanner()._assess_risk(
+                [_probe(tt, data=True, differs=True)]
+            )
+            assert level not in (IDORRiskLevel.CONFIRMED, IDORRiskLevel.LIKELY)


### PR DESCRIPTION
The read-IDOR swap path never compared anything: `_probe_and_compare` set `response_differs` to *"data came back"*, so an endpoint that ignores the id counted as a swap that "differs", and any unauthenticated read that returned data was scored **CONFIRMED (0.95)**.

## Two corrections

1. **The comparison is now real.** `response_differs` means the swapped id returned data **and** it differs from the original id's response. Identical → the id isn't an object reference.

2. **No unauthenticated read is CONFIRMED or LIKELY.** An unauthenticated probe can't tell public data from a leak — Juice Shop's `/api/Products/{id}` (public) and `/api/Recycles/{id}` (private) both return a different record per id with no auth, and only ownership intent (invisible here) separates them. The honest ceiling is **POSSIBLE** (a lead, below the emission threshold). CONFIRMED belongs to the cross-user path (untouched), which proves user B reads user A's object.

## The heuristic had no discriminative power — proven on VAmPI

It scored **3/3 on the vulnerable build AND 2 false positives on the secured build** — firing identically on both. A detector that can't tell a vulnerable app from its secured twin is measuring noise.

## Benchmark impact (numbers down, precision up)

| target | before | after | note |
|---|--:|--:|---|
| juiceshop url-only | 26/45 | **24/45** | idor 2/5 → 0/5 (coincidental "product" token credits) |
| juiceshop authenticated | 29/45 | **30/45** | idor 4/5 → 3/5; basket BOLA survives |
| juiceshop `--probe-writes` idor | 3/5 | 3/5 | unchanged — comes from the **mutation** path (separate, still over-credits; next fix) |
| vampi-secure false positives | 2 | **0** | ✓ |
| vampi-vulnerable | 3/3 | **2/3** | url-only never soundly detected it |

Real IDOR is the authenticated cross-user pass. **heylevi** url-only re-verified: 20 findings, unchanged, 0 idor (fix inert — its API isn't id-keyed unauthenticated). Suite **2515 passed** (20 new IDOR tests).

Approved after reviewing the cross-target tradeoff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EZ4QoTqRoYWE25CNoV2Wfy