### PR TITLE
fix(idor): the mutation probe must not mistake the SPA shell for a write

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,14 +198,14 @@ Measured on OWASP Juice Shop v20.1.1, url-only:
 
 | | without | with `--probe-writes` |
 |---|---|---|
-| **recall** | 24/45 (53%) | **32/45 (71%)** |
+| **recall** | 24/45 (53%) | **31/45 (69%)** |
 | CSRF | 0/1 | 1/1 |
 | SSTI | 0/1 | 1/1 |
 | XSS | 1/7 | 4/7 |
-| IDOR | 0/5 | 3/5† |
+| IDOR | 0/5 | 2/5† |
 | mass assignment | 0/2 | 1/2 |
 
-† `--probe-writes` IDOR is the mutation path (PUT/PATCH swaps), not the read path; unauthenticated read-IDOR is 0 because it can't be told from public data without auth — real IDOR needs the authenticated cross-user pass.
+† `--probe-writes` IDOR is the mutation path (unauthenticated PUT/PATCH accepted on `/api/Products`, `/api/Hints`), not the read path; unauthenticated read-IDOR is 0 because it can't be told from public data without auth — real IDOR needs the authenticated cross-user pass.
 
 **It is off by default, and should stay off for anything you do not own.**
 The scan *writes to the target*: it creates records, and an endpoint that
@@ -734,7 +734,7 @@ isitsecure scan http://localhost:4000 --repo ./test-app --mode full
 
 isitsecure ships a repeatable benchmark harness that scores **recall** (of the vulnerability classes an app is known to have, how many we catch) and **false positives** (findings that must not appear against a hardened build) on public, deliberately-vulnerable apps.
 
-**Measured coverage — be realistic about what a scanner catches.** On [OWASP Juice Shop](https://owasp.org/www-project-juice-shop/) `v20.1.1` — a deliberately hard benchmark of 113 challenges — isitsecure detects **53% of the 45 DAST-detectable challenge classes** in a url-only scan, scored automatically against the app's own `/api/Challenges` list. `--probe-writes` takes that to **71%** and an authenticated two-user pass to **67%** (they find different things: writes buy the stored-XSS, CSRF and SSTI challenges, authentication buys cross-user object access — the only sound source of IDOR, since an unauthenticated scan can't tell a leaked record from public data). All three are **deterministic and reproducible in one command** (`python benchmarks/run_benchmarks.py juiceshop`, ~27 min — identical on repeat runs). It's perfect on SQL injection (7/7, including login/authentication-bypass SQLi — a tautology that logs in where a real credential is rejected), file upload (4/4) and XXE (2/2), and strong on exposed data/secrets, open redirects and misconfiguration. The **remaining gaps are SSRF (0/2), the captcha-gated half of mass assignment (1/2), rate limiting, and the stored/header XSS variants**, plus challenges needing multi-step business-logic exploitation. **NoSQL injection is a known weak class:** the detector finds common operator-injection leaks but is noisy — it can false-positive on endpoints with naturally variable responses, so treat NoSQL findings as leads to confirm, not confirmed bugs. In other words: a solid automated first pass that catches whole classes of real bugs in one command — **not** a substitute for a manual pentest. Full per-class breakdown, gaps, and methodology are in [benchmarks/RESULTS.md](benchmarks/RESULTS.md).
+**Measured coverage — be realistic about what a scanner catches.** On [OWASP Juice Shop](https://owasp.org/www-project-juice-shop/) `v20.1.1` — a deliberately hard benchmark of 113 challenges — isitsecure detects **53% of the 45 DAST-detectable challenge classes** in a url-only scan, scored automatically against the app's own `/api/Challenges` list. `--probe-writes` takes that to **69%** and an authenticated two-user pass to **67%** (they find different things: writes buy the stored-XSS, CSRF and SSTI challenges, authentication buys cross-user object access — the only sound source of IDOR, since an unauthenticated scan can't tell a leaked record from public data). All three are **deterministic and reproducible in one command** (`python benchmarks/run_benchmarks.py juiceshop`, ~27 min — identical on repeat runs). It's perfect on SQL injection (7/7, including login/authentication-bypass SQLi — a tautology that logs in where a real credential is rejected), file upload (4/4) and XXE (2/2), and strong on exposed data/secrets, open redirects and misconfiguration. The **remaining gaps are SSRF (0/2), the captcha-gated half of mass assignment (1/2), rate limiting, and the stored/header XSS variants**, plus challenges needing multi-step business-logic exploitation. **NoSQL injection is a known weak class:** the detector finds common operator-injection leaks but is noisy — it can false-positive on endpoints with naturally variable responses, so treat NoSQL findings as leads to confirm, not confirmed bugs. In other words: a solid automated first pass that catches whole classes of real bugs in one command — **not** a substitute for a manual pentest. Full per-class breakdown, gaps, and methodology are in [benchmarks/RESULTS.md](benchmarks/RESULTS.md).
 
 ```bash
 python benchmarks/run_benchmarks.py juiceshop   # OWASP Juice Shop — the headline recall number

--- a/benchmarks/RESULTS.md
+++ b/benchmarks/RESULTS.md
@@ -15,7 +15,7 @@ _Runs: 2026-09 · `--llm none` (pure DAST detection, no LLM) · Juice Shop pinne
 | Target | Mode | Recall | False positives | Findings |
 |---|---|--:|--:|--:|
 | `juiceshop` | url-only | **24/45 (53%)** — per-challenge, deterministic | idor read-FPs removed (see below) | 28 |
-| `juiceshop-writes` | url-only + `--probe-writes` | **32/45 (71%)** | mutation-IDOR still noisy (see below) | 86 |
+| `juiceshop-writes` | url-only + `--probe-writes` | **31/45 (69%)** | mutation-IDOR shell-FPs fixed (see below) | 73 |
 | `juiceshop-auth` | authenticated, two-user | **30/45 (67%)** | not yet measured | 35 |
 | `vampi-vulnerable` | url-only | **2/3** (SQLi, headers; IDOR needs auth) | — | 8–10 |
 | `vampi-secure` | url-only | — | **0** (was 2 IDOR — fixed) | 7–9 |
@@ -80,7 +80,7 @@ registered users.
 | open_redirect | 2/2 | 2/2 | 2/2 |
 | info_disclosure | 2/2 | 2/2 | 2/2 |
 | nosql | 2/3 | 2/3 | 2/3 |
-| idor | **0/5** | 3/5† | 3/5 |
+| idor | **0/5** | 2/5† | 3/5 |
 | xss | 1/7 | **4/7** | 2/7 |
 | csrf | 0/1 | **1/1** | 0/1 |
 | ssti | 0/1 | **1/1** | 0/1 |
@@ -90,7 +90,7 @@ registered users.
 | rate_limit | 0/1 | 0/1 | 0/1 |
 | **total** | **24/45** | **32/45** | **30/45** |
 
-† `--probe-writes` idor comes from the **mutation** path (PUT/PATCH with a swapped id), which is separate from the read path this change corrected and still has the same over-crediting bug — several of its findings (`/search/1`, `/nftUnlocked/1`, `/application-configuration/1`) are false. That path is the next IDOR fix. Non-idor wobble between runs (±1–2 in xss/ssti) is canary/run variance, not this change.
+† `--probe-writes` idor comes from the **mutation** path (PUT/PATCH with a swapped id). It had the same `2xx = confirmed` bug the read path did, made worse by not rejecting the SPA shell: an Angular catch-all serves index.html (200 text/html) for any unmatched route, so a PATCH to `/search/1`, `/basket/1`, `/orders/1` … read as a CRITICAL unauthorized write. **Fixed** — the mutation probes now reject the shell, taking mutation-IDOR findings from 15 to 2 (13 were index.html). The 2 that remain (`PUT /api/Products/1`, `PUT /api/Hints/1`) are genuine unauthenticated-write surface. Non-idor wobble between runs (±1–2 in xss/ssti) is canary/run variance, not this change.
 
 **Biggest gaps (the recall levers):**
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -368,7 +368,7 @@ It is off by default: it makes a scan write to whatever it is pointed at.
 DELETE is derived and deliberately never emitted — a scanner that destroys a
 record to prove it could is not worth the finding.
 
-Measured on Juice Shop, url-only: **24/45 → 32/45**, gaining CSRF, SSTI,
+Measured on Juice Shop, url-only: **24/45 → 31/45**, gaining CSRF, SSTI,
 three of the five XSS challenges and one IDOR, losing nothing. The scan takes
 about 48 minutes against 27, since the inventory doubles.
 

--- a/isitsecure/engine/scanners/idor_scanner.py
+++ b/isitsecure/engine/scanners/idor_scanner.py
@@ -607,6 +607,11 @@ class IDORScanner:
 
         if response.status_code not in (200, 201, 204):
             return None
+        if _is_spa_shell(response):
+            # A code-split front end serves index.html (200 text/html) for
+            # every unmatched path, so a PUT/PATCH to a route that does not
+            # exist reads as a successful write. That is not a mutation.
+            return None
 
         return DeepFinding(
             source=FindingSource.DAST_URL,
@@ -670,6 +675,10 @@ class IDORScanner:
             return None
 
         if response.status_code not in (200, 202, 204):
+            return None
+        if _is_spa_shell(response):
+            # Same SPA-catch-all trap as the write probe: an index.html 200
+            # for a route with no DELETE handler is not a deletion.
             return None
 
         return DeepFinding(
@@ -1347,3 +1356,19 @@ def _bodies_differ(original: str, swapped: str) -> bool:
     if not original:
         return False
     return "".join(original.split()) != "".join(swapped.split())
+
+
+def _is_spa_shell(response: httpx.Response) -> bool:
+    """Whether a 2xx response is the single-page-app shell, not an API write.
+
+    A code-split front end (Angular, React, Vue) serves its index.html with a
+    200 for every path its router does not recognise. A PUT/PATCH/DELETE to a
+    route with no server handler therefore comes back 200 text/html -- which
+    the mutation probes counted as a CRITICAL unauthorized change. A genuine
+    API write returns JSON, or an empty body (204); HTML is the shell.
+    """
+    ctype = response.headers.get("content-type", "").lower()
+    if "text/html" in ctype:
+        return True
+    body = response.text.lstrip()[:64].lower()
+    return body.startswith(("<!doctype", "<html", "<!--"))

--- a/tests/engine/test_idor_mutation_spa_shell.py
+++ b/tests/engine/test_idor_mutation_spa_shell.py
@@ -1,0 +1,41 @@
+"""The mutation-IDOR probes must not mistake the SPA shell for a write.
+
+A code-split front end serves index.html (200 text/html) for any path its
+router doesn't know, so a PUT/PATCH/DELETE to a non-existent server route comes
+back 2xx and read as a CRITICAL unauthorized change. 13 of 15 mutation-IDOR
+findings on Juice Shop were exactly this.
+"""
+
+from __future__ import annotations
+
+import httpx
+
+from isitsecure.engine.scanners.idor_scanner import _is_spa_shell
+
+
+def _resp(status=200, ctype="application/json", body="") -> httpx.Response:
+    return httpx.Response(status_code=status,
+                          headers={"content-type": ctype},
+                          content=body.encode())
+
+
+class TestIsSpaShell:
+    def test_html_content_type_is_shell(self) -> None:
+        assert _is_spa_shell(_resp(ctype="text/html; charset=utf-8",
+                                   body="<!DOCTYPE html><html>...</html>"))
+
+    def test_html_body_without_content_type_is_shell(self) -> None:
+        # Some servers omit/mislabel the content-type; sniff the body too.
+        assert _is_spa_shell(_resp(ctype="", body="<!-- Juice Shop -->\n<html>"))
+
+    def test_json_write_response_is_not_shell(self) -> None:
+        assert not _is_spa_shell(
+            _resp(body='{"status":"success","data":{"id":1}}')
+        )
+
+    def test_empty_204_is_not_shell(self) -> None:
+        # A real API accept with no body must still count as a write.
+        assert not _is_spa_shell(_resp(status=204, ctype="", body=""))
+
+    def test_plain_text_ok_is_not_shell(self) -> None:
+        assert not _is_spa_shell(_resp(ctype="text/plain", body="OK"))


### PR DESCRIPTION
`_probe_mutation_write` and `_probe_mutation_delete` fired a **CRITICAL** finding on any 2xx, with no content-type guard — not even the `text/html` rejection the read path's `_response_has_data` already has. A code-split front end serves `index.html` with a `200` for every unrecognised path, so a PUT/PATCH/DELETE to a route with no server handler comes back `200 text/html` and was scored a CRITICAL unauthorized change.

## On Juice Shop `--probe-writes`, that was 13 of 15 findings

Live-verified — each returns `200 text/html` with the Juice Shop SPA shell as the body:

```
PATCH /search/1        → 200 text/html  → CRITICAL "unauthorized update"   ← index.html
PATCH /basket/1        → 200 text/html  → CRITICAL                          ← index.html
PATCH /orders/1        → 200 text/html  → CRITICAL                          ← index.html
… 13 total
```

## The fix

Both probes reject the shell (content-type `text/html`, or a body opening with `<!doctype`/`<html`/`<!--`). It's a **pure suppression** — it can only remove findings, never add one. The 2 genuine findings survive: `PUT /api/Products/1` (the Product Tampering surface) and `PUT /api/Hints/1`, both real JSON writes accepted unauthenticated.

## Impact

| | before | after |
|---|--:|--:|
| mutation-IDOR findings | 15 | **2** |
| juiceshop `--probe-writes` | 32/45 | 31/45 |
| idor (probe-writes) | 3/5 | 2/5 |

The −1 recall was itself a coincidental credit — a `/basket/1` shell-200 matched the basket challenge by URL token. **heylevi** url-only re-verified: 20 findings, unchanged, 0 idor (inert — nothing to suppress). Suite **2520 passed**.

Companion to the read-path swap fix (#214): an unauthenticated 2xx is not proof of a vulnerability — same overclaim, the other mutation path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EZ4QoTqRoYWE25CNoV2Wfy